### PR TITLE
feat: ペルソナ一覧に無限スクロール機能を追加

### DIFF
--- a/web/src/hooks/useDashboard.ts
+++ b/web/src/hooks/useDashboard.ts
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { fetchEmergencies } from "~/repository/emergency-repository";
 import {
   deleteAllKnowledge,
@@ -15,10 +20,12 @@ export const dashboardKeys = {
   emergencies: ["dashboard", "emergencies"] as const,
 };
 
-export const usePersonas = (limit = 100) =>
-  useQuery({
-    queryKey: dashboardKeys.personas,
-    queryFn: () => fetchPersonas(limit),
+export const usePersonas = (limit = 30) =>
+  useInfiniteQuery({
+    queryKey: [...dashboardKeys.personas, limit],
+    queryFn: ({ pageParam }) => fetchPersonas({ limit, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
 export const useEmergencies = (limit = 100) =>

--- a/web/src/repository/persona-repository.ts
+++ b/web/src/repository/persona-repository.ts
@@ -1,9 +1,20 @@
 import { apiClient } from "~/lib/api/client";
 import type { PersonasResponse } from "~/types";
 
-export const fetchPersonas = (limit = 100): Promise<PersonasResponse> => {
-  const params = new URLSearchParams({ limit: String(limit) });
-  return apiClient<PersonasResponse>(`/admin/persona?${params}`, {
+type FetchPersonasParams = {
+  limit?: number;
+  cursor?: string;
+};
+
+export const fetchPersonas = (
+  params: FetchPersonasParams = {},
+): Promise<PersonasResponse> => {
+  const searchParams = new URLSearchParams();
+  searchParams.set("limit", String(params.limit ?? 30));
+  if (params.cursor) {
+    searchParams.set("cursor", params.cursor);
+  }
+  return apiClient<PersonasResponse>(`/admin/persona?${searchParams}`, {
     admin: true,
   });
 };

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -39,6 +39,8 @@ export type Persona = {
 export type PersonasResponse = {
   personas: Persona[];
   total: number;
+  nextCursor: string | null;
+  hasMore: boolean;
 };
 
 export type EmergencyReport = {


### PR DESCRIPTION
closes: #17

## Summary

- ペルソナ一覧APIにカーソルベースのページネーションを追加
- フロントエンドにIntersection Observerを使った無限スクロールを実装
- 30件ずつ追加取得し、スクロールで自動読み込み

## 主な変更内容

### サーバー側 (`server/src/routes/admin/persona.ts`)
- `cursor` クエリパラメータを追加（`{created_at}_{id}` 形式）
- レスポンスに `nextCursor`, `hasMore` フィールドを追加
- `ORDER BY created_at DESC, id DESC` で一貫したソート

### フロントエンド側
- `useQuery` → `useInfiniteQuery` に変更
- Intersection Observerでテーブル末尾を監視し自動読み込み
- 表示: `{現在の件数} / {総件数}件のペルソナ`

## Test plan

- [x] ペルソナ一覧が30件ずつ表示されること
- [x] スクロールで次ページが自動取得されること
- [x] 全件読み込み後「すべてのペルソナを表示しました」が表示されること
- [x] 削除・抽出後にデータが正しく再取得されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)