### PR TITLE
fix: Vectorize vector ID を UUID に変更して64バイト制限を回避

### DIFF
--- a/server/src/services/knowledge/embedding.ts
+++ b/server/src/services/knowledge/embedding.ts
@@ -141,7 +141,7 @@ export const processKnowledgeFile = async (
 
     // 3. ベクトルデータの作成
     const vectors: VectorData[] = texts.map((_, i) => ({
-      id: `${filename}-${i}`,
+      id: crypto.randomUUID(),
       values: embeddings[i],
       metadata: metadata[i],
     }));


### PR DESCRIPTION
## Summary
- ナレッジ同期時の Vectorize vector ID を `${filename}-${index}` から `crypto.randomUUID()` に変更
- ファイルパスが長い場合に Vectorize の 64 バイト ID 制限（`VECTOR_UPSERT_ERROR code=40008`）でエラーになる問題を修正
- 削除は `metadata.source` でフィルタしているため、ID 形式変更の影響なし

## Test plan
- [ ] ナレッジファイルを R2 にアップロードし、Queue 経由の sync が成功することを確認
- [ ] 長いパスのファイル（例: `villotoinep/kakuka/chiikishinkou/oshirase/asahikawa-mokkougei.md`）で ID 制限エラーが出ないことを確認
- [ ] `/admin/knowledge/sync` からの全同期が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)