### PR TITLE
refactor: LINE イベントハンドラーの責務を分離

### DIFF
--- a/server/src/__tests__/line-messaging.test.ts
+++ b/server/src/__tests__/line-messaging.test.ts
@@ -1,0 +1,55 @@
+import type { messagingApi } from "@line/bot-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sendLineMessages } from "~/services/line-messaging";
+
+describe("sendLineMessages", () => {
+  const mockReplyMessage = vi.fn();
+  const mockPushMessage = vi.fn();
+  const client = {
+    replyMessage: mockReplyMessage,
+    pushMessage: mockPushMessage,
+  } as unknown as messagingApi.MessagingApiClient;
+
+  const baseParams = {
+    client,
+    replyToken: "token-123",
+    userId: "user-456",
+    texts: ["こんにちは", "元気？"],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("replyMessage で送信成功した場合は pushMessage を呼ばない", async () => {
+    mockReplyMessage.mockResolvedValue({});
+
+    await sendLineMessages(baseParams);
+
+    expect(mockReplyMessage).toHaveBeenCalledWith({
+      replyToken: "token-123",
+      messages: [
+        { type: "text", text: "こんにちは" },
+        { type: "text", text: "元気？" },
+      ],
+    });
+    expect(mockPushMessage).not.toHaveBeenCalled();
+  });
+
+  it("replyMessage 失敗時に pushMessage へフォールバックする", async () => {
+    mockReplyMessage.mockRejectedValue(new Error("reply failed"));
+    mockPushMessage.mockResolvedValue({});
+
+    await sendLineMessages(baseParams);
+
+    expect(mockReplyMessage).toHaveBeenCalled();
+    expect(mockPushMessage).toHaveBeenCalledWith({
+      to: "user-456",
+      messages: [
+        { type: "text", text: "こんにちは" },
+        { type: "text", text: "元気？" },
+      ],
+    });
+  });
+});

--- a/server/src/__tests__/split-message.test.ts
+++ b/server/src/__tests__/split-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { splitMessagesForLine } from "~/lib/split-message";
+
+describe("splitMessagesForLine", () => {
+  it("空配列を渡すと空配列を返す", () => {
+    expect(splitMessagesForLine([])).toEqual([]);
+  });
+
+  it("空文字列やスペースのみのテキストをスキップする", () => {
+    expect(splitMessagesForLine(["", "  ", "hello"])).toEqual(["hello"]);
+  });
+
+  it("5000文字以下のテキストはそのまま返す", () => {
+    expect(splitMessagesForLine(["こんにちは"])).toEqual(["こんにちは"]);
+  });
+
+  it("5000文字を超えるテキストを分割する", () => {
+    const longText = "a".repeat(12000);
+    const result = splitMessagesForLine([longText]);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toHaveLength(5000);
+    expect(result[1]).toHaveLength(5000);
+    expect(result[2]).toHaveLength(2000);
+  });
+
+  it("最大5メッセージに制限する", () => {
+    const texts = Array.from({ length: 10 }, (_, i) => `msg${i}`);
+    const result = splitMessagesForLine(texts);
+
+    expect(result).toHaveLength(5);
+  });
+
+  it("長文の分割でも最大5メッセージに制限する", () => {
+    const longText = "a".repeat(30000);
+    const result = splitMessagesForLine([longText]);
+
+    expect(result).toHaveLength(5);
+  });
+
+  it("複数テキストの合計が5メッセージを超える場合に切り捨てる", () => {
+    const texts = [
+      "a".repeat(6000), // → 2メッセージ
+      "b".repeat(6000), // → 2メッセージ
+      "c".repeat(6000), // → 1メッセージ（5に到達）
+    ];
+    const result = splitMessagesForLine(texts);
+
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe("a".repeat(5000));
+    expect(result[1]).toBe("a".repeat(1000));
+    expect(result[2]).toBe("b".repeat(5000));
+    expect(result[3]).toBe("b".repeat(1000));
+    expect(result[4]).toBe("c".repeat(5000));
+  });
+
+  it("単一テキストの分割（splitMessage 相当）が正しく動作する", () => {
+    const text = "hello world";
+    expect(splitMessagesForLine([text])).toEqual(["hello world"]);
+  });
+});

--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -1,27 +1,15 @@
-import { messagingApi } from "@line/bot-sdk";
-import { Mastra } from "@mastra/core/mastra";
-
-import { getStorage } from "~/lib/storage";
-import { stripMarkdown } from "~/lib/strip-markdown";
-import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
-import { createRequestContext } from "~/mastra/request-context";
-
-const LINE_MAX_MESSAGES = 5;
-const LINE_MAX_CHARS = 5000;
-
-export type LineEventMessage = {
-  userId: string;
-  userMessage: string;
-  replyToken: string;
-};
+import type { LineEventMessage } from "~/schemas/line-schema";
+import {
+  createLineClient,
+  generateReply,
+  sendLineMessages,
+} from "~/services/line-messaging";
 
 export const handleLineEvent = async (
   batch: MessageBatch<LineEventMessage>,
   env: CloudflareBindings,
 ) => {
-  const client = new messagingApi.MessagingApiClient({
-    channelAccessToken: env.LINE_CHANNEL_ACCESS_TOKEN,
-  });
+  const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
 
   for (const message of batch.messages) {
     const { userId, userMessage, replyToken } = message.body;
@@ -35,17 +23,12 @@ export const handleLineEvent = async (
       });
 
       if (replyTexts.length > 0) {
-        const messages = replyTexts.map((text) => ({
-          type: "text" as const,
-          text,
-        }));
-        await client
-          .replyMessage({ replyToken, messages })
-          .then(() => console.log(`LINE replyMessage sent to ${userId}`))
-          .catch(async () => {
-            await client.pushMessage({ to: userId, messages });
-            console.log(`LINE pushMessage sent to ${userId}`);
-          });
+        await sendLineMessages({
+          client,
+          replyToken,
+          userId,
+          texts: replyTexts,
+        });
       }
 
       message.ack();
@@ -54,76 +37,4 @@ export const handleLineEvent = async (
       message.retry();
     }
   }
-};
-
-const generateReply = async (params: {
-  userMessage: string;
-  resourceId: string;
-  threadId: string;
-  env: CloudflareBindings;
-}): Promise<string[]> => {
-  const storage = await getStorage(params.env.DB);
-
-  const requestContext = createRequestContext({
-    storage,
-    db: params.env.DB,
-    env: params.env,
-  });
-
-  const neppChanAgent = createNeppChanAgent({ channel: "line" });
-  const mastra = new Mastra({
-    agents: { neppChanAgent },
-    storage,
-  });
-  const agent = mastra.getAgent("neppChanAgent");
-
-  const response = await agent.generate(params.userMessage, {
-    requestContext,
-    memory: {
-      resource: params.resourceId,
-      thread: params.threadId,
-    },
-  });
-
-  const texts = extractReplyTexts(response.steps ?? []);
-
-  if (texts.length === 0 && response.text) {
-    return splitMessage(response.text).map(stripMarkdown);
-  }
-
-  return texts.map(stripMarkdown);
-};
-
-const extractReplyTexts = (steps: Array<{ text: string }>): string[] => {
-  const messages: string[] = [];
-
-  for (const step of steps) {
-    if (!step.text || step.text.trim().length === 0) continue;
-
-    if (step.text.length <= LINE_MAX_CHARS) {
-      messages.push(step.text);
-    } else {
-      for (let i = 0; i < step.text.length; i += LINE_MAX_CHARS) {
-        messages.push(step.text.slice(i, i + LINE_MAX_CHARS));
-        if (messages.length >= LINE_MAX_MESSAGES) break;
-      }
-    }
-
-    if (messages.length >= LINE_MAX_MESSAGES) break;
-  }
-
-  return messages.slice(0, LINE_MAX_MESSAGES);
-};
-
-const splitMessage = (text: string): string[] => {
-  if (text.length <= LINE_MAX_CHARS) return [text];
-  const messages: string[] = [];
-  for (
-    let i = 0;
-    i < text.length && messages.length < LINE_MAX_MESSAGES;
-    i += LINE_MAX_CHARS
-  ) {
-    messages.push(text.slice(i, i + LINE_MAX_CHARS));
-  }
-  return messages;
 };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,6 @@
 import { swaggerUI } from "@hono/swagger-ui";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { handleLineEvent, handleR2Event } from "~/handlers";
-import type { LineEventMessage } from "~/handlers/line-event-handler";
 import { handlePersonaExtract } from "~/handlers/persona-extract-handler";
 import type { R2EventMessage } from "~/handlers/r2-event-handler";
 import { corsMiddleware, errorHandler, securityHeaders } from "~/middleware";
@@ -18,6 +17,7 @@ import {
   personaAdminRoutes,
   threadsRoutes,
 } from "~/routes";
+import type { LineEventMessage } from "~/schemas/line-schema";
 
 const app = new OpenAPIHono<{ Bindings: CloudflareBindings }>();
 

--- a/server/src/lib/split-message.ts
+++ b/server/src/lib/split-message.ts
@@ -1,0 +1,23 @@
+const LINE_MAX_MESSAGES = 5;
+const LINE_MAX_CHARS = 5000;
+
+export const splitMessagesForLine = (texts: string[]): string[] => {
+  const messages: string[] = [];
+
+  for (const text of texts) {
+    if (!text || text.trim().length === 0) continue;
+
+    if (text.length <= LINE_MAX_CHARS) {
+      messages.push(text);
+    } else {
+      for (let i = 0; i < text.length; i += LINE_MAX_CHARS) {
+        messages.push(text.slice(i, i + LINE_MAX_CHARS));
+        if (messages.length >= LINE_MAX_MESSAGES) break;
+      }
+    }
+
+    if (messages.length >= LINE_MAX_MESSAGES) break;
+  }
+
+  return messages.slice(0, LINE_MAX_MESSAGES);
+};

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -1,8 +1,8 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import type { WebhookEvent, WebhookRequestBody } from "@line/bot-sdk";
 
-import type { LineEventMessage } from "~/handlers/line-event-handler";
 import { lineSignatureVerify } from "~/middleware";
+import type { LineEventMessage } from "~/schemas/line-schema";
 
 export const lineRoutes = new OpenAPIHono<{
   Bindings: CloudflareBindings;

--- a/server/src/schemas/line-schema.ts
+++ b/server/src/schemas/line-schema.ts
@@ -1,0 +1,5 @@
+export type LineEventMessage = {
+  userId: string;
+  userMessage: string;
+  replyToken: string;
+};

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -1,0 +1,77 @@
+import { messagingApi } from "@line/bot-sdk";
+import { Mastra } from "@mastra/core/mastra";
+
+import { splitMessagesForLine } from "~/lib/split-message";
+import { getStorage } from "~/lib/storage";
+import { stripMarkdown } from "~/lib/strip-markdown";
+import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
+import { createRequestContext } from "~/mastra/request-context";
+
+export const createLineClient = (token: string) =>
+  new messagingApi.MessagingApiClient({ channelAccessToken: token });
+
+export const generateReply = async (params: {
+  userMessage: string;
+  resourceId: string;
+  threadId: string;
+  env: CloudflareBindings;
+}): Promise<string[]> => {
+  const storage = await getStorage(params.env.DB);
+
+  const requestContext = createRequestContext({
+    storage,
+    db: params.env.DB,
+    env: params.env,
+  });
+
+  const neppChanAgent = createNeppChanAgent({ channel: "line" });
+  const mastra = new Mastra({
+    agents: { neppChanAgent },
+    storage,
+  });
+  const agent = mastra.getAgent("neppChanAgent");
+
+  const response = await agent.generate(params.userMessage, {
+    requestContext,
+    memory: {
+      resource: params.resourceId,
+      thread: params.threadId,
+    },
+  });
+
+  const stepTexts = (response.steps ?? []).map((step) => step.text);
+  const texts = splitMessagesForLine(stepTexts);
+
+  if (texts.length === 0 && response.text) {
+    return splitMessagesForLine([response.text]).map(stripMarkdown);
+  }
+
+  return texts.map(stripMarkdown);
+};
+
+export const sendLineMessages = async (params: {
+  client: messagingApi.MessagingApiClient;
+  replyToken: string;
+  userId: string;
+  texts: string[];
+}) => {
+  const messages = params.texts.map((text) => ({
+    type: "text" as const,
+    text,
+  }));
+
+  try {
+    await params.client.replyMessage({
+      replyToken: params.replyToken,
+      messages,
+    });
+    console.log(`LINE replyMessage sent to ${params.userId}`);
+  } catch (replyError) {
+    console.log(
+      `LINE replyMessage failed for ${params.userId}, falling back to pushMessage:`,
+      replyError,
+    );
+    await params.client.pushMessage({ to: params.userId, messages });
+    console.log(`LINE pushMessage sent to ${params.userId}`);
+  }
+};


### PR DESCRIPTION
## Summary

- `line-event-handler.ts`（129行）に混在していた責務をプロジェクトの既存パターンに合わせて分離
- `schemas/line-schema.ts`: `LineEventMessage` 型を `schemas/` に移動
- `lib/split-message.ts`: `extractReplyTexts` と `splitMessage` の重複ロジックを `splitMessagesForLine` に統合
- `services/line-messaging.ts`: AI 返信生成（`generateReply`）+ LINE 送信（`sendLineMessages`）+ クライアント生成（`createLineClient`）を抽出
- `handlers/line-event-handler.ts`: キュー制御のみに簡素化（129行 → 35行）
- replyMessage 失敗時のフォールバック理由をログ出力するよう改善

## Test plan

- [x] `split-message.test.ts`: 空配列、空文字列スキップ、長文分割、最大5件制限など8ケース
- [x] `line-messaging.test.ts`: replyMessage 成功/失敗時のフォールバック動作2ケース
- [x] 全266テスト通過
- [x] lint（Biome + tsc）通過
- [x] wrangler dry-run ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)