### PR TITLE
fix: モバイルでログイン後の API リクエスト失敗を修正

### DIFF
--- a/web/src/pages/dashboard/contexts/AuthContext.tsx
+++ b/web/src/pages/dashboard/contexts/AuthContext.tsx
@@ -41,8 +41,6 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     } catch (error) {
       console.error("認証チェック失敗:", error);
       setState({ user: null, isLoading: false, isAuthenticated: false });
-    } finally {
-      sessionStorage.removeItem("just_logged_in");
     }
   }, []);
 

--- a/web/src/pages/dashboard/routes.tsx
+++ b/web/src/pages/dashboard/routes.tsx
@@ -34,13 +34,20 @@ const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/dashboard",
   beforeLoad: async ({ context }) => {
-    // ログイン直後はスキップ（クッキー設定完了待ち）
     const justLoggedIn = sessionStorage.getItem("just_logged_in");
+
     if (justLoggedIn) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      sessionStorage.removeItem("just_logged_in");
+      const user = await fetchCurrentUser();
+      if (!user) {
+        window.location.href = "/login";
+        return;
+      }
+      context.auth.setUser(user);
       return;
     }
 
-    // 認証状態が確定している場合はそのまま判定
     if (!context.auth.isLoading) {
       if (!context.auth.isAuthenticated) {
         window.location.href = "/login";
@@ -48,14 +55,11 @@ const dashboardRoute = createRoute({
       return;
     }
 
-    // isLoading 中は直接 API を呼んで認証確認
     const user = await fetchCurrentUser();
     if (!user) {
       window.location.href = "/login";
       return;
     }
-
-    // ユーザー情報を AuthContext に反映
     context.auth.setUser(user);
   },
   component: App,


### PR DESCRIPTION
## Summary
- モバイル Safari でログイン後、Cookie が反映される前に API リクエストが発行される問題を修正
- `beforeLoad` で 100ms 待機してから認証確認を行うように変更

## 主な変更内容
- `routes.tsx`: ログイン直後（`just_logged_in` フラグあり）の場合、Cookie 反映を待機してから `fetchCurrentUser` で認証確認
- `AuthContext.tsx`: `sessionStorage.removeItem` は `routes.tsx` で行うため削除

## Test plan
- [ ] モバイル Safari でパスキーログイン後、ダッシュボードが正常に表示される
- [ ] ナレッジ一覧が正常に取得できる
- [ ] 通常のブラウザリロードでも認証が維持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)