### PR TITLE
feat: LINE チャネルに googleSearch を直接ツールとして追加

### DIFF
--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -1,3 +1,4 @@
+import { google } from "@ai-sdk/google";
 import type { AgentConfig } from "@mastra/core/agent";
 import { Agent } from "@mastra/core/agent";
 import { getCurrentDateInfo } from "~/lib/date";
@@ -104,16 +105,15 @@ const adminInstructions = `
 - デモグラフィック分析（例: 「年代別の傾向は？」「属性別に分析して」）→ personaAnalystAgent
 `;
 
-const baseAgents = {
-  emergencyReporterAgent,
-  webResearcherAgent,
-};
-
-const adminAgents = {
-  ...baseAgents,
-  emergencyAgent,
-  feedbackAgent,
-  personaAnalystAgent,
+const getAgents = (channel: "web" | "line", isAdmin: boolean) => {
+  if (channel === "line") {
+    const base = { emergencyReporterAgent };
+    if (!isAdmin) return base;
+    return { ...base, emergencyAgent, feedbackAgent, personaAnalystAgent };
+  }
+  const base = { emergencyReporterAgent, webResearcherAgent };
+  if (!isAdmin) return base;
+  return { ...base, emergencyAgent, feedbackAgent, personaAnalystAgent };
 };
 
 const defaultTools = {
@@ -128,7 +128,9 @@ const webTools = {
 };
 
 const getTools = (channel: "web" | "line") => {
-  if (channel === "line") return defaultTools;
+  if (channel === "line") {
+    return { ...defaultTools, googleSearch: google.tools.googleSearch({}) };
+  }
   return { ...defaultTools, ...webTools };
 };
 
@@ -155,6 +157,13 @@ const lineInstructions = `
   × \`コード\` → ○ そのまま書く
   × [リンク](URL) → ○ URLをそのまま貼る
 - 箇条書きには「・」を使い、装飾なしで読みやすく整形する
+
+### 検索ルールの上書き
+ステップ3で「webResearcherAgent に委譲」と書かれている箇所は、LINE では googleSearch ツールで直接検索する。
+- 村の情報・事実確認 → まず knowledgeSearchTool → 不十分なら googleSearch で検索
+- 最新情報・天気・一般的な質問 → googleSearch で検索
+- 検索結果の情報源（URL）があれば明記する。関連するURLだけを厳選し、重複は1つにまとめる
+- URLは検索結果から得たもののみ使用し、推測や捏造は絶対にしない
 `;
 
 interface Props
@@ -168,7 +177,7 @@ export const createNeppChanAgent = ({
   channel = "web",
   ...agentOptions
 }: Props = {}) => {
-  const agents = isAdmin ? adminAgents : baseAgents;
+  const agents = getAgents(channel, isAdmin);
   const tools = getTools(channel);
 
   // instructionsを関数化（リクエスト時に評価され、現在日時が動的に取得される）


### PR DESCRIPTION
## Summary
- LINE チャネルで `webResearcherAgent` への委譲（LLM 3往復）を `googleSearch` ツール直接呼び出し（LLM 2往復）に置き換え、reply token 有効期限内での応答完了率を向上
- `baseAgents` / `adminAgents` 定数を `getAgents(channel, isAdmin)` 関数に統合し、LINE では `webResearcherAgent` を除外
- `lineInstructions` に検索ルール上書きセクションを追加

## Test plan
- [x] `pnpm lint` — 型チェック・lint 通過
- [x] `pnpm test` — 全 256 テスト通過
- [x] Web ビルド成功確認
- [ ] LINE チャネルで検索を含む質問に reply token 内で応答できることを確認
- [ ] Web チャネルで従来通り webResearcherAgent が使われることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)