### PR TITLE
feat: GitHub Actions によるデプロイ自動化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy to Cloudflare
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy-server:
+    name: Deploy Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run DB Migrations
+        run: pnpm db:migrate
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Deploy Server
+        run: pnpm --filter @aiss-nepch/server deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  deploy-web:
+    name: Deploy Web
+    runs-on: ubuntu-latest
+    needs: deploy-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Deploy Web
+        run: |
+          pnpm --filter @aiss-nepch/web build
+          pnpm --filter @aiss-nepch/web exec wrangler pages deploy dist
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          DOTENV_PRIVATE_KEY_PRODUCTION: ${{ secrets.DOTENV_PRIVATE_KEY_PRODUCTION }}


### PR DESCRIPTION
## Summary
- develop ブランチへのマージ時に Cloudflare へ自動デプロイする GitHub Actions ワークフローを追加

## 主な変更内容
- `.github/workflows/deploy.yml` を新規作成
- deploy-server ジョブ: D1 マイグレーション実行 → Workers デプロイ
- deploy-web ジョブ: Vite ビルド → Pages デプロイ（server 完了後に実行）

## 必要な GitHub Secrets
| シークレット名 | 用途 |
|---------------|------|
| `CLOUDFLARE_API_TOKEN` | Cloudflare API トークン（Workers Scripts / Pages / D1 の Edit 権限） |
| `DOTENV_PRIVATE_KEY_PRODUCTION` | 本番環境用 dotenvx 秘密鍵 |

## Test plan
- [ ] GitHub Secrets を設定
- [ ] develop にマージして Actions が実行されることを確認
- [ ] Cloudflare Dashboard で Workers と Pages のデプロイを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)