### PR TITLE
fix: LINE webhook の waitUntil タイムアウトによる無応答を修正

### DIFF
--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -26,7 +26,7 @@ lineRoutes.post("/webhook", async (c) => {
     return c.json({ status: "ok" });
   }
 
-  c.executionCtx.waitUntil(handleLineEvents(body.events, c.env));
+  await handleLineEvents(body.events, c.env);
 
   return c.json({ status: "ok" });
 });
@@ -63,11 +63,9 @@ const handleLineEvents = async (
         type: "text" as const,
         text,
       }));
-      try {
-        await client.replyMessage({ replyToken: event.replyToken, messages });
-      } catch {
-        await client.pushMessage({ to: userId, messages });
-      }
+      await client
+        .replyMessage({ replyToken: event.replyToken, messages })
+        .catch(() => client.pushMessage({ to: userId, messages }));
     } catch (error) {
       console.error(`LINE reply failed for user ${userId}:`, error);
     }


### PR DESCRIPTION
## Summary
- `waitUntil()` の30秒制限によりAI生成完了前にWorkerがキャンセルされ、LINE返信が届かない問題を修正
- `waitUntil` を `await` に変更し、処理完了後にレスポンスを返す方式に変更
- reply失敗時のpushフォールバックをネストしたtry-catchから `.catch()` チェーンに簡略化

## Test plan
- [ ] dev環境にデプロイしてLINEで長時間応答のメッセージを送信し、返信が届くことを確認
- [ ] LINEのWebhookリトライが発生しないことを確認
- [ ] replyToken切れの場合にpushMessageで返信が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)