### PR TITLE
feat: LINE応答からMarkdown記法を除去する後処理を追加

### DIFF
--- a/server/src/__tests__/strip-markdown.test.ts
+++ b/server/src/__tests__/strip-markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripMarkdown } from "~/routes/line";
+import { stripMarkdown } from "~/lib/strip-markdown";
 
 describe("stripMarkdown", () => {
   it("太字を除去する", () => {

--- a/server/src/lib/strip-markdown.ts
+++ b/server/src/lib/strip-markdown.ts
@@ -1,0 +1,23 @@
+export const stripMarkdown = (text: string): string =>
+  text
+    // コードブロック: ```lang\n...\n``` → 中身のみ
+    .replace(/```[\s\S]*?\n([\s\S]*?)```/g, "$1")
+    // インラインコード: `code` → code
+    .replace(/`([^`]+)`/g, "$1")
+    // リンク: [text](url) → text url
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 $2")
+    // 太字+斜体: ***text*** → text
+    .replace(/\*{3}(.+?)\*{3}/g, "$1")
+    // 太字: **text** → text
+    .replace(/\*{2}(.+?)\*{2}/g, "$1")
+    // 斜体: *text* → text（行頭リスト記号は除外）
+    .replace(/(?<!\n|A)\*(?!\s)(.+?)(?<!\s)\*/g, "$1")
+    // 見出し: # text → text
+    .replace(/^#{1,6}\s+/gm, "")
+    // リスト記号: * や - → ・
+    .replace(/^[\t ]*[*-]\s+/gm, "・")
+    // 水平線: --- 等 → 空行
+    .replace(/^[-*_]{3,}$/gm, "")
+    // 連続空行を1つに
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -4,6 +4,7 @@ import { messagingApi } from "@line/bot-sdk";
 import { Mastra } from "@mastra/core/mastra";
 
 import { getStorage } from "~/lib/storage";
+import { stripMarkdown } from "~/lib/strip-markdown";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
 import { createRequestContext } from "~/mastra/request-context";
 import { lineSignatureVerify } from "~/middleware";
@@ -126,30 +127,6 @@ const extractReplyTexts = (steps: Array<{ text: string }>): string[] => {
 
   return messages.slice(0, LINE_MAX_MESSAGES);
 };
-
-export const stripMarkdown = (text: string): string =>
-  text
-    // コードブロック: ```lang\n...\n``` → 中身のみ
-    .replace(/```[\s\S]*?\n([\s\S]*?)```/g, "$1")
-    // インラインコード: `code` → code
-    .replace(/`([^`]+)`/g, "$1")
-    // リンク: [text](url) → text url
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 $2")
-    // 太字+斜体: ***text*** → text
-    .replace(/\*{3}(.+?)\*{3}/g, "$1")
-    // 太字: **text** → text
-    .replace(/\*{2}(.+?)\*{2}/g, "$1")
-    // 斜体: *text* → text（行頭リスト記号は除外）
-    .replace(/(?<!\n|A)\*(?!\s)(.+?)(?<!\s)\*/g, "$1")
-    // 見出し: # text → text
-    .replace(/^#{1,6}\s+/gm, "")
-    // リスト記号: * や - → ・
-    .replace(/^[\t ]*[*-]\s+/gm, "・")
-    // 水平線: --- 等 → 空行
-    .replace(/^[-*_]{3,}$/gm, "")
-    // 連続空行を1つに
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
 
 const splitMessage = (text: string): string[] => {
   if (text.length <= LINE_MAX_CHARS) return [text];


### PR DESCRIPTION
## Summary
- `stripMarkdown` 関数を `lib/strip-markdown.ts` に追加し、LINE応答テキストからMarkdown記法を機械的に除去する後処理を実装
- 太字、見出し、リスト記号、コードブロック、リンク等を対応するプレーンテキストに変換
- #236（プロンプト指示）+ #237（指示強化）に加え、後処理による確実な除去を実現

## Test plan
- [x] `stripMarkdown` の単体テスト（11ケース）通過
- [ ] LINE チャネルで応答にMarkdown記法が含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)