### PR TITLE
fix: AuthContext の useEffect で checkAuth をスキップ

### DIFF
--- a/web/src/pages/dashboard/contexts/AuthContext.tsx
+++ b/web/src/pages/dashboard/contexts/AuthContext.tsx
@@ -61,6 +61,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
+    const justLoggedIn = sessionStorage.getItem("just_logged_in");
+    if (justLoggedIn) {
+      return;
+    }
     checkAuth();
   }, [checkAuth]);
 


### PR DESCRIPTION
## Summary
- ログイン直後に `AuthContext` の `useEffect` で `checkAuth()` がスキップされるよう修正
- Cookie 反映前のリクエスト発行を防止

## 主な変更内容
- `AuthContext.tsx`: `just_logged_in` フラグがある場合、`useEffect` での `checkAuth()` をスキップ
- `beforeLoad` で Cookie 反映を待機してから認証確認を行う既存の修正と組み合わせて動作

## 背景
前回の PR #85 で `beforeLoad` での待機を追加したが、`AuthContext` の `useEffect` が即座に `checkAuth()` を発火し、Cookie なしでリクエストが送信される問題が残っていた。

## Test plan
- [ ] モバイル Safari でパスキーログイン後、ダッシュボードが正常に表示される
- [ ] `/auth/me` が重複して呼ばれない
- [ ] ナレッジ一覧が正常に取得できる
- [ ] 通常のブラウザリロードでも認証が維持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)