### PR TITLE
fix: AuthProvider で認証完了まで子コンポーネントをレンダリングしない

### DIFF
--- a/web/src/pages/auth/login.tsx
+++ b/web/src/pages/auth/login.tsx
@@ -18,9 +18,6 @@ const LoginPage = () => {
       const authResponse = await startAuthentication({ optionsJSON: options });
       await verifyLogin({ challengeId, response: authResponse });
 
-      // ログイン直後フラグを設定（クッキー設定完了前のリダイレクト対策）
-      sessionStorage.setItem("just_logged_in", "true");
-
       window.location.href = "/dashboard";
     } catch (err) {
       if (err instanceof Error) {

--- a/web/src/pages/dashboard/contexts/AuthContext.tsx
+++ b/web/src/pages/dashboard/contexts/AuthContext.tsx
@@ -61,12 +61,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, []);
 
   useEffect(() => {
-    const justLoggedIn = sessionStorage.getItem("just_logged_in");
-    if (justLoggedIn) {
-      return;
-    }
     checkAuth();
   }, [checkAuth]);
+
+  if (state.isLoading) {
+    return null;
+  }
 
   return (
     <AuthContext.Provider value={{ ...state, checkAuth, logout, setUser }}>

--- a/web/src/pages/dashboard/routes.tsx
+++ b/web/src/pages/dashboard/routes.tsx
@@ -5,7 +5,6 @@ import {
   Outlet,
 } from "@tanstack/react-router";
 
-import { fetchCurrentUser } from "~/lib/api/auth";
 import { App } from "./App";
 
 type AuthContext = {
@@ -33,34 +32,10 @@ const rootRoute = createRootRouteWithContext<RouterContext>()({
 const dashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/dashboard",
-  beforeLoad: async ({ context }) => {
-    const justLoggedIn = sessionStorage.getItem("just_logged_in");
-
-    if (justLoggedIn) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      sessionStorage.removeItem("just_logged_in");
-      const user = await fetchCurrentUser();
-      if (!user) {
-        window.location.href = "/login";
-        return;
-      }
-      context.auth.setUser(user);
-      return;
-    }
-
-    if (!context.auth.isLoading) {
-      if (!context.auth.isAuthenticated) {
-        window.location.href = "/login";
-      }
-      return;
-    }
-
-    const user = await fetchCurrentUser();
-    if (!user) {
+  beforeLoad: ({ context }) => {
+    if (!context.auth.isAuthenticated) {
       window.location.href = "/login";
-      return;
     }
-    context.auth.setUser(user);
   },
   component: App,
 });


### PR DESCRIPTION
## Summary
- `AuthProvider` で認証チェック完了まで子コンポーネントをレンダリングしないように変更
- `just_logged_in` フラグと関連する複雑なロジックを削除
- シンプルで堅牢な認証フローに改善

## 主な変更内容

### AuthContext.tsx
- `isLoading` が `true` の間は `children` をレンダリングしない
- `just_logged_in` フラグのチェックを削除

### routes.tsx
- `beforeLoad` をシンプル化（`isAuthenticated` のチェックのみ）
- `loader` や複雑な待機ロジックを削除
- `fetchCurrentUser` のインポートを削除

### login.tsx
- `sessionStorage.setItem("just_logged_in", "true")` を削除

## これで解決する理由
- ダッシュボードにアクセス → `AuthProvider` がマウント
- `checkAuth()` が `/auth/me` を呼ぶ（Cookie 付き）
- 成功するまで何もレンダリングしない
- 成功したら `isLoading: false` になり、子コンポーネントがレンダリング
- `KnowledgePanel` がマウントされる頃には認証済み

## Test plan
- [ ] モバイル Safari でパスキーログイン後、ダッシュボードが正常に表示される
- [ ] ナレッジ一覧が正常に取得できる
- [ ] 通常のブラウザリロードでも認証が維持される
- [ ] 未認証状態でダッシュボードにアクセスするとログインページにリダイレクトされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)