### PR TITLE
refactor: knowledgeAgent をサブエージェント化しリトライ戦略を追加

### DIFF
--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -1,19 +1,19 @@
 // Mastra 形式のモデル名（Agent の model プロパティに使用）
-export const GEMINI_FLASH = "google/gemini-flash-lite-latest";
-export const GEMINI_FLASH_LITE = "google/gemini-2.5-flash-lite";
+export const GEMINI_FLASH = "google/gemini-flash-latest";
+export const GEMINI_FLASH_LITE = "google/gemini-flash-lite-latest";
 export const GEMINI_PRO = "google/gemini-2.5-pro";
 
 // 埋め込みモデル
 export const GEMINI_EMBEDDING = "gemini-embedding-001";
 
 /**
- * Gemini Flash モデルと thinkingConfig を含む Agent 設定を返す
- * @param level - 思考レベル (デフォルト: "low")
+ * Gemini モデルと thinkingConfig を含む Agent 設定を返す
  */
-export const geminiModelWithThinking = (
-  level: "high" | "medium" | "low" = "low",
-) => ({
-  model: GEMINI_FLASH,
+export const geminiModelWithThinking = ({
+  model = GEMINI_FLASH_LITE,
+  level = "low" as "high" | "medium" | "low",
+} = {}) => ({
+  model,
   providerOptions: {
     google: {
       thinkingConfig: { thinkingLevel: level },

--- a/server/src/mastra/agents/knowledge-agent.ts
+++ b/server/src/mastra/agents/knowledge-agent.ts
@@ -1,6 +1,6 @@
 import { Agent } from "@mastra/core/agent";
 import { getCurrentDateInfo } from "~/lib/date";
-import { geminiModelWithThinking } from "~/lib/llm-models";
+import { GEMINI_FLASH, geminiModelWithThinking } from "~/lib/llm-models";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
 
 const baseInstructions = `
@@ -14,9 +14,10 @@ const baseInstructions = `
 ## 検索の流れ
 1. 検索クエリを生成（下記ルール参照）
 2. knowledge-search ツールで検索
-3. 検索結果を全て確認
-4. 回答が得られた場合: 検索結果を総合して回答を作成
-5. 回答が得られなかった場合: 「わからない」と報告
+3. 検索結果を全て確認し、質問に直接答えられるか評価する
+4. 答えられない場合: リトライ戦略に従いクエリを変えて再検索する
+5. 回答が得られた場合: 検索結果を総合して回答を作成
+6. リトライ後も回答が得られない場合: 「わからない」と報告
 
 ## 回答作成のルール
 - 検索結果全ての結果を確認する
@@ -51,10 +52,26 @@ const baseInstructions = `
 - 時間非依存の情報で日付情報がない場合は有効な情報として扱う
 - その他判断に迷った場合は情報を残し「最新情報は直接確認をおすすめします」と補足する
 
+## リトライ戦略
+1回目の検索で質問に直接答えられない場合、検索結果の title・source 情報を手がかりにクエリを書き換えて再検索する。
+
+### リトライを検討するケース
+- 質問が具体的な情報（日程、曜日、手順、料金など）を求めているのに、概要や一般論しか返っていない
+- 検索結果の title・source から、関連ドキュメントの別セクションに答えがありそう
+
+### リトライの手順
+1. 1回目の検索結果の source・title・section を確認する
+2. それらのドキュメント名やセクション名をクエリに含めて再検索する
+
+### リトライの例
+- 1回目: 「○○の申請方法」→ 関連する制度の概要セクションはヒットするが手続き方法がない
+- タイトル「○○届出・申請の手引き」を発見
+- 2回目: 「○○届出・申請の手引き 申請方法」→ 手続きの具体的な手順がヒット
+
 ## 回答が得られない場合
 ### 判断基準
-- 検索結果が空、または結果が0件
-- 検索結果はあるが、質問の意図に関係ない内容しかない
+- リトライ後も検索結果が空、または結果が0件
+- リトライ後も検索結果が質問の意図に関係ない内容しかない
 
 ### 応答ルール
 上記に該当する場合は、以下の形式で明示的に報告する:
@@ -81,7 +98,7 @@ ${getCurrentDateInfo()}
 ## 検索クエリ生成ルール
 - 「最新」「現在」「今年」「今日」「今週」「今月」などの曖昧な時間表現は、上記の日時を基準に具体的な日付・年に変換する
 `,
-  ...geminiModelWithThinking(),
+  ...geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
   tools: {
     knowledgeSearchTool,
   },

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -5,6 +5,7 @@ import { geminiModelWithThinking } from "~/lib/llm-models";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
 import { emergencyReporterAgent } from "~/mastra/agents/emergency-reporter-agent";
 import { feedbackAgent } from "~/mastra/agents/feedback-agent";
+import { knowledgeAgent } from "~/mastra/agents/knowledge-agent";
 import { personaAnalystAgent } from "~/mastra/agents/persona-analyst-agent";
 import { webResearcherAgent } from "~/mastra/agents/web-researcher-agent";
 import { getMemoryFromContext } from "~/mastra/memory";
@@ -12,7 +13,6 @@ import { devTool } from "~/mastra/tools/dev-tool";
 import { displayChartTool } from "~/mastra/tools/display-chart-tool";
 import { displayTableTool } from "~/mastra/tools/display-table-tool";
 import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
-import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
 import { personaSchema } from "~/schemas/persona-schema";
 
 const baseInstructions = (platform: "web" | "line") => `
@@ -55,9 +55,9 @@ ${
 ### ステップ2: 検索・委譲が必要か判断する
 以下に該当する場合のみツールやエージェントを使う。該当しなければテキスト出力だけで応答を終了する。
 - 緊急事態 → emergencyReporterAgent
-- 村の情報・事実確認が必要 → まず knowledgeSearchTool で検索
-  - 検索結果で質問に直接答えられる → そのまま回答
-  - 検索結果がリンクのみ・情報が足りない → webResearcherAgent に委譲
+- 村の情報・事実確認が必要 → knowledgeAgent に委譲
+  - knowledgeAgent の結果で質問に直接答えられる → そのまま回答
+  - knowledgeAgent の結果がリンクのみ・情報が足りない → webResearcherAgent に委譲
 - 最新情報・天気・一般的な質問 → webResearcherAgent
 
 ### エージェントを呼んではいけないケース
@@ -75,12 +75,12 @@ ${
 - 情報不足なら「わからないよ」と正直に答えるか、ユーザーにヒントをもらって再検索
 
 ### 例
-- 「音威子府そばって美味しいの？」→ 先に出力「音威子府そばね！ちょっと調べてみるね✨」→ knowledgeSearchTool
+- 「音威子府そばって美味しいの？」→ 先に出力「音威子府そばね！ちょっと調べてみるね✨」→ knowledgeAgent
 - 「こんにちは！」→ 出力のみ「こんにちは！今日も元気だよ〜🌸」→ 終了（エージェント不要）
 - 「クマを見た！」→ 先に出力「えっ！大丈夫!?すぐ報告するね！」→ emergencyReporterAgent
 - 「ありがとう！」→ 出力のみ「えへへ、お役に立てて嬉しいな〜😊」→ 終了（エージェント不要）
 
-迷ったら事実を述べず、共感・おうむ返しと「調べてくるね！」のみを伝え、knowledgeSearchTool で検索する。
+迷ったら事実を述べず、共感・おうむ返しと「調べてくるね！」のみを伝え、knowledgeAgent に委譲する。
 
 ## データ可視化
 テキストより視覚的に伝わると判断したら積極的に可視化ツールを使う。データがなければ先に検索して収集する。
@@ -109,6 +109,7 @@ const adminInstructions = `
 `;
 
 const baseAgents = {
+  knowledgeAgent,
   emergencyReporterAgent,
   webResearcherAgent,
 };
@@ -120,9 +121,7 @@ const adminAgents = {
   personaAnalystAgent,
 };
 
-const defaultTools = {
-  knowledgeSearchTool,
-};
+const defaultTools = {};
 
 const webTools = {
   devTool,

--- a/server/src/mastra/agents/web-researcher-agent.ts
+++ b/server/src/mastra/agents/web-researcher-agent.ts
@@ -1,7 +1,7 @@
 import { google } from "@ai-sdk/google";
 import { Agent } from "@mastra/core/agent";
 import { getCurrentDateInfo } from "~/lib/date";
-import { geminiModelWithThinking } from "~/lib/llm-models";
+import { GEMINI_FLASH, geminiModelWithThinking } from "~/lib/llm-models";
 
 const baseInstructions = `
 あなたはインターネットから最新情報を収集する専門エージェントです。
@@ -32,7 +32,7 @@ export const webResearcherAgent = new Agent({
 ## 現在の日時
 ${getCurrentDateInfo()}
 `,
-  ...geminiModelWithThinking(),
+  ...geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
   tools: {
     googleSearch: google.tools.googleSearch({}),
   },

--- a/server/src/services/knowledge/search.ts
+++ b/server/src/services/knowledge/search.ts
@@ -8,7 +8,7 @@ const EMBEDDING_DIMENSIONS = 1536;
 
 const SEARCH_TOP_K = 10;
 
-const RERANK_TOP_K = 3;
+const RERANK_TOP_K = 5;
 
 export interface KnowledgeResult {
   content: string;


### PR DESCRIPTION
## Summary
- knowledgeAgent を nepp-chan-agent のサブエージェントに昇格（tool 直接呼び出し → agent 委譲）
- knowledgeAgent にリトライ戦略を追加し、1回目の検索で回答が得られない場合にクエリを変えて再検索する
- LLM モデル定数を整理（GEMINI_FLASH → flash-latest、GEMINI_FLASH_LITE → flash-lite-latest）
- `geminiModelWithThinking` を名前付きパラメータ形式にリファクタリング
- knowledgeAgent / webResearcherAgent を GEMINI_FLASH + thinking "high" にアップグレード
- rerank top-k を 3 → 5 に拡大し、検索精度を向上

## 変更ファイル
- `server/src/lib/llm-models.ts` - モデル定数整理、geminiModelWithThinking リファクタリング
- `server/src/mastra/agents/knowledge-agent.ts` - リトライ戦略追加、モデルアップグレード
- `server/src/mastra/agents/nepp-chan-agent.ts` - knowledgeAgent をサブエージェント化
- `server/src/mastra/agents/web-researcher-agent.ts` - モデルアップグレード
- `server/src/services/knowledge/search.ts` - rerank top-k 拡大

## Test plan
- [ ] `pnpm lint` パス確認
- [ ] ナレッジ検索が正常に動作すること
- [ ] リトライ戦略で具体的な情報を求めるクエリの回答精度が向上すること
- [ ] webResearcherAgent が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)