### PR TITLE
perf: Memory インスタンスのキャッシュ機構を導入し応答速度を98.9%改善

### DIFF
--- a/server/src/mastra/agents/nepch-agent.ts
+++ b/server/src/mastra/agents/nepch-agent.ts
@@ -1,12 +1,11 @@
-import type { D1Store } from "@mastra/cloudflare-d1";
 import { Agent } from "@mastra/core/agent";
-import { Memory } from "@mastra/memory";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
 import { knowledgeAgent } from "~/mastra/agents/knowledge-agent";
 import { masterAgent } from "~/mastra/agents/master-agent";
 import { personaAgent } from "~/mastra/agents/persona-agent";
 import { weatherAgent } from "~/mastra/agents/weather-agent";
 import { webResearcherAgent } from "~/mastra/agents/web-researcher-agent";
+import { getMemoryFromContext } from "~/mastra/memory";
 import { personaSchema } from "~/mastra/schemas/persona-schema";
 import { devTool } from "~/mastra/tools/dev-tool";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
@@ -89,19 +88,14 @@ dev-tool を呼び出してユーザーペルソナ（Working Memory）を表示
     knowledgeSearchTool,
     verifyPasswordTool,
   },
-  memory: ({ requestContext }) => {
-    const storage = requestContext.get("storage") as D1Store;
-    return new Memory({
-      storage,
-      options: {
-        generateTitle: true,
-        workingMemory: {
-          enabled: true,
-          scope: "resource",
-          schema: personaSchema,
-        },
-        lastMessages: 20,
+  memory: ({ requestContext }) =>
+    getMemoryFromContext(requestContext, {
+      generateTitle: true,
+      workingMemory: {
+        enabled: true,
+        scope: "resource",
+        schema: personaSchema,
       },
-    });
-  },
+      lastMessages: 20,
+    }),
 });

--- a/server/src/mastra/memory/index.ts
+++ b/server/src/mastra/memory/index.ts
@@ -1,0 +1,22 @@
+import type { D1Store } from "@mastra/cloudflare-d1";
+import type { MemoryConfig } from "@mastra/core/memory";
+import type { RequestContext } from "@mastra/core/request-context";
+import { Memory } from "@mastra/memory";
+
+export const getMemoryFromContext = (
+  requestContext: RequestContext,
+  options?: MemoryConfig,
+) => {
+  const cachedMemory = requestContext.get("cachedMemory") as Memory | undefined;
+  if (cachedMemory) {
+    return cachedMemory;
+  }
+
+  const storage = requestContext.get("storage") as D1Store;
+  const memory = new Memory({
+    storage,
+    options,
+  });
+  requestContext.set("cachedMemory", memory);
+  return memory;
+};

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -60,26 +60,15 @@ const chatRoute = createRoute({
 });
 
 chatRoutes.openapi(chatRoute, async (c) => {
-  const startTime = Date.now();
-  const log = (label: string) =>
-    console.log(`[TIMING] ${label}: ${Date.now() - startTime}ms`);
-
   const { message, resourceId, threadId } = c.req.valid("json");
-  log("request parsed");
-
   const storage = await getStorage(c.env.DB);
-  log("storage ready");
-
   const mastra = createMastra(storage as unknown as MastraStorage);
-  log("mastra created");
-
   const requestContext = createRequestContext({
     storage,
     db: c.env.DB,
     env: c.env,
     masterPassword: c.env.MASTER_PASSWORD,
   });
-  log("requestContext created");
 
   const stream = await handleChatStream({
     mastra,
@@ -93,7 +82,6 @@ chatRoutes.openapi(chatRoute, async (c) => {
       },
     },
   });
-  log("stream created");
 
   return createUIMessageStreamResponse({ stream });
 });


### PR DESCRIPTION
## 概要

Memory 有効時のチャット応答が 5-7 秒かかる問題を解決し、応答速度を **98.9% 改善**（7,195ms → 75ms）しました。

## 背景・問題

Memory を有効にした状態でのチャット応答が著しく遅い問題を調査しました。

### 調査結果

Mastra の `getMemory()` メソッドが、1 リクエストあたり **16 回** Memory ファクトリ関数を呼び出していることが判明。

#### 呼び出しタイミング（計 16 回）

| カテゴリ | 呼び出し回数 | 説明 |
|---------|------------|------|
| MessageHistory processor | 6 回 | 初期化、save、query 等 |
| WorkingMemory processor | 6 回 | 初期化、get、update 等 |
| サブエージェント委譲判定 | 2 回 | 各サブエージェントの Memory 取得 |
| ツール実行時 | 2 回 | コンテキスト取得 |

各呼び出しで `new Memory()` が実行され、D1Store の初期化や内部 processor のセットアップが繰り返されていました。

### 根本原因

Mastra v1 の `getMemory()` 実装は、memory ファクトリ関数の結果をキャッシュしない設計になっています：

```javascript
// @mastra/core 内部
async getMemory({ requestContext }) {
  if (typeof this.#memory === "function") {
    // 毎回ファクトリ関数を呼び出す（キャッシュなし）
    const result = this.#memory({ requestContext, mastra: this.#mastra });
    resolvedMemory = await Promise.resolve(result);
  }
}
```

これは柔軟性を提供するための意図的な設計ですが、キャッシュはアプリケーション側で実装する必要があります。

## 解決策

RequestContext を活用した Memory キャッシュパターンを実装しました。

### 1. `getMemoryFromContext()` 関数を新設

```typescript
// server/src/mastra/memory/index.ts
export const getMemoryFromContext = (
  requestContext: RequestContext,
  options?: MemoryConfig,
) => {
  // キャッシュがあれば返却
  const cachedMemory = requestContext.get("cachedMemory") as Memory | undefined;
  if (cachedMemory) {
    return cachedMemory;
  }

  // なければ生成してキャッシュ
  const storage = requestContext.get("storage") as D1Store;
  const memory = new Memory({ storage, options });
  requestContext.set("cachedMemory", memory);
  return memory;
};
```

### 2. エージェントでの使用

```typescript
// server/src/mastra/agents/nepch-agent.ts
memory: ({ requestContext }) =>
  getMemoryFromContext(requestContext, {
    generateTitle: true,
    workingMemory: {
      enabled: true,
      scope: "resource",
      schema: personaSchema,
    },
    lastMessages: 20,
  }),
```

### アーキテクチャ上の分離

- `~/mastra/memory/index.ts`: キャッシュロジック（汎用、他エージェントでも再利用可能）
- 各エージェント: Memory オプション（workingMemory schema 等）を個別に指定

## パフォーマンス改善

| 指標 | 改善前 | 改善後 | 改善率 |
|-----|-------|-------|-------|
| LLM ストリーム開始待ち | 7,195ms | 75ms | **98.9%** |
| Memory 生成回数 | 16 回 | 1 回 | 93.75% 削減 |

## 変更ファイル

- `server/src/mastra/memory/index.ts` - **新規**: Memory キャッシュ関数
- `server/src/mastra/agents/nepch-agent.ts` - キャッシュ関数を使用するよう変更
- `server/src/routes/chat.ts` - 調査用のデバッグログを削除

## テスト計画

- [x] ローカル環境でのチャット応答確認
- [x] 本番環境でのパフォーマンス計測
- [ ] 既存のテストが通ること

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)