### PR TITLE
fix: ダッシュボード無限スクロールが動作しない問題を修正

### DIFF
--- a/web/src/pages/dashboard/components/FeedbackPanel.tsx
+++ b/web/src/pages/dashboard/components/FeedbackPanel.tsx
@@ -454,221 +454,146 @@ export const FeedbackPanel = () => {
           フィードバックデータがありません
         </div>
       ) : (
-        <>
-          {/* Desktop: Table View */}
-          <div className="hidden md:block bg-white rounded-xl border border-stone-200 overflow-auto max-h-[70dvh]">
-            <table className="min-w-[700px] w-full text-sm">
-              <thead className="bg-stone-50 border-b border-stone-200 sticky top-0">
-                <tr>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-24">
-                    評価
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap">
-                    カテゴリ
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap">
-                    コメント
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap">
-                    日時
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-24">
-                    ステータス
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-16">
-                    詳細
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-stone-100">
-                {feedbacks.map((feedback) => {
-                  const isResolved = !!feedback.resolvedAt;
-                  return (
-                    <tr
-                      key={feedback.id}
-                      className={`hover:bg-stone-50 ${isResolved ? "bg-stone-50 opacity-60" : ""}`}
-                    >
-                      <td className="px-4 py-3 w-24">
-                        <span
-                          className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded ${
-                            feedback.rating === "good"
-                              ? "bg-green-100 text-green-700"
-                              : feedback.rating === "idea"
-                                ? "bg-amber-100 text-amber-700"
-                                : "bg-red-100 text-red-700"
-                          }`}
-                        >
-                          {feedback.rating === "good" ? (
-                            <>
-                              <HandThumbUpIcon className="w-3.5 h-3.5" />
-                              Good
-                            </>
-                          ) : feedback.rating === "idea" ? (
-                            <>
-                              <LightBulbIcon className="w-3.5 h-3.5" />
-                              Idea
-                            </>
-                          ) : (
-                            <>
-                              <HandThumbDownIcon className="w-3.5 h-3.5" />
-                              Bad
-                            </>
-                          )}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-stone-600 text-xs">
-                        {feedback.category
-                          ? FEEDBACK_CATEGORY_LABELS[
-                              feedback.category as FeedbackCategory
-                            ] || feedback.category
-                          : "-"}
-                      </td>
-                      <td className="px-4 py-3 text-stone-700 max-w-md truncate">
-                        {feedback.comment || "-"}
-                      </td>
-                      <td className="px-4 py-3 text-stone-500 text-xs whitespace-nowrap">
-                        {formatDateTime(feedback.createdAt)}
-                      </td>
-                      <td className="px-4 py-3 w-24">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (isResolved) {
-                              unresolveMutation.mutate(feedback.id);
-                            } else {
-                              resolveMutation.mutate(feedback.id);
-                            }
-                          }}
-                          disabled={
-                            resolveMutation.isPending ||
-                            unresolveMutation.isPending
-                          }
-                          className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors whitespace-nowrap ${
-                            isResolved
-                              ? "bg-teal-100 text-teal-700 hover:bg-teal-200"
-                              : "bg-stone-100 text-stone-600 hover:bg-stone-200"
-                          } disabled:opacity-50`}
-                        >
-                          {isResolved ? (
-                            <>
-                              <CheckIcon className="w-3 h-3" />
-                              解決済み
-                            </>
-                          ) : (
-                            "未解決"
-                          )}
-                        </button>
-                      </td>
-                      <td className="px-4 py-3 w-16">
-                        <button
-                          type="button"
-                          onClick={() => setSelectedFeedback(feedback)}
-                          className="text-teal-600 hover:text-teal-700 hover:underline text-sm"
-                        >
-                          詳細
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-            <div ref={loadMoreRef} className="py-4 text-center">
-              {isFetchingNextPage && (
-                <div className="text-stone-500 text-sm">読み込み中...</div>
-              )}
-              {!hasNextPage && feedbacks.length > 0 && (
-                <div className="text-stone-400 text-sm">
-                  すべてのフィードバックを表示しました
-                </div>
-              )}
+        <div className="bg-white rounded-xl border border-stone-200 overflow-auto max-h-[70dvh]">
+          <div
+            className="grid text-sm"
+            style={{
+              gridTemplateColumns:
+                "minmax(4rem, auto) minmax(4rem, auto) 1fr minmax(6rem, auto) minmax(5rem, auto) minmax(3rem, auto)",
+            }}
+          >
+            <div className="contents hidden md:[display:contents] font-medium text-stone-600 text-xs">
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                評価
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                カテゴリ
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                コメント
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                日時
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                ステータス
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                詳細
+              </div>
             </div>
-          </div>
 
-          {/* Mobile: Card View */}
-          <div className="md:hidden space-y-3 max-h-[70dvh] overflow-auto">
             {feedbacks.map((feedback) => {
               const isResolved = !!feedback.resolvedAt;
+              const ratingBadge = (
+                <span
+                  className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded ${
+                    feedback.rating === "good"
+                      ? "bg-green-100 text-green-700"
+                      : feedback.rating === "idea"
+                        ? "bg-amber-100 text-amber-700"
+                        : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {feedback.rating === "good" ? (
+                    <>
+                      <HandThumbUpIcon className="w-3.5 h-3.5" />
+                      Good
+                    </>
+                  ) : feedback.rating === "idea" ? (
+                    <>
+                      <LightBulbIcon className="w-3.5 h-3.5" />
+                      Idea
+                    </>
+                  ) : (
+                    <>
+                      <HandThumbDownIcon className="w-3.5 h-3.5" />
+                      Bad
+                    </>
+                  )}
+                </span>
+              );
+              const statusButton = (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (isResolved) {
+                      unresolveMutation.mutate(feedback.id);
+                    } else {
+                      resolveMutation.mutate(feedback.id);
+                    }
+                  }}
+                  disabled={
+                    resolveMutation.isPending || unresolveMutation.isPending
+                  }
+                  className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors whitespace-nowrap ${
+                    isResolved
+                      ? "bg-teal-100 text-teal-700 hover:bg-teal-200"
+                      : "bg-stone-100 text-stone-600 hover:bg-stone-200"
+                  } disabled:opacity-50`}
+                >
+                  {isResolved ? (
+                    <>
+                      <CheckIcon className="w-3 h-3" />
+                      解決済み
+                    </>
+                  ) : (
+                    "未解決"
+                  )}
+                </button>
+              );
+
               return (
                 <div
                   key={feedback.id}
-                  className={`bg-white rounded-xl border border-stone-200 p-4 space-y-3 ${isResolved ? "opacity-60" : ""}`}
+                  className={`contents md:hover:[&>div]:bg-stone-50 ${isResolved ? "[&>div]:opacity-60" : ""}`}
                 >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span
-                        className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded ${
-                          feedback.rating === "good"
-                            ? "bg-green-100 text-green-700"
-                            : feedback.rating === "idea"
-                              ? "bg-amber-100 text-amber-700"
-                              : "bg-red-100 text-red-700"
-                        }`}
-                      >
-                        {feedback.rating === "good" ? (
-                          <>
-                            <HandThumbUpIcon className="w-3.5 h-3.5" />
-                            Good
-                          </>
-                        ) : feedback.rating === "idea" ? (
-                          <>
-                            <LightBulbIcon className="w-3.5 h-3.5" />
-                            Idea
-                          </>
-                        ) : (
-                          <>
-                            <HandThumbDownIcon className="w-3.5 h-3.5" />
-                            Bad
-                          </>
-                        )}
+                  <div className="col-span-full md:col-span-1 px-4 pt-3 md:py-3 md:border-b md:border-stone-100 flex flex-wrap items-center gap-2">
+                    {ratingBadge}
+                    {feedback.category && (
+                      <span className="inline-flex px-2 py-1 text-xs font-medium bg-stone-100 text-stone-600 rounded md:hidden">
+                        {FEEDBACK_CATEGORY_LABELS[
+                          feedback.category as FeedbackCategory
+                        ] || feedback.category}
                       </span>
-                      {feedback.category && (
-                        <span className="inline-flex px-2 py-1 text-xs font-medium bg-stone-100 text-stone-600 rounded">
-                          {FEEDBACK_CATEGORY_LABELS[
-                            feedback.category as FeedbackCategory
-                          ] || feedback.category}
-                        </span>
-                      )}
-                    </div>
-                    <span className="text-xs text-stone-400 whitespace-nowrap">
+                    )}
+                    <span className="text-xs text-stone-400 whitespace-nowrap ml-auto md:hidden">
                       {formatDateTime(feedback.createdAt)}
                     </span>
                   </div>
-
-                  {feedback.comment && (
-                    <p className="text-sm text-stone-700 line-clamp-3">
-                      {feedback.comment}
-                    </p>
-                  )}
-
-                  <div className="flex items-center justify-between pt-2 border-t border-stone-100">
+                  <div className="hidden md:block px-4 py-3 text-stone-600 text-xs border-b border-stone-100">
+                    {feedback.category
+                      ? FEEDBACK_CATEGORY_LABELS[
+                          feedback.category as FeedbackCategory
+                        ] || feedback.category
+                      : "-"}
+                  </div>
+                  <div className="col-span-full md:col-span-1 px-4 py-1 md:py-3 md:border-b md:border-stone-100 text-stone-700">
+                    {feedback.comment ? (
+                      <p className="line-clamp-3 md:line-clamp-none md:truncate md:max-w-md">
+                        {feedback.comment}
+                      </p>
+                    ) : (
+                      <span className="hidden md:inline text-stone-400">-</span>
+                    )}
+                  </div>
+                  <div className="hidden md:block px-4 py-3 text-stone-500 text-xs whitespace-nowrap border-b border-stone-100">
+                    {formatDateTime(feedback.createdAt)}
+                  </div>
+                  <div className="hidden md:block px-4 py-3 border-b border-stone-100">
+                    {statusButton}
+                  </div>
+                  <div className="hidden md:block px-4 py-3 border-b border-stone-100">
                     <button
                       type="button"
-                      onClick={() => {
-                        if (isResolved) {
-                          unresolveMutation.mutate(feedback.id);
-                        } else {
-                          resolveMutation.mutate(feedback.id);
-                        }
-                      }}
-                      disabled={
-                        resolveMutation.isPending || unresolveMutation.isPending
-                      }
-                      className={`inline-flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${
-                        isResolved
-                          ? "bg-teal-100 text-teal-700"
-                          : "bg-stone-100 text-stone-600"
-                      } disabled:opacity-50`}
+                      onClick={() => setSelectedFeedback(feedback)}
+                      className="text-teal-600 hover:text-teal-700 hover:underline text-sm"
                     >
-                      {isResolved ? (
-                        <>
-                          <CheckIcon className="w-3 h-3" />
-                          解決済み
-                        </>
-                      ) : (
-                        "未解決"
-                      )}
+                      詳細
                     </button>
+                  </div>
+                  <div className="col-span-full md:hidden px-4 pb-3 flex items-center justify-between pt-2 border-b border-stone-100">
+                    {statusButton}
                     <button
                       type="button"
                       onClick={() => setSelectedFeedback(feedback)}
@@ -680,18 +605,18 @@ export const FeedbackPanel = () => {
                 </div>
               );
             })}
-            <div ref={loadMoreRef} className="py-4 text-center">
-              {isFetchingNextPage && (
-                <div className="text-stone-500 text-sm">読み込み中...</div>
-              )}
-              {!hasNextPage && feedbacks.length > 0 && (
-                <div className="text-stone-400 text-sm">
-                  すべてのフィードバックを表示しました
-                </div>
-              )}
-            </div>
           </div>
-        </>
+          <div ref={loadMoreRef} className="py-4 text-center">
+            {isFetchingNextPage && (
+              <div className="text-stone-500 text-sm">読み込み中...</div>
+            )}
+            {!hasNextPage && feedbacks.length > 0 && (
+              <div className="text-stone-400 text-sm">
+                すべてのフィードバックを表示しました
+              </div>
+            )}
+          </div>
+        </div>
       )}
 
       {selectedFeedback && (

--- a/web/src/pages/dashboard/components/PersonaPanel.tsx
+++ b/web/src/pages/dashboard/components/PersonaPanel.tsx
@@ -114,133 +114,105 @@ export const PersonaPanel = () => {
           ペルソナデータがありません
         </div>
       ) : (
-        <>
-          {/* Desktop: Table View */}
-          <div className="hidden md:block bg-white rounded-xl border border-stone-200 overflow-auto max-h-[70dvh]">
-            <table className="min-w-[1000px] w-full text-sm">
-              <thead className="bg-stone-50 border-b border-stone-200 sticky top-0">
-                <tr>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-28">
-                    カテゴリ
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-32">
-                    トピック
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap">
-                    内容
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-20">
-                    感情
-                  </th>
-                  <th className="px-4 py-3 text-left font-medium text-stone-600 whitespace-nowrap w-36">
-                    会話日時
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-stone-100">
-                {personas.map((persona) => (
-                  <tr key={persona.id} className="hover:bg-stone-50">
-                    <td className="px-4 py-3">
-                      <span className="inline-flex px-2 py-1 text-xs font-medium bg-teal-50 text-teal-700 rounded">
-                        {persona.category}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-stone-600 text-xs">
-                      {persona.topic || "-"}
-                    </td>
-                    <td className="px-4 py-3 text-stone-700 whitespace-pre-wrap break-words">
-                      {persona.content}
-                    </td>
-                    <td className="px-4 py-3">
-                      {persona.sentiment && (
-                        <span
-                          className={`inline-flex px-2 py-1 text-xs font-medium rounded ${getSentimentStyle(persona.sentiment)}`}
-                        >
-                          {persona.sentiment}
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-3 text-stone-500 text-xs whitespace-nowrap">
-                      {persona.conversationEndedAt
-                        ? formatDateTime(persona.conversationEndedAt)
-                        : "-"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <div ref={loadMoreRef} className="py-4 text-center">
-              {isFetchingNextPage && (
-                <div className="text-stone-500 text-sm">読み込み中...</div>
-              )}
-              {!hasNextPage && personas.length > 0 && (
-                <div className="text-stone-400 text-sm">
-                  すべてのペルソナを表示しました
-                </div>
-              )}
+        <div className="bg-white rounded-xl border border-stone-200 overflow-auto max-h-[70dvh]">
+          <div
+            className="grid text-sm"
+            style={{
+              gridTemplateColumns:
+                "minmax(5rem, auto) minmax(5rem, auto) 1fr minmax(4rem, auto) minmax(8rem, auto)",
+            }}
+          >
+            <div className="contents hidden md:[display:contents] font-medium text-stone-600 bg-stone-50 text-xs">
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                カテゴリ
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                トピック
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                内容
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                感情
+              </div>
+              <div className="px-4 py-3 border-b border-stone-200 sticky top-0 bg-stone-50">
+                会話日時
+              </div>
             </div>
-          </div>
 
-          {/* Mobile: Card View */}
-          <div className="md:hidden space-y-3 max-h-[70dvh] overflow-auto">
             {personas.map((persona) => (
               <div
                 key={persona.id}
-                className="bg-white rounded-xl border border-stone-200 p-4 space-y-3"
+                className="contents md:[&>div]:border-b md:[&>div]:border-stone-100 md:hover:[&>div]:bg-stone-50"
               >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex flex-wrap gap-2">
-                    <span className="inline-flex px-2 py-1 text-xs font-medium bg-teal-50 text-teal-700 rounded">
-                      {persona.category}
+                <div className="col-span-full md:col-span-1 px-4 pt-3 md:py-3 flex flex-wrap items-center gap-2">
+                  <span className="inline-flex px-2 py-1 text-xs font-medium bg-teal-50 text-teal-700 rounded">
+                    {persona.category}
+                  </span>
+                  {persona.sentiment && (
+                    <span
+                      className={`inline-flex px-2 py-1 text-xs font-medium rounded md:hidden ${getSentimentStyle(persona.sentiment)}`}
+                    >
+                      {persona.sentiment}
                     </span>
-                    {persona.sentiment && (
-                      <span
-                        className={`inline-flex px-2 py-1 text-xs font-medium rounded ${getSentimentStyle(persona.sentiment)}`}
-                      >
-                        {persona.sentiment}
-                      </span>
-                    )}
-                  </div>
-                  <span className="text-xs text-stone-400 whitespace-nowrap">
+                  )}
+                  <span className="text-xs text-stone-400 whitespace-nowrap md:hidden ml-auto">
                     {persona.conversationEndedAt
                       ? formatDateTime(persona.conversationEndedAt)
                       : "-"}
                   </span>
                 </div>
-
-                {persona.topic && (
-                  <div className="text-xs text-stone-500">
-                    <span className="font-medium">トピック:</span>{" "}
-                    {persona.topic}
-                  </div>
-                )}
-
-                <p className="text-sm text-stone-700 whitespace-pre-wrap break-words">
-                  {persona.content}
-                </p>
-
-                {(persona.demographicSummary || persona.tags) && (
-                  <div className="flex flex-wrap gap-2 text-xs text-stone-500 pt-2 border-t border-stone-100">
-                    {persona.demographicSummary && (
-                      <span>属性: {persona.demographicSummary}</span>
-                    )}
-                    {persona.tags && <span>タグ: {persona.tags}</span>}
-                  </div>
-                )}
+                <div className="hidden md:block px-4 py-3 text-stone-600 text-xs">
+                  {persona.topic || "-"}
+                </div>
+                <div className="col-span-full md:col-span-1 px-4 py-1 md:py-3">
+                  {persona.topic && (
+                    <div className="text-xs text-stone-500 mb-1 md:hidden">
+                      <span className="font-medium">トピック:</span>{" "}
+                      {persona.topic}
+                    </div>
+                  )}
+                  <p className="text-stone-700 whitespace-pre-wrap break-words">
+                    {persona.content}
+                  </p>
+                  {(persona.demographicSummary || persona.tags) && (
+                    <div className="flex flex-wrap gap-2 text-xs text-stone-500 pt-1 md:hidden">
+                      {persona.demographicSummary && (
+                        <span>属性: {persona.demographicSummary}</span>
+                      )}
+                      {persona.tags && <span>タグ: {persona.tags}</span>}
+                    </div>
+                  )}
+                </div>
+                <div className="hidden md:block px-4 py-3">
+                  {persona.sentiment && (
+                    <span
+                      className={`inline-flex px-2 py-1 text-xs font-medium rounded ${getSentimentStyle(persona.sentiment)}`}
+                    >
+                      {persona.sentiment}
+                    </span>
+                  )}
+                </div>
+                <div className="hidden md:block px-4 py-3 text-stone-500 text-xs whitespace-nowrap">
+                  {persona.conversationEndedAt
+                    ? formatDateTime(persona.conversationEndedAt)
+                    : "-"}
+                </div>
+                <div className="col-span-full h-px bg-stone-100 md:hidden" />
               </div>
             ))}
-            <div ref={loadMoreRef} className="py-4 text-center">
-              {isFetchingNextPage && (
-                <div className="text-stone-500 text-sm">読み込み中...</div>
-              )}
-              {!hasNextPage && personas.length > 0 && (
-                <div className="text-stone-400 text-sm">
-                  すべてのペルソナを表示しました
-                </div>
-              )}
-            </div>
           </div>
-        </>
+          <div ref={loadMoreRef} className="py-4 text-center">
+            {isFetchingNextPage && (
+              <div className="text-stone-500 text-sm">読み込み中...</div>
+            )}
+            {!hasNextPage && personas.length > 0 && (
+              <div className="text-stone-400 text-sm">
+                すべてのペルソナを表示しました
+              </div>
+            )}
+          </div>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- ダッシュボードのペルソナ一覧・フィードバック一覧で無限スクロールが動作しない問題を修正
- デスクトップ/モバイルで別々のDOM（table + cards）を持つ構造を、CSS gridベースの単一レスポンシブレイアウトに統合
- 同一 `loadMoreRef` が複数要素にアタッチされ `IntersectionObserver` が発火しない根本原因を解消

## 原因
`useInfiniteScroll` が返す ref を、デスクトップ用とモバイル用の2箇所に `ref={loadMoreRef}` として設定していた。React の ref は1つの要素にしかアタッチできないため、後にマウントされるモバイル側（CSS `hidden`）にのみ Observer がアタッチされ、交差が検知されなかった。

## 変更内容
- `PersonaPanel.tsx` / `FeedbackPanel.tsx`: table + cards の二重構造を CSS grid + `contents` による単一レスポンシブレイアウトに置き換え
- ヘッダー行は `hidden md:[display:contents]` でデスクトップのみ表示
- 各セルは `col-span-full md:col-span-1` でモバイルではスタック、デスクトップでは横並び
- `useInfiniteScroll` は各パネル1回の呼び出しに統一

## Test plan
- [x] `pnpm lint` でエラーがないことを確認 ✅
- [x] `pnpm build` でビルドが通ることを確認 ✅
- [ ] ダッシュボードのペルソナ一覧で30件以上のデータをスクロールして追加読み込みされることを確認
- [ ] ダッシュボードのフィードバック一覧で同様に確認
- [ ] デスクトップ幅でテーブル風のグリッド表示になることを確認
- [ ] モバイル幅でカード風のスタック表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)