### PR TITLE
fix: ペルソナテーブルの属性・タグをデスクトップでも表示

### DIFF
--- a/web/src/pages/dashboard/components/PersonaPanel.tsx
+++ b/web/src/pages/dashboard/components/PersonaPanel.tsx
@@ -176,11 +176,23 @@ export const PersonaPanel = () => {
                     {persona.content}
                   </p>
                   {(persona.demographicSummary || persona.tags) && (
-                    <div className="flex flex-wrap gap-2 text-xs text-stone-500 pt-1 md:hidden">
-                      {persona.demographicSummary && (
-                        <span>属性: {persona.demographicSummary}</span>
-                      )}
-                      {persona.tags && <span>タグ: {persona.tags}</span>}
+                    <div className="flex flex-wrap gap-1.5 text-xs pt-1">
+                      {persona.demographicSummary?.split(",").map((attr) => (
+                        <span
+                          key={attr}
+                          className="inline-flex px-1.5 py-0.5 bg-stone-100 text-stone-600 rounded"
+                        >
+                          {attr.trim()}
+                        </span>
+                      ))}
+                      {persona.tags?.split(",").map((tag) => (
+                        <span
+                          key={tag}
+                          className="inline-flex px-1.5 py-0.5 bg-teal-50 text-teal-600 rounded"
+                        >
+                          {tag.trim()}
+                        </span>
+                      ))}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- ペルソナ一覧テーブルで `md:hidden` により非表示だった属性（demographicSummary）とタグ（tags）をデスクトップでもバッジ表示するように変更
- 属性は stone 背景、タグは teal 背景で視覚的に区別

## Test plan
- [ ] ダッシュボードのペルソナ一覧で属性・タグがデスクトップ表示されることを確認
- [ ] モバイル表示でも引き続き正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)