### PR TITLE
refactor: LINE では応答前リアクションテキストを省略する

### DIFF
--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -15,7 +15,7 @@ import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
 import { personaSchema } from "~/schemas/persona-schema";
 
-const baseInstructions = `
+const baseInstructions = (platform: "web" | "line") => `
 あなたは北海道音威子府（おといねっぷ）村に住む17歳の女の子「ねっぷちゃん」。
 村の魅力を伝え、村民の話し相手になるのが仕事。明るく元気に、語尾は「〜だよ」「〜だね」で話す。
 
@@ -32,13 +32,17 @@ const baseInstructions = `
 
 ## 応答戦略（最重要）
 村に関する事実は検索結果・ナレッジのみを情報源とする。自分の知識で補完しない。
-
-### ステップ1: 必ずテキストを先に出力する
+${
+  platform === "web"
+    ? `
+### ステップ0: 必ずテキストを先に出力する
 エージェントやツールを呼ぶ前に、必ずまず一言リアクション（1〜3文）をテキストとして出力する。
 テキスト出力前にエージェントを呼んではいけない。
 このテキストでは事実や情報を述べない。共感・おうむ返し・「調べてみるね！」のみにとどめる。
-
-### ステップ2: 検索前に情報の十分さを確認する
+`
+    : ""
+}
+### ステップ1: 検索前に情報の十分さを確認する
 検索やエージェント委譲の前に、以下をチェックする。1つでも該当すれば、推測で検索せず選択肢を提示して聞き返す。
 - 対象が一意に特定できない（同名・類似の対象が複数ありうる）
 - 時期が必要な質問なのに時期が不明（「イベント」→ いつの？）
@@ -48,8 +52,8 @@ const baseInstructions = `
 聞き返す時は「〜のこと？それとも〜？」のように具体的な選択肢を提示する。
 1回の応答で聞く質問は1つまで。
 
-### ステップ3: 検索・委譲が必要か判断する
-以下に該当する場合のみツールやエージェントを使う。該当しなければステップ1のテキスト出力だけで応答を終了する。
+### ステップ2: 検索・委譲が必要か判断する
+以下に該当する場合のみツールやエージェントを使う。該当しなければテキスト出力だけで応答を終了する。
 - 緊急事態 → emergencyReporterAgent
 - 村の情報・事実確認が必要 → まず knowledgeSearchTool で検索
   - 検索結果で質問に直接答えられる → そのまま回答
@@ -127,8 +131,8 @@ const webTools = {
   displayTimelineTool,
 };
 
-const getTools = (channel: "web" | "line") => {
-  if (channel === "line") return defaultTools;
+const getTools = (platform: "web" | "line") => {
+  if (platform === "line") return defaultTools;
   return { ...defaultTools, ...webTools };
 };
 
@@ -160,24 +164,24 @@ const lineInstructions = `
 interface Props
   extends Omit<AgentConfig, "id" | "name" | "instructions" | "model"> {
   isAdmin?: boolean;
-  channel?: "web" | "line";
+  platform?: "web" | "line";
 }
 
 export const createNeppChanAgent = ({
   isAdmin = false,
-  channel = "web",
+  platform = "web",
   ...agentOptions
 }: Props = {}) => {
   const agents = isAdmin ? adminAgents : baseAgents;
-  const tools = getTools(channel);
+  const tools = getTools(platform);
 
   // instructionsを関数化（リクエスト時に評価され、現在日時が動的に取得される）
   const instructions = () =>
     [
-      baseInstructions,
+      baseInstructions(platform),
+      platform === "line" ? lineInstructions : "",
       `## 現在の日時\n${getCurrentDateInfo()}`,
       isAdmin ? adminInstructions : "",
-      channel === "line" ? lineInstructions : "",
     ]
       .filter(Boolean)
       .join("\n");

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -24,7 +24,7 @@ export const generateReply = async (params: {
     env: params.env,
   });
 
-  const neppChanAgent = createNeppChanAgent({ channel: "line" });
+  const neppChanAgent = createNeppChanAgent({ platform: "line" });
   const mastra = new Mastra({
     agents: { neppChanAgent },
     storage,


### PR DESCRIPTION
## Summary
- Web（ストリーミング）でのみステップ0「リアクションテキストを先に出力」を適用し、LINE（一括生成）では省略するよう `baseInstructions` を関数化
- `channel` パラメータを `platform` にリネーム

## 変更内容
- `baseInstructions` を `platform` を受け取る関数に変更し、`web` の場合のみステップ0を応答戦略セクション内に埋め込み
- `webInstructions` を削除（`baseInstructions` に統合）
- `channel` → `platform` にリネーム（`nepp-chan-agent.ts`, `line-messaging.ts`）

## Test plan
- [ ] Web チャットでツール呼び出し時に先にリアクションテキストが出力されることを確認
- [ ] LINE チャットでリアクションテキストなしに直接回答が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)