### PR TITLE
fix: local 環境に Queue consumer を追加

### DIFF
--- a/server/wrangler.jsonc
+++ b/server/wrangler.jsonc
@@ -44,6 +44,15 @@
           "remote": true
         }
       ],
+      "queues": {
+        "consumers": [
+          {
+            "queue": "nepp-chan-knowledge-sync-local",
+            "max_batch_size": 10,
+            "max_batch_timeout": 30
+          }
+        ]
+      },
       "vars": {
         "ENVIRONMENT": "local",
         "WEB_URL": "http://localhost:5173",


### PR DESCRIPTION
## Summary

- local 環境の wrangler.jsonc に Queue consumer が未定義だったため追加
- dev/prd と同様に R2 → Vectorize の自動同期が動くようにする