### PR TITLE
feat(server): エージェントに現在日時を動的に注入

### DIFF
--- a/server/src/lib/date.ts
+++ b/server/src/lib/date.ts
@@ -1,0 +1,15 @@
+/**
+ * 現在の日時情報を生成する（JST）
+ * エージェントの instructions に注入して使用
+ */
+export const getCurrentDateInfo = () => {
+  const now = new Date();
+  const jst = new Intl.DateTimeFormat("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  });
+  return `今日は${jst.format(now)}です。`;
+};

--- a/server/src/mastra/agents/knowledge-agent.ts
+++ b/server/src/mastra/agents/knowledge-agent.ts
@@ -1,21 +1,7 @@
 import { Agent } from "@mastra/core/agent";
+import { getCurrentDateInfo } from "~/lib/date";
 import { GEMINI_FLASH } from "~/lib/llm-models";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
-
-/**
- * 現在の日時情報を生成する
- */
-const getCurrentDateInfo = () => {
-  const now = new Date();
-  const jst = new Intl.DateTimeFormat("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    weekday: "long",
-  });
-  return `今日は${jst.format(now)}です。`;
-};
 
 const baseInstructions = `
 あなたは音威子府村の情報検索専門エージェントです。

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -1,5 +1,6 @@
 import type { AgentConfig } from "@mastra/core/agent";
 import { Agent } from "@mastra/core/agent";
+import { getCurrentDateInfo } from "~/lib/date";
 import { GEMINI_FLASH } from "~/lib/llm-models";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
 import { emergencyReporterAgent } from "~/mastra/agents/emergency-reporter-agent";
@@ -14,26 +15,6 @@ import { displayChartTool } from "~/mastra/tools/display-chart-tool";
 import { displayTableTool } from "~/mastra/tools/display-table-tool";
 import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
-
-/**
- * 現在の日時情報を生成する
- * リクエスト時に動的に生成され、instructionsに注入される
- */
-const getCurrentDateInfo = () => {
-  const now = new Date();
-  const jst = new Intl.DateTimeFormat("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    weekday: "long",
-  });
-
-  return `
-## 現在の日時
-今日は${jst.format(now)}です。
-`;
-};
 
 const baseInstructions = `
 あなたは北海道音威子府（おといねっぷ）村に住む17歳の女の子「ねっぷちゃん」。
@@ -147,7 +128,11 @@ export const createNepChanAgent = ({
 
   // instructionsを関数化（リクエスト時に評価され、現在日時が動的に取得される）
   const instructions = () =>
-    [baseInstructions, getCurrentDateInfo(), isAdmin ? adminInstructions : ""]
+    [
+      baseInstructions,
+      `## 現在の日時\n${getCurrentDateInfo()}`,
+      isAdmin ? adminInstructions : "",
+    ]
       .filter(Boolean)
       .join("\n");
 


### PR DESCRIPTION
## Summary
- `knowledgeAgent` と `neppChanAgent` の instructions を関数化し、リクエスト時に現在日時を動的に取得するように変更
- 「今年」「最新」などの曖昧な時間表現を具体的な日付に変換するための基準日時を提供

## 主な変更内容
- `getCurrentDateInfo()` 関数を追加し、JST の日付を整形して返す
- `instructions` を文字列から関数に変更（Mastra がリクエスト時に評価）
- knowledgeAgent に検索クエリ生成ルールを追加

## Test plan
- [ ] チャットで「今年のイベント」など時間表現を含む質問をして、正しく解釈されることを確認
- [ ] knowledgeAgent が現在日時を基準に検索クエリを生成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)