### PR TITLE
refactor: インラインSVGをHeroiconsに置換

### DIFF
--- a/web/src/pages/chat/components/ChatContainer.tsx
+++ b/web/src/pages/chat/components/ChatContainer.tsx
@@ -1,4 +1,5 @@
 import { useChat } from "@ai-sdk/react";
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 import { useQueryClient } from "@tanstack/react-query";
 import type { UIMessage } from "ai";
 import { DefaultChatTransport, isToolOrDynamicToolUIPart } from "ai";
@@ -271,21 +272,10 @@ export const ChatContainer = () => {
                   className="p-1 hover:bg-white/60 rounded transition-colors"
                   aria-label="閉じる"
                 >
-                  <svg
+                  <XMarkIcon
                     className="w-5 h-5 text-[var(--color-text-muted)]"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
                     aria-hidden="true"
-                  >
-                    <title>閉じる</title>
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
+                  />
                 </button>
               </div>
               <button
@@ -329,21 +319,10 @@ export const ChatContainer = () => {
               className="p-2 -ml-2 hover:bg-[var(--color-surface)] rounded-lg transition-colors"
               aria-label="メニュー"
             >
-              <svg
+              <Bars3Icon
                 className="w-5 h-5 text-[var(--color-text-muted)]"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
                 aria-hidden="true"
-              >
-                <title>メニュー</title>
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M4 6h16M4 12h16M4 18h16"
-                />
-              </svg>
+              />
             </button>
             <h1 className="text-base font-semibold">ねっぷちゃん</h1>
           </div>

--- a/web/src/pages/dashboard/App.tsx
+++ b/web/src/pages/dashboard/App.tsx
@@ -1,3 +1,9 @@
+import {
+  BookOpenIcon,
+  ChatBubbleLeftIcon,
+  ExclamationTriangleIcon,
+  UserGroupIcon,
+} from "@heroicons/react/24/outline";
 import { useState } from "react";
 import { EmergencyPanel } from "./components/EmergencyPanel";
 import { FeedbackPanel } from "./components/FeedbackPanel";
@@ -10,82 +16,22 @@ const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
   {
     id: "knowledge",
     label: "ナレッジ",
-    icon: (
-      <svg
-        className="w-4 h-4"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-        />
-      </svg>
-    ),
+    icon: <BookOpenIcon className="w-4 h-4" aria-hidden="true" />,
   },
   {
     id: "persona",
     label: "ペルソナ",
-    icon: (
-      <svg
-        className="w-4 h-4"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-        />
-      </svg>
-    ),
+    icon: <UserGroupIcon className="w-4 h-4" aria-hidden="true" />,
   },
   {
     id: "feedback",
     label: "フィードバック",
-    icon: (
-      <svg
-        className="w-4 h-4"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"
-        />
-      </svg>
-    ),
+    icon: <ChatBubbleLeftIcon className="w-4 h-4" aria-hidden="true" />,
   },
   {
     id: "emergency",
     label: "緊急情報",
-    icon: (
-      <svg
-        className="w-4 h-4"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-        />
-      </svg>
-    ),
+    icon: <ExclamationTriangleIcon className="w-4 h-4" aria-hidden="true" />,
   },
 ];
 

--- a/web/src/pages/dashboard/components/knowledge/FileUpload.tsx
+++ b/web/src/pages/dashboard/components/knowledge/FileUpload.tsx
@@ -1,3 +1,4 @@
+import { ArrowUpTrayIcon } from "@heroicons/react/24/outline";
 import { useCallback, useState } from "react";
 import { useConvertFile, useUploadFile } from "~/hooks/useDashboard";
 import { ConvertDialog } from "./ConvertDialog";
@@ -128,20 +129,10 @@ export const FileUpload = ({ onSuccess }: Props) => {
         }`}
       >
         <div className="space-y-2">
-          <svg
+          <ArrowUpTrayIcon
             className="mx-auto h-12 w-12 text-stone-400"
-            stroke="currentColor"
-            fill="none"
-            viewBox="0 0 48 48"
             aria-hidden="true"
-          >
-            <path
-              d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
+          />
           <div className="text-sm text-stone-600">
             <span className="text-teal-600 hover:text-teal-700 font-medium">
               ファイルを選択

--- a/web/src/pages/dashboard/components/knowledge/FileViewer.tsx
+++ b/web/src/pages/dashboard/components/knowledge/FileViewer.tsx
@@ -1,3 +1,4 @@
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import { useKnowledgeFile } from "~/hooks/useDashboard";
 
 type Props = {
@@ -56,21 +57,7 @@ export const FileViewer = ({ fileKey, onClose }: Props) => {
             className="p-1.5 text-stone-400 hover:text-stone-600 rounded-lg hover:bg-stone-100"
             aria-label="閉じる"
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <title>閉じる</title>
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <XMarkIcon className="w-5 h-5" aria-hidden="true" />
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
- インラインSVGアイコンを `@heroicons/react/24/outline` コンポーネントに統一
- コードの一貫性と保守性を向上

## 主な変更内容
| ファイル | 変更内容 |
|---------|---------|
| `ChatContainer.tsx` | `XMarkIcon`, `Bars3Icon` に置換 |
| `dashboard/App.tsx` | `BookOpenIcon`, `UserGroupIcon`, `ChatBubbleLeftIcon`, `ExclamationTriangleIcon` に置換 |
| `FileViewer.tsx` | `XMarkIcon` に置換 |
| `FileUpload.tsx` | `ArrowUpTrayIcon` に置換 |

### 削減効果
- 4ファイルで **117行削減**、**20行追加**

## Test plan
- [x] lint チェック通過
- [x] format チェック通過
- [x] web ビルド成功
- [x] チャット画面のメニューアイコン表示確認
- [x] チャット画面のサイドバー閉じるアイコン表示確認
- [x] ダッシュボードのタブアイコン表示確認
- [x] ファイルビューアの閉じるアイコン表示確認
- [x] ファイルアップロードのアイコン表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)