### PR TITLE
chore: v0.3.0 リリース準備

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nepp-chan",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -26,7 +26,6 @@ server/src/
 │   ├── agents/              # AI エージェント
 │   ├── tools/               # ツール
 │   ├── workflows/           # ワークフロー
-│   ├── scorers/             # 評価スコアラー
 │   └── mcp/                 # MCP 設定
 ├── services/                # ビジネスロジック
 │   ├── knowledge/           # RAG ナレッジ処理
@@ -47,17 +46,18 @@ server/src/
 | `/health`                          | GET      | ヘルスチェック                 |
 | `/chat`                            | POST     | チャット（ストリーミング）     |
 | `/threads`                         | GET/POST | スレッド一覧・作成             |
-| `/threads/:threadId`               | GET      | スレッド詳細                   |
+| `/threads/:threadId`               | GET/DELETE | スレッド詳細・削除           |
 | `/threads/:threadId/messages`      | GET      | メッセージ履歴                 |
 | `/feedback`                        | POST     | フィードバック送信             |
 | `/admin/knowledge/sync`            | POST     | ナレッジ同期                   |
 | `/admin/knowledge`                 | DELETE   | ナレッジ削除                   |
-| `/admin/persona`                   | GET      | ペルソナ一覧                   |
+| `/admin/persona`                   | GET/DELETE | ペルソナ一覧・全削除         |
 | `/admin/persona/extract`           | POST     | ペルソナ抽出                   |
+| `/admin/persona/extract/:threadId` | POST     | 特定スレッドのペルソナ抽出     |
 | `/admin/emergency`                 | GET      | 緊急情報一覧（認証必須）       |
 | `/admin/feedback`                  | GET      | フィードバック一覧（認証必須） |
 | `/admin/feedback/:id`              | GET      | フィードバック詳細             |
-| `/admin/feedback/:id/resolve`      | PUT      | フィードバック解決             |
+| `/admin/feedback/:id/resolve`      | PUT/DELETE | フィードバック解決・未解決に戻す |
 | `/admin/feedback`                  | DELETE   | 全フィードバック削除           |
 | `/admin/invitations`               | GET/POST | 招待一覧・作成                 |
 | `/admin/invitations/:id`           | DELETE   | 招待削除                       |
@@ -91,7 +91,6 @@ const agent = createNeppChanAgent({ isAdmin: true });
 | ID                         | 説明                               |
 | -------------------------- | ---------------------------------- |
 | `nep-chan`                 | メインキャラクター（ねっぷちゃん） |
-| `weather-agent`            | 天気情報取得                       |
 | `web-researcher`           | Web 検索（Google Grounding）       |
 | `emergency-reporter-agent` | 緊急事態報告（一般ユーザー）       |
 | `emergency-agent`          | 緊急報告取得（管理者専用）         |
@@ -105,7 +104,6 @@ const agent = createNeppChanAgent({ isAdmin: true });
 
 | ツール名（変数名）       | ツール ID            | 説明                                   |
 | ------------------------ | -------------------- | -------------------------------------- |
-| `weatherTool`            | `get-weather`        | Open-Meteo API で天気取得              |
 | `searchGoogleTool`       | `google-search`      | Google Custom Search                   |
 | `devTool`                | `dev-tool`           | Working Memory 表示（デバッグ）        |
 | `displayChartTool`       | `display-chart`      | グラフ表示（line/bar/pie）             |
@@ -145,7 +143,6 @@ app.openapi(route, async (c) => { ... });
 - エージェントは `mastra/agents/` に配置
 - ツールは `mastra/tools/` に配置
 - ワークフローは `mastra/workflows/` に配置
-- スコアラーは `mastra/scorers/` に配置
 - **サービスロジックは `services/` に配置**（`mastra/` には Mastra プリミティブのみ）
 
 ### createTool の execute シグネチャ

--- a/server/README.md
+++ b/server/README.md
@@ -51,10 +51,17 @@ pnpm dev
 | ----------------------------- | -------- | -------------------------------- |
 | `/health`                     | GET      | ヘルスチェック                   |
 | `/chat`                       | POST     | チャットメッセージ送信（ストリーミング） |
-| `/threads`                    | GET      | スレッド一覧取得（ページング対応） |
-| `/threads`                    | POST     | スレッド作成                     |
-| `/threads/:threadId`          | GET      | スレッド詳細取得                 |
+| `/threads`                    | GET/POST | スレッド一覧取得・作成           |
+| `/threads/:threadId`          | GET/DELETE | スレッド詳細取得・削除         |
 | `/threads/:threadId/messages` | GET      | メッセージ履歴取得               |
+| `/feedback`                   | POST     | フィードバック送信               |
+| `/auth/register/options`      | POST     | WebAuthn 登録オプション取得      |
+| `/auth/register/verify`       | POST     | WebAuthn 登録検証                |
+| `/auth/login/options`         | POST     | WebAuthn ログインオプション      |
+| `/auth/login/verify`          | POST     | WebAuthn ログイン検証            |
+| `/auth/me`                    | GET      | 認証状態確認                     |
+| `/auth/logout`                | POST     | ログアウト                       |
+| `/line/webhook`               | POST     | LINE Webhook 受信                |
 
 ## API テスト（curl）
 
@@ -112,8 +119,11 @@ pnpm db:studio        # Drizzle Studio（DB GUI）起動
 pnpm db:check         # スキーマとマイグレーションの整合性チェック
 
 # ナレッジ管理
-pnpm knowledge:upload:dev # ナレッジアップロード（dev 環境）
-pnpm knowledge:clear  # ナレッジ全削除して再アップロード
+pnpm knowledge:upload:dev   # ナレッジアップロード（dev 環境）
+
+# 評価
+pnpm eval:v2          # Eval V2 実行
+pnpm eval:v3          # Eval V3 実行
 ```
 
 ## Drizzle ORM
@@ -182,7 +192,7 @@ wrangler vectorize create nepp-chan-knowledge-dev --dimensions=1536 --metric=cos
 初期管理者は招待スクリプトで作成します：
 
 ```bash
-pnpm admin:invite admin@example.com
+pnpm admin:invite:local admin@example.com
 ```
 
 ### ナレッジファイルの配置
@@ -239,19 +249,26 @@ pnpm knowledge:upload:dev --clean --file=mayor-interview.md
 
 ### 管理API
 
-| パス                             | メソッド | 説明                           |
-| -------------------------------- | -------- | ------------------------------ |
-| `/admin/knowledge`               | DELETE   | 全ナレッジを削除               |
-| `/admin/knowledge/sync`          | POST     | 全ナレッジを同期               |
-| `/admin/knowledge/files`         | GET      | ファイル一覧取得               |
-| `/admin/knowledge/files/:key`    | GET      | ファイル内容取得               |
-| `/admin/knowledge/files/:key`    | PUT      | ファイル保存                   |
-| `/admin/knowledge/files/:key`    | DELETE   | ファイル削除                   |
-| `/admin/knowledge/upload`        | POST     | Markdown アップロード          |
-| `/admin/knowledge/convert`       | POST     | 画像/PDF → Markdown 変換       |
-| `/admin/knowledge/unified`       | GET      | 統合ファイル一覧取得           |
-| `/admin/knowledge/originals/:key`| GET      | 元ファイル取得                 |
-| `/admin/knowledge/reconvert`     | POST     | 元ファイルから Markdown 再生成 |
+| パス                              | メソッド   | 説明                           |
+| --------------------------------- | ---------- | ------------------------------ |
+| `/admin/knowledge`                | DELETE     | 全ナレッジを削除               |
+| `/admin/knowledge/sync`           | POST       | 全ナレッジを同期               |
+| `/admin/knowledge/files`          | GET        | ファイル一覧取得               |
+| `/admin/knowledge/files/:key`     | GET/PUT/DELETE | ファイル取得・保存・削除   |
+| `/admin/knowledge/upload`         | POST       | Markdown アップロード          |
+| `/admin/knowledge/convert`        | POST       | 画像/PDF → Markdown 変換       |
+| `/admin/knowledge/unified`        | GET        | 統合ファイル一覧取得           |
+| `/admin/knowledge/originals/:key` | GET        | 元ファイル取得                 |
+| `/admin/knowledge/reconvert`      | POST       | 元ファイルから Markdown 再生成 |
+| `/admin/persona`                  | GET/DELETE | ペルソナ一覧・全削除           |
+| `/admin/persona/extract`          | POST       | ペルソナ抽出                   |
+| `/admin/persona/extract/:threadId`| POST       | 特定スレッドのペルソナ抽出     |
+| `/admin/emergency`                | GET        | 緊急報告一覧取得               |
+| `/admin/feedback`                 | GET/DELETE | フィードバック一覧・全削除     |
+| `/admin/feedback/:id`             | GET        | フィードバック詳細             |
+| `/admin/feedback/:id/resolve`     | PUT/DELETE | フィードバック解決・未解決に戻す |
+| `/admin/invitations`              | GET/POST   | 招待一覧・作成                 |
+| `/admin/invitations/:id`          | DELETE     | 招待削除                       |
 
 **認証**: パスキー認証でログインしたセッションが必要です。ダッシュボード（`/dashboard`）からログイン後、管理機能を利用できます。
 

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@nepp-chan/server",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "test": "vitest",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nepp-chan/web",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- 全パッケージのバージョンを v0.3.0 に更新
- server/CLAUDE.md, server/README.md を最新のコードベースに同期
  - 削除済みの weather-agent / weatherTool / scorers/ の記載を削除
  - 不足エンドポイント（auth, line, feedback, admin系）を追加
  - スクリプト記載の修正（knowledge:clear, admin:invite, eval追加）

## Test plan
- [ ] `pnpm lint` が通ること
- [ ] `pnpm web:build` が通ること
- [ ] ドキュメントの記載内容が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)