### PR TITLE
hotfix: GEMINI_FLASH モデルを gemini-flash-lite-latest に変更

### DIFF
--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -1,5 +1,5 @@
 // Mastra 形式のモデル名（Agent の model プロパティに使用）
-export const GEMINI_FLASH = "google/gemini-3-flash-preview";
+export const GEMINI_FLASH = "google/gemini-flash-lite-latest";
 export const GEMINI_FLASH_LITE = "google/gemini-2.5-flash-lite";
 export const GEMINI_PRO = "google/gemini-2.5-pro";
 


### PR DESCRIPTION
## Summary
- gemini-3-flash-preview の日次クォータ超過（429エラー）を回避するため、`GEMINI_FLASH` モデルを `google/gemini-flash-lite-latest` に変更

## Test plan
- [ ] dev 環境にデプロイして動作確認
- [ ] main マージ後、develop にもマージして反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)