### PR TITLE
fix: フィードバックモーダルが送信完了後に閉じない問題を修正

### DIFF
--- a/web/src/pages/chat/FeedbackContext.tsx
+++ b/web/src/pages/chat/FeedbackContext.tsx
@@ -87,13 +87,16 @@ const extractConversationContext = (
 };
 
 const extractToolExecutions = (message: UIMessage): ToolExecution[] =>
-  message.parts.filter(isToolOrDynamicToolUIPart).map((part) => ({
-    toolName: getToolNameFromPart(part),
-    state: part.state,
-    input: "input" in part ? part.input : undefined,
-    output: "output" in part ? part.output : undefined,
-    errorText: "errorText" in part ? (part.errorText as string) : undefined,
-  }));
+  message.parts
+    .filter(isToolOrDynamicToolUIPart)
+    .filter((part) => part.state !== undefined)
+    .map((part) => ({
+      toolName: getToolNameFromPart(part),
+      state: part.state as string,
+      input: "input" in part ? part.input : undefined,
+      output: "output" in part ? part.output : undefined,
+      errorText: "errorText" in part ? (part.errorText as string) : undefined,
+    }));
 
 /**
  * assistant-ui の ThreadMessage を UIMessage に変換

--- a/web/src/pages/chat/components/FeedbackModal.tsx
+++ b/web/src/pages/chat/components/FeedbackModal.tsx
@@ -20,7 +20,10 @@ type Props = {
   isOpen: boolean;
   onClose: () => void;
   rating: FeedbackRating;
-  onSubmit: (data: { category?: FeedbackCategory; comment?: string }) => void;
+  onSubmit: (data: {
+    category?: FeedbackCategory;
+    comment?: string;
+  }) => Promise<void>;
   isSubmitting: boolean;
 };
 
@@ -38,9 +41,9 @@ export const FeedbackModal = ({
 
   const isBadRating = rating === "bad";
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({
+    await onSubmit({
       category: isBadRating ? category : undefined,
       comment: comment.trim() || undefined,
     });


### PR DESCRIPTION
## Summary
- フィードバックモーダルが送信完了後に正しく閉じるように修正
- `onSubmit` を非同期関数として適切に扱うよう変更

## 主な変更内容
- `FeedbackModal.tsx`: `onSubmit` の型を `Promise<void>` に変更し、`handleSubmit` を `async` 関数化
- `FeedbackContext.tsx`: `extractToolExecutions` で `state` が `undefined` のパートを除外するフィルタを追加

## Test plan
- [x] 良い回答（👍）ボタンをクリックしてフィードバックを送信
- [x] 送信完了後にモーダルが自動的に閉じることを確認
- [x] 改善が必要（👎）ボタンでも同様にモーダルが閉じることを確認
- [x] アイデア（💡）ボタンでも同様にモーダルが閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)