### PR TITLE
refactor: ナレッジ管理画面の機能を整理（閲覧・削除のみ有効化）

### DIFF
--- a/web/src/pages/dashboard/components/KnowledgePanel.tsx
+++ b/web/src/pages/dashboard/components/KnowledgePanel.tsx
@@ -1,21 +1,26 @@
 import { useState } from "react";
-import {
-  useDeleteFile,
-  useReconvertFile,
-  useUnifiedFiles,
-} from "~/hooks/useDashboard";
-import { FileEditor, FileList, FileUpload } from "./knowledge";
+import { useDeleteFile, useUnifiedFiles } from "~/hooks/useDashboard";
+import { FileList, FileViewer } from "./knowledge";
 
+/**
+ * ナレッジ管理パネル
+ *
+ * NOTE: アップロード・編集機能は一時的に無効化
+ * 運用フェーズで必要に応じて復活させる
+ * 関連コンポーネント: FileUpload, FileEditor
+ */
 export const KnowledgePanel = () => {
+  const { data: filesData, isLoading, error } = useUnifiedFiles();
+  const [viewingFile, setViewingFile] = useState<string | null>(null);
   const [message, setMessage] = useState<{
-    type: "success" | "error" | "warning";
+    type: "success" | "error";
     text: string;
   } | null>(null);
-  const [editingFile, setEditingFile] = useState<string | null>(null);
-
-  const { data: filesData, isLoading, error } = useUnifiedFiles();
   const deleteFileMutation = useDeleteFile();
-  const reconvertMutation = useReconvertFile();
+
+  // TODO: 運用時に復活
+  // const [editingFile, setEditingFile] = useState<string | null>(null);
+  // const reconvertMutation = useReconvertFile();
 
   const handleDeleteFile = (baseName: string) => {
     if (
@@ -42,43 +47,43 @@ export const KnowledgePanel = () => {
     });
   };
 
-  const handleReconvert = (originalKey: string, baseName: string) => {
-    if (
-      !confirm(
-        `${baseName} のMarkdownを元ファイルから再生成しますか？\n（現在の編集内容は上書きされます）`,
-      )
-    ) {
-      return;
-    }
-    setMessage(null);
-    reconvertMutation.mutate(
-      { originalKey, filename: baseName },
-      {
-        onSuccess: (result) => {
-          setMessage({
-            type: "success",
-            text: `${result.key} を生成しました（${result.chunks}チャンク）`,
-          });
-        },
-        onError: (err) => {
-          setMessage({
-            type: "error",
-            text: `変換失敗: ${err instanceof Error ? err.message : "Unknown error"}`,
-          });
-        },
-      },
-    );
-  };
+  // const handleReconvert = (originalKey: string, baseName: string) => {
+  //   if (
+  //     !confirm(
+  //       `${baseName} のMarkdownを元ファイルから再生成しますか？\n（現在の編集内容は上書きされます）`,
+  //     )
+  //   ) {
+  //     return;
+  //   }
+  //   setMessage(null);
+  //   reconvertMutation.mutate(
+  //     { originalKey, filename: baseName },
+  //     {
+  //       onSuccess: (result) => {
+  //         setMessage({
+  //           type: "success",
+  //           text: `${result.key} を生成しました（${result.chunks}チャンク）`,
+  //         });
+  //       },
+  //       onError: (err) => {
+  //         setMessage({
+  //           type: "error",
+  //           text: `変換失敗: ${err instanceof Error ? err.message : "Unknown error"}`,
+  //         });
+  //       },
+  //     },
+  //   );
+  // };
 
   return (
     <div className="space-y-6">
-      {/* アップロードセクション */}
-      <div className="bg-white rounded-xl border border-stone-200 p-6">
+      {/* TODO: 運用時に復活 - アップロードセクション */}
+      {/* <div className="bg-white rounded-xl border border-stone-200 p-6">
         <h2 className="text-lg font-bold text-stone-800 mb-4">
           ファイルアップロード
         </h2>
         <FileUpload onSuccess={() => {}} />
-      </div>
+      </div> */}
 
       {/* ファイル一覧セクション */}
       <div className="bg-white rounded-xl border border-stone-200 p-6">
@@ -89,9 +94,7 @@ export const KnowledgePanel = () => {
             className={`mb-4 px-4 py-3 rounded-lg text-sm ${
               message.type === "success"
                 ? "bg-green-50 text-green-700"
-                : message.type === "warning"
-                  ? "bg-amber-50 text-amber-700"
-                  : "bg-red-50 text-red-700"
+                : "bg-red-50 text-red-700"
             }`}
           >
             {message.text}
@@ -112,22 +115,32 @@ export const KnowledgePanel = () => {
         {filesData && (
           <FileList
             files={filesData.files}
-            onEdit={(key) => setEditingFile(key)}
+            onView={(key) => setViewingFile(key)}
             onDelete={handleDeleteFile}
-            onReconvert={handleReconvert}
             isDeleting={deleteFileMutation.isPending}
-            isReconverting={reconvertMutation.isPending}
+            // TODO: 運用時に復活
+            // onEdit={(key) => setEditingFile(key)}
+            // onReconvert={handleReconvert}
+            // isReconverting={reconvertMutation.isPending}
           />
         )}
       </div>
 
-      {/* エディタモーダル */}
-      {editingFile && (
+      {/* 閲覧モーダル */}
+      {viewingFile && (
+        <FileViewer
+          fileKey={viewingFile}
+          onClose={() => setViewingFile(null)}
+        />
+      )}
+
+      {/* TODO: 運用時に復活 - エディタモーダル */}
+      {/* {editingFile && (
         <FileEditor
           fileKey={editingFile}
           onClose={() => setEditingFile(null)}
         />
-      )}
+      )} */}
     </div>
   );
 };

--- a/web/src/pages/dashboard/components/knowledge/FileList.tsx
+++ b/web/src/pages/dashboard/components/knowledge/FileList.tsx
@@ -1,13 +1,19 @@
 import { getOriginalFileUrl } from "~/repository/knowledge-repository";
 import type { UnifiedFileInfo } from "~/types";
 
+/**
+ * NOTE: onEdit, onReconvert は運用時に復活させる
+ * 現在は閲覧・削除のみ可能
+ */
 type Props = {
   files: UnifiedFileInfo[];
-  onEdit: (key: string) => void;
-  onDelete: (baseName: string) => void;
-  onReconvert: (originalKey: string, baseName: string) => void;
-  isDeleting: boolean;
-  isReconverting: boolean;
+  onView?: (key: string) => void;
+  onDelete?: (baseName: string) => void;
+  isDeleting?: boolean;
+  // TODO: 運用時に復活
+  // onEdit: (key: string) => void;
+  // onReconvert: (originalKey: string, baseName: string) => void;
+  // isReconverting: boolean;
 };
 
 const formatFileSize = (bytes: number) => {
@@ -29,11 +35,13 @@ const isImageType = (contentType: string) => contentType.startsWith("image/");
 
 export const FileList = ({
   files,
-  onEdit,
+  onView,
   onDelete,
-  onReconvert,
   isDeleting,
-  isReconverting,
+  // TODO: 運用時に復活
+  // onEdit,
+  // onReconvert,
+  // isReconverting,
 }: Props) => {
   if (files.length === 0) {
     return (
@@ -97,7 +105,8 @@ export const FileList = ({
                           </span>
                           <span>{formatFileSize(orig.size)}</span>
                         </a>
-                        <button
+                        {/* TODO: 運用時に復活 - 再生成ボタン */}
+                        {/* <button
                           type="button"
                           onClick={() => onReconvert(orig.key, file.baseName)}
                           disabled={isReconverting}
@@ -107,7 +116,7 @@ export const FileList = ({
                           title="元ファイルからMarkdownを再生成"
                         >
                           {isReconverting ? "生成中..." : "再生成"}
-                        </button>
+                        </button> */}
                       </div>
                     );
                   })()}
@@ -121,7 +130,19 @@ export const FileList = ({
                 {/* 操作 */}
                 <td className="px-4 py-3 whitespace-nowrap text-right text-sm">
                   <div className="flex justify-end gap-3">
-                    {file.hasMarkdown && (
+                    {file.hasMarkdown && onView && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          file.markdown && onView(file.markdown.key)
+                        }
+                        className="text-teal-600 hover:text-teal-800 font-medium"
+                      >
+                        閲覧
+                      </button>
+                    )}
+                    {/* TODO: 運用時に復活 - 編集ボタン */}
+                    {/* {file.hasMarkdown && (
                       <button
                         type="button"
                         onClick={() =>
@@ -131,15 +152,17 @@ export const FileList = ({
                       >
                         編集
                       </button>
+                    )} */}
+                    {onDelete && (
+                      <button
+                        type="button"
+                        onClick={() => onDelete(file.baseName)}
+                        disabled={isDeleting}
+                        className="text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
+                      >
+                        削除
+                      </button>
                     )}
-                    <button
-                      type="button"
-                      onClick={() => onDelete(file.baseName)}
-                      disabled={isDeleting}
-                      className="text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
-                    >
-                      削除
-                    </button>
                   </div>
                 </td>
               </tr>

--- a/web/src/pages/dashboard/components/knowledge/FileViewer.tsx
+++ b/web/src/pages/dashboard/components/knowledge/FileViewer.tsx
@@ -1,0 +1,97 @@
+import { useKnowledgeFile } from "~/hooks/useDashboard";
+
+type Props = {
+  fileKey: string;
+  onClose: () => void;
+};
+
+/**
+ * ナレッジファイルの閲覧専用ビューア
+ * 運用時はFileEditorに置き換え可能
+ */
+export const FileViewer = ({ fileKey, onClose }: Props) => {
+  const { data, isLoading, error } = useKnowledgeFile(fileKey);
+
+  if (isLoading) {
+    return (
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div className="bg-white rounded-xl p-6 w-full max-w-4xl mx-4">
+          <div className="text-center py-8 text-stone-500">読み込み中...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+        <div className="bg-white rounded-xl p-6 w-full max-w-4xl mx-4">
+          <div className="text-center py-8 text-red-500">
+            エラー:{" "}
+            {error instanceof Error ? error.message : "読み込みに失敗しました"}
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-stone-600 hover:text-stone-800"
+            >
+              閉じる
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-xl w-full max-w-4xl mx-4 max-h-[90vh] flex flex-col">
+        {/* ヘッダー */}
+        <div className="flex items-center justify-between p-4 border-b border-stone-200">
+          <h3 className="text-lg font-bold text-stone-800">{fileKey}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 text-stone-400 hover:text-stone-600 rounded-lg hover:bg-stone-100"
+            aria-label="閉じる"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <title>閉じる</title>
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="flex-1 overflow-auto p-4">
+          <div className="prose prose-stone max-w-none whitespace-pre-wrap font-mono text-sm">
+            {data?.content}
+          </div>
+        </div>
+
+        {/* フッター */}
+        <div className="flex justify-end p-4 border-t border-stone-200 bg-stone-50">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-stone-600 hover:text-stone-800"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/web/src/pages/dashboard/components/knowledge/index.ts
+++ b/web/src/pages/dashboard/components/knowledge/index.ts
@@ -2,3 +2,4 @@ export { ConvertDialog } from "./ConvertDialog";
 export { FileEditor } from "./FileEditor";
 export { FileList } from "./FileList";
 export { FileUpload } from "./FileUpload";
+export { FileViewer } from "./FileViewer";


### PR DESCRIPTION
## 経緯
ナレッジの文章構造は慎重に検討する必要があるため、管理画面からアップロードのロジックは一旦オミットする。
文章アップロードの機能が整ったらロジックを繋ぎ込み再開する。

## Summary
- ナレッジ管理画面のアップロード・編集機能を一時的に無効化
- 閲覧専用のFileViewerコンポーネントを新規追加
- 削除機能は維持

## 主な変更内容
- `KnowledgePanel.tsx`: アップロードセクション、編集ハンドラをコメントアウト
- `FileList.tsx`: 編集・再生成ボタンをコメントアウト、閲覧・削除ボタンを有効化
- `FileViewer.tsx`: 新規作成 - Markdownファイルの読み取り専用ビューア
- 運用フェーズで必要に応じて復活させるため、TODOコメントを追加

## Test plan
- [x] lint/format/buildが正常に通ること
- [x] ファイル一覧が正常に表示されること
- [x] 閲覧ボタンでMarkdown内容が表示されること
- [x] 削除ボタンでファイルが削除されること
- [x] アップロード・編集UIが非表示であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)