### PR TITLE
feat(web): ファビコンを追加

### DIFF
--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-chat.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ねっぷちゃん 管理画面</title>
   </head>

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-chat.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ねっぷちゃん</title>
   </head>

--- a/web/login.html
+++ b/web/login.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-chat.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ログイン | ねっぷちゃん 管理画面</title>
   </head>

--- a/web/public/favicon-chat.svg
+++ b/web/public/favicon-chat.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <!-- Main chat bubble -->
+  <rect x="3" y="4" width="26" height="18" rx="6" ry="6" fill="#0f766e"/>
+  <!-- Bubble tail -->
+  <path d="M8 22 L6 28 L14 22" fill="#0f766e"/>
+  <!-- Dot 1 -->
+  <circle cx="10" cy="13" r="2" fill="#fff"/>
+  <!-- Dot 2 -->
+  <circle cx="16" cy="13" r="2" fill="#fff"/>
+  <!-- Dot 3 -->
+  <circle cx="22" cy="13" r="2" fill="#fff"/>
+</svg>

--- a/web/register.html
+++ b/web/register.html
@@ -2,6 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon-chat.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>登録 | ねっぷちゃん 管理画面</title>
   </head>


### PR DESCRIPTION
## Summary
- チャット吹き出しデザインのSVGファビコンを作成（ティール色・透過背景）
- 全HTMLページ（chat / dashboard / login / register）に `<link rel="icon">` を設定

## Test plan
- [ ] 各ページでファビコンが表示されるか確認（/, /dashboard, /login, /register）
