### PR TITLE
fix: iOS Safariでのチャット入力欄の自動ズームを修正

### DIFF
--- a/web/src/components/assistant-ui/Thread.tsx
+++ b/web/src/components/assistant-ui/Thread.tsx
@@ -127,7 +127,7 @@ const Composer = () => (
   <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
     <ComposerPrimitive.Input
       placeholder="メッセージを入力..."
-      className="aui-composer-input mb-1 max-h-32 min-h-14 w-full resize-none rounded-xl border border-(--color-border) bg-(--color-surface) px-4 pt-4 pb-3 text-sm text-(--color-text) outline-none placeholder:text-(--color-text-faint) focus:border-(--color-accent) focus:ring-2 focus:ring-(--color-accent-light)/20 transition-all"
+      className="aui-composer-input mb-1 max-h-32 min-h-14 w-full resize-none rounded-xl border border-(--color-border) bg-(--color-surface) px-4 pt-4 pb-3 text-base text-(--color-text) outline-none placeholder:text-(--color-text-faint) focus:border-(--color-accent) focus:ring-2 focus:ring-(--color-accent-light)/20 transition-all"
       rows={1}
       autoFocus
       aria-label="メッセージ入力"


### PR DESCRIPTION
## Summary
- iOS Safari でチャット入力欄にフォーカスした際の自動ズームを修正

## 主な変更内容
- チャット入力欄のフォントサイズを `text-sm`（14px）から `text-base`（16px）に変更
- iOS Safari は 16px 未満の input/textarea にフォーカスすると自動的にズームするため、16px に設定することで回避

## Test plan
- [ ] iOS Safari でチャット入力欄をタップした際にズームしないことを確認
- [ ] デスクトップブラウザで表示が崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)