### PR TITLE
fix: LINE応答でMarkdown記法を使わないよう修正

### DIFF
--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -135,6 +135,7 @@ const getTools = (channel: "web" | "line") => {
 const lineInstructions = `
 ## LINE チャットの制約
 - LINEのチャットに適した長さ（目安: 500文字以内）で簡潔に回答する
+- LINEはMarkdownを表示できない。**太字**、# 見出し、- リスト、\`コード\`などのMarkdown記法は一切使わず、プレーンテキストのみで回答する
 `;
 
 interface Props


### PR DESCRIPTION
## Summary
- LINE チャネルでの応答にMarkdown記法（**太字**、# 見出し、- リスト、`コード`等）が含まれないよう、エージェントのシステムプロンプトに制約を追加
- Web チャネル側は変更なし

## Test plan
- [ ] LINE チャネルでメッセージを送信し、応答にMarkdown記法が含まれないことを確認
- [ ] Web チャネルで従来通りMarkdownが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)