### PR TITLE
fix(web): フィードバック送信時の ZodError を修正

### DIFF
--- a/web/src/pages/chat/FeedbackContext.tsx
+++ b/web/src/pages/chat/FeedbackContext.tsx
@@ -89,7 +89,7 @@ const extractConversationContext = (
 const extractToolExecutions = (message: UIMessage): ToolExecution[] =>
   message.parts.filter(isToolOrDynamicToolUIPart).map((part) => ({
     toolName: getToolNameFromPart(part),
-    state: part.state,
+    state: part.state ?? "unknown",
     input: "input" in part ? part.input : undefined,
     output: "output" in part ? part.output : undefined,
     errorText: "errorText" in part ? (part.errorText as string) : undefined,


### PR DESCRIPTION
## Summary
- toolExecutions の state が undefined の場合に ZodError が発生する問題を修正
- `part.state ?? "unknown"` でデフォルト値を設定

## Test plan
- [ ] フィードバック送信が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)