### PR TITLE
feat: knowledge:upload:production コマンドを追加

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,4 @@
+# R2 アップロードスクリプト用（pnpm knowledge:upload:production）
+CLOUDFLARE_ACCOUNT_ID=your-cloudflare-account-id
+R2_BUCKET_NAME=nepp-chan-knowledge-prd
+VECTORIZE_INDEX_NAME=nepp-chan-knowledge-prd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ await storage.init(); // 必須
 ```bash
 # ルート
 cp .env.example .env
+cp .env.production.example .env.production  # 本番ナレッジアップロード用（任意）
 
 # server
 cp server/.env.example server/.env

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pnpm install
 ```bash
 # ルート
 cp .env.example .env
+cp .env.production.example .env.production  # 本番ナレッジアップロード用（任意）
 
 # server
 cp server/.env.example server/.env

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "db:push": "pnpm --filter @nepp-chan/server db:push",
     "db:check": "pnpm --filter @nepp-chan/server db:check",
     "knowledge:upload": "tsx scripts/upload-knowledge.ts",
+    "knowledge:upload:production": "tsx --env-file=.env.production scripts/upload-knowledge.ts",
     "test": "pnpm --filter @nepp-chan/server test",
     "admin:invite:local": "tsx server/scripts/create-invitation.ts",
     "admin:invite:dev": "tsx server/scripts/create-invitation.ts --env=dev",

--- a/scripts/upload-knowledge.ts
+++ b/scripts/upload-knowledge.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { basename } from "node:path";
 import { glob } from "glob";
 
-const KNOWLEDGE_DIR = "./dataset/v3/src/villotoinep";
+const KNOWLEDGE_DIR = "./knowledge";
 const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID;
 const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME;
 const VECTORIZE_INDEX_NAME = process.env.VECTORIZE_INDEX_NAME;
@@ -79,10 +79,10 @@ const deleteVectorizeIndex = (): boolean => {
   try {
     console.log(`  Deleting Vectorize index: ${VECTORIZE_INDEX_NAME}`);
 
-    // wrangler vectorize delete-index でインデックス内の全ベクトルを削除
-    // --force フラグで確認をスキップ
+    // wrangler vectorize delete でインデックスを削除
+    // -y フラグで確認をスキップ
     execSync(
-      `CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID} wrangler vectorize delete-index ${VECTORIZE_INDEX_NAME} --force`,
+      `CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID} wrangler vectorize delete ${VECTORIZE_INDEX_NAME} -y`,
       { stdio: "pipe" },
     );
 


### PR DESCRIPTION
## Summary
- `pnpm knowledge:upload:production` コマンドを追加（本番環境の R2 バケットにナレッジをアップロード）
- KNOWLEDGE_DIR を `./knowledge` に変更
- wrangler vectorize コマンドを `delete -y` に更新
- `.env.production.example` を追加

## Test plan
- [x] `pnpm knowledge:upload` が正常に動作する
- [x] `pnpm knowledge:upload:production` が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)