### PR TITLE
feat(server): Sentry Logs ラッパー導入・全ログ統一

### DIFF
--- a/server/__mocks__/@sentry/cloudflare.ts
+++ b/server/__mocks__/@sentry/cloudflare.ts
@@ -1,0 +1,13 @@
+const noop = () => {};
+
+export const captureException = noop;
+export const withSentry = (_opts: unknown, handler: unknown) => handler;
+
+export const logger = {
+  info: noop,
+  warn: noop,
+  error: noop,
+  debug: noop,
+  trace: noop,
+  fatal: noop,
+};

--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
+import { logger } from "~/lib/logger";
 import type { LineEventMessage } from "~/schemas/line-schema";
 import {
   createLineClient,
@@ -35,7 +36,7 @@ export const handleLineEvent = async (
       message.ack();
     } catch (error) {
       Sentry.captureException(error, { tags: { handler: "line-event" } });
-      console.error(`LINE reply failed for user ${userId}:`, error);
+      logger.error(`LINE reply failed for user ${userId}`, error);
       message.retry();
     }
   }

--- a/server/src/handlers/persona-extract-handler.ts
+++ b/server/src/handlers/persona-extract-handler.ts
@@ -1,9 +1,10 @@
+import { logger } from "~/lib/logger";
 import { extractAllPendingThreads } from "~/services/persona-extractor";
 
 export const handlePersonaExtract: ExportedHandlerScheduledHandler<
   CloudflareBindings
 > = async (_event, env, _ctx) => {
-  console.log(`[PersonaExtract] Cron triggered at ${new Date().toISOString()}`);
+  logger.info(`[PersonaExtract] Cron triggered at ${new Date().toISOString()}`);
 
   try {
     const results = await extractAllPendingThreads(env);
@@ -15,11 +16,11 @@ export const handlePersonaExtract: ExportedHandlerScheduledHandler<
       (r) => "skipped" in r.result && r.result.skipped,
     ).length;
 
-    console.log(
+    logger.info(
       `[PersonaExtract] Completed: ${extracted} extracted, ${skipped} skipped`,
     );
   } catch (error) {
-    console.error("[PersonaExtract] Error:", error);
+    logger.error("[PersonaExtract] Error", error);
     // withSentry が未捕捉例外として自動送信するため再 throw のみ
     throw error;
   }

--- a/server/src/handlers/r2-event-handler.ts
+++ b/server/src/handlers/r2-event-handler.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
+import { logger } from "~/lib/logger";
 import {
   deleteKnowledgeBySource,
   processKnowledgeFile,
@@ -84,7 +85,7 @@ export const handleR2Event = async (
       continue;
     }
 
-    console.log(`Processing R2 event: ${action} for ${key}`);
+    logger.info(`Processing R2 event: ${action} for ${key}`);
 
     try {
       let success = true;
@@ -95,9 +96,9 @@ export const handleR2Event = async (
         case "CopyObject": {
           const result = await handleObjectCreate(key, env);
           if (result.success) {
-            console.log(`Synced ${key}: ${result.chunks} chunks`);
+            logger.info(`Synced ${key}: ${result.chunks} chunks`);
           } else {
-            console.error(`Failed to sync ${key}: ${result.error}`);
+            logger.error(`Failed to sync ${key}`, result.error);
             success = false;
           }
           break;
@@ -106,15 +107,15 @@ export const handleR2Event = async (
         case "LifecycleDeletion": {
           const result = await handleObjectDelete(key, env);
           if (result.success) {
-            console.log(`Deleted vectors for ${key}: ${result.deleted} items`);
+            logger.info(`Deleted vectors for ${key}: ${result.deleted} items`);
           } else {
-            console.error(`Failed to delete ${key}: ${result.error}`);
+            logger.error(`Failed to delete ${key}`, result.error);
             success = false;
           }
           break;
         }
         default:
-          console.log(`Ignoring action: ${action}`);
+          logger.info(`Ignoring action: ${action}`);
       }
 
       if (success) {
@@ -124,7 +125,7 @@ export const handleR2Event = async (
       }
     } catch (error) {
       Sentry.captureException(error, { tags: { handler: "r2-event" } });
-      console.error(`Error processing ${key}:`, error);
+      logger.error(`Error processing ${key}`, error);
       message.retry();
     }
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import * as Sentry from "@sentry/cloudflare";
 import { handleLineEvent, handleR2Event } from "~/handlers";
 import { handlePersonaExtract } from "~/handlers/persona-extract-handler";
 import type { R2EventMessage } from "~/handlers/r2-event-handler";
+import { logger } from "~/lib/logger";
 import { getSentryOptions } from "~/lib/sentry";
 import { corsMiddleware, errorHandler, securityHeaders } from "~/middleware";
 import {
@@ -60,7 +61,7 @@ const handler: ExportedHandler<CloudflareBindings> = {
     if (batch.queue.startsWith("nepp-chan-knowledge-sync")) {
       return handleR2Event(batch as MessageBatch<R2EventMessage>, env);
     }
-    console.error(`Unknown queue: ${batch.queue}`);
+    logger.error(`Unknown queue: ${batch.queue}`);
   },
   scheduled: handlePersonaExtract,
 };

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -1,0 +1,26 @@
+import * as Sentry from "@sentry/cloudflare";
+
+type LogAttributes = Record<string, string | number | boolean>;
+
+const serializeError = (error: unknown): LogAttributes => {
+  if (error == null) return {};
+  if (error instanceof Error) {
+    return { "error.type": error.name, "error.message": error.message };
+  }
+  return { "error.message": String(error) };
+};
+
+export const logger = {
+  info: (message: string, attrs?: LogAttributes) => {
+    console.info(message, attrs ?? "");
+    Sentry.logger.info(message, attrs);
+  },
+  warn: (message: string, attrs?: LogAttributes) => {
+    console.warn(message, attrs ?? "");
+    Sentry.logger.warn(message, attrs);
+  },
+  error: (message: string, error?: unknown, attrs?: LogAttributes) => {
+    console.error(message, error ?? "");
+    Sentry.logger.error(message, { ...serializeError(error), ...attrs });
+  },
+} as const;

--- a/server/src/lib/sentry.ts
+++ b/server/src/lib/sentry.ts
@@ -6,6 +6,9 @@ export const getSentryOptions = (
   dsn: env.SENTRY_DSN,
   environment: env.ENVIRONMENT,
   tracesSampleRate: (env.ENVIRONMENT as string) === "production" ? 0.1 : 1.0,
+  _experiments: {
+    enableLogs: true,
+  },
   beforeSend(event) {
     if (event.request?.data) {
       event.request.data = "[Filtered]";

--- a/server/src/mastra/index.ts
+++ b/server/src/mastra/index.ts
@@ -7,6 +7,7 @@ import {
   SamplingStrategyType,
 } from "@mastra/observability";
 import { getPlatformProxy } from "wrangler";
+import { logger } from "~/lib/logger";
 import { converterAgent } from "~/mastra/agents/converter-agent";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
 import { emergencyReporterAgent } from "~/mastra/agents/emergency-reporter-agent";
@@ -32,8 +33,8 @@ const getCloudflareEnv = async () => {
     });
     cloudflareEnv = env;
     return env;
-  } catch (error) {
-    console.warn("Cloudflare bindings not available:", error);
+  } catch {
+    logger.warn("Cloudflare bindings not available");
     return null;
   }
 };

--- a/server/src/mastra/tools/admin-emergency-tool.ts
+++ b/server/src/mastra/tools/admin-emergency-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { emergencyRepository } from "~/repository/emergency-repository";
 import { emergencyReportSchema } from "~/schemas/emergency-schema";
 import { requireAdmin } from "./helpers";
@@ -64,7 +65,7 @@ export const adminEmergencyTool = createTool({
         message: `【管理者】直近${days}日間の緊急報告を${reports.length}件取得しました`,
       };
     } catch (error) {
-      console.error("Admin emergency reports fetch failed:", error);
+      logger.error("Admin emergency reports fetch failed", error);
       return {
         success: false,
         reports: [],

--- a/server/src/mastra/tools/admin-feedback-tool.ts
+++ b/server/src/mastra/tools/admin-feedback-tool.ts
@@ -1,6 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
+import { logger } from "~/lib/logger";
 import { feedbackRepository } from "~/repository/feedback-repository";
 import {
   feedbackBaseSchema,
@@ -91,7 +92,7 @@ export const adminFeedbackTool = createTool({
         message,
       };
     } catch (error) {
-      console.error("Admin feedback fetch failed:", error);
+      logger.error("Admin feedback fetch failed", error);
       return {
         success: false,
         feedbacks: [],

--- a/server/src/mastra/tools/admin-persona-tool.ts
+++ b/server/src/mastra/tools/admin-persona-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { personaRepository } from "~/repository/persona-repository";
 import { personaOutputSchema } from "~/schemas/persona-schema";
 import { requireAdmin } from "./helpers";
@@ -95,7 +96,7 @@ export const adminPersonaTool = createTool({
         },
       };
     } catch (error) {
-      console.error("Admin persona fetch failed:", error);
+      logger.error("Admin persona fetch failed", error);
       return {
         success: false,
         personas: [],

--- a/server/src/mastra/tools/emergency-get-tool.ts
+++ b/server/src/mastra/tools/emergency-get-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { emergencyRepository } from "~/repository/emergency-repository";
 import { emergencyReportSchema } from "~/schemas/emergency-schema";
 import { requireAdmin } from "./helpers";
@@ -64,7 +65,7 @@ export const emergencyGetTool = createTool({
         message: `直近${days}日間の緊急報告を${reports.length}件取得しました`,
       };
     } catch (error) {
-      console.error("Emergency reports fetch failed:", error);
+      logger.error("Emergency reports fetch failed", error);
       return {
         success: false,
         reports: [],

--- a/server/src/mastra/tools/emergency-report-tool.ts
+++ b/server/src/mastra/tools/emergency-report-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { emergencyRepository } from "~/repository/emergency-repository";
 import { requireDb } from "./helpers";
 
@@ -53,7 +54,7 @@ export const emergencyReportTool = createTool({
         message: `緊急報告を記録しました（ID: ${reportId}）`,
       };
     } catch (error) {
-      console.error("Emergency report creation failed:", error);
+      logger.error("Emergency report creation failed", error);
       return {
         success: false,
         message: "緊急報告の記録に失敗しました",

--- a/server/src/mastra/tools/emergency-update-tool.ts
+++ b/server/src/mastra/tools/emergency-update-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { emergencyRepository } from "~/repository/emergency-repository";
 import { requireDb } from "./helpers";
 
@@ -59,7 +60,7 @@ export const emergencyUpdateTool = createTool({
         message: `報告 ${reportId} を更新しました`,
       };
     } catch (error) {
-      console.error("Emergency report update failed:", error);
+      logger.error("Emergency report update failed", error);
       return {
         success: false,
         message: "緊急報告の更新に失敗しました",

--- a/server/src/mastra/tools/google-search-tool.ts
+++ b/server/src/mastra/tools/google-search-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { getEnv } from "./helpers";
 
 interface GoogleSearchResponse {
@@ -55,7 +56,7 @@ const searchGoogle = async (
   engineId?: string,
 ): Promise<SearchOutput> => {
   if (!apiKey || !engineId) {
-    console.error("Google Search API Key or Engine ID is missing.");
+    logger.error("Google Search API Key or Engine ID is missing.");
     return {
       results: [],
       error: "API_KEY_MISSING",
@@ -75,7 +76,7 @@ const searchGoogle = async (
 
     return { results, source: SOURCE };
   } catch (error) {
-    console.error("Search tool error:", error);
+    logger.error("Search tool error", error);
     return {
       results: [],
       error: error instanceof Error ? error.message : "Unknown error",
@@ -93,7 +94,7 @@ const handleErrorResponse = async (
   response: Response,
 ): Promise<SearchOutput> => {
   if (response.status === 429) {
-    console.warn("Google Custom Search API Rate Limit Exceeded");
+    logger.warn("Google Custom Search API Rate Limit Exceeded");
     return {
       results: [],
       error: "RATE_LIMIT_EXCEEDED",
@@ -102,7 +103,7 @@ const handleErrorResponse = async (
   }
 
   const errorText = await response.text();
-  console.error("Google Search API Error:", errorText);
+  logger.error("Google Search API Error", errorText);
 
   let errorMessage = "Unknown error";
   try {

--- a/server/src/mastra/tools/persona-aggregate-tool.ts
+++ b/server/src/mastra/tools/persona-aggregate-tool.ts
@@ -1,6 +1,7 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 
+import { logger } from "~/lib/logger";
 import { personaRepository } from "~/repository/persona-repository";
 import { requireAdmin } from "./helpers";
 
@@ -84,7 +85,7 @@ export const personaAggregateTool = createTool({
         message: `${aggregations.length}件のトピックを集計しました（合計${totalCount}件の意見）`,
       };
     } catch (error) {
-      console.error("Persona aggregation failed:", error);
+      logger.error("Persona aggregation failed", error);
       return {
         success: false,
         aggregations: [],

--- a/server/src/mastra/tools/persona-get-tool.ts
+++ b/server/src/mastra/tools/persona-get-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { personaRepository } from "~/repository/persona-repository";
 import { personaOutputSchema } from "~/schemas/persona-schema";
 import { requireAdmin } from "./helpers";
@@ -87,7 +88,7 @@ export const personaGetTool = createTool({
         message: `${personas.length}件のペルソナ情報を取得しました`,
       };
     } catch (error) {
-      console.error("Persona fetch failed:", error);
+      logger.error("Persona fetch failed", error);
       return {
         success: false,
         personas: [],

--- a/server/src/mastra/tools/persona-save-tool.ts
+++ b/server/src/mastra/tools/persona-save-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { personaRepository } from "~/repository/persona-repository";
 import { getConversationEndedAt, requireDb } from "./helpers";
 
@@ -93,7 +94,7 @@ export const personaSaveTool = createTool({
         message: `ペルソナ情報を保存しました（ID: ${personaId}）`,
       };
     } catch (error) {
-      console.error("Persona save failed:", error);
+      logger.error("Persona save failed", error);
       return {
         success: false,
         message: "ペルソナ情報の保存に失敗しました",

--- a/server/src/mastra/tools/persona-update-tool.ts
+++ b/server/src/mastra/tools/persona-update-tool.ts
@@ -1,5 +1,6 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
+import { logger } from "~/lib/logger";
 import { personaRepository } from "~/repository/persona-repository";
 import { requireDb } from "./helpers";
 
@@ -62,7 +63,7 @@ export const personaUpdateTool = createTool({
         message: `ペルソナ情報を更新しました（ID: ${id}）`,
       };
     } catch (error) {
-      console.error("Persona update failed:", error);
+      logger.error("Persona update failed", error);
       return {
         success: false,
         message: "ペルソナ情報の更新に失敗しました",

--- a/server/src/mastra/workflows/eval-workflow.ts
+++ b/server/src/mastra/workflows/eval-workflow.ts
@@ -22,8 +22,8 @@ import {
   createTestMessage,
 } from "@mastra/evals/scorers/utils";
 import { z } from "zod";
-
 import { GEMINI_FLASH_LITE } from "~/lib/llm-models";
+import { logger } from "~/lib/logger";
 import { evalTestCases } from "~/mastra/data/eval-test-cases";
 
 const KNOWLEDGE_TOOL_NAME = "knowledgeSearchTool";
@@ -204,13 +204,13 @@ const runBatchEval = createStep({
     const results = [];
     for (let i = 0; i < evalTestCases.length; i++) {
       const testCase = evalTestCases[i];
-      console.log(
+      logger.info(
         `[EVAL ${i + 1}/${evalTestCases.length}] 開始: ${testCase.input.slice(0, 30)}...`,
       );
 
       const result = await runEval(agent, testCase, requestContext);
 
-      console.log(
+      logger.info(
         `[EVAL ${i + 1}/${evalTestCases.length}] 完了: ${testCase.input.slice(0, 30)}...`,
       );
       results.push(result);

--- a/server/src/middleware/cors.ts
+++ b/server/src/middleware/cors.ts
@@ -1,5 +1,6 @@
 import type { MiddlewareHandler } from "hono";
 import { cors } from "hono/cors";
+import { logger } from "~/lib/logger";
 
 const isAllowedOrigin = (
   origin: string,
@@ -16,7 +17,11 @@ export const corsMiddleware: MiddlewareHandler<{
   const corsHandler = cors({
     origin: (origin) => {
       if (!origin) return undefined;
-      return isAllowedOrigin(origin, c.env);
+      const allowed = isAllowedOrigin(origin, c.env);
+      if (!allowed) {
+        logger.warn("[CORS] rejected origin", { origin });
+      }
+      return allowed;
     },
     allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     allowHeaders: ["Content-Type", "User-Agent", "Authorization"],

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/cloudflare";
 import type { ErrorHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { StatusCode } from "hono/utils/http-status";
+import { logger } from "~/lib/logger";
 
 type ErrorResponse = {
   error: {
@@ -14,8 +15,7 @@ export const errorHandler: ErrorHandler = (err, c) => {
   if (err instanceof HTTPException) {
     if (err.status >= 500) {
       Sentry.captureException(err);
-      console.error("HTTPException", {
-        message: err.message,
+      logger.error("HTTPException", err, {
         status: err.status,
       });
     }
@@ -32,12 +32,7 @@ export const errorHandler: ErrorHandler = (err, c) => {
   }
 
   Sentry.captureException(err);
-  console.error("Unhandled exception", {
-    name: err.name,
-    message: err.message,
-    cause: err.cause,
-    stack: err.stack,
-  });
+  logger.error("Unhandled exception", err);
 
   return c.json<ErrorResponse>(
     {

--- a/server/src/middleware/line-signature.ts
+++ b/server/src/middleware/line-signature.ts
@@ -1,6 +1,7 @@
 import { validateSignature } from "@line/bot-sdk";
 import type { MiddlewareHandler } from "hono";
 import { HTTPException } from "hono/http-exception";
+import { logger } from "~/lib/logger";
 
 export const lineSignatureVerify: MiddlewareHandler<{
   Bindings: CloudflareBindings;
@@ -8,12 +9,14 @@ export const lineSignatureVerify: MiddlewareHandler<{
 }> = async (c, next) => {
   const signature = c.req.header("x-line-signature");
   if (!signature) {
+    logger.warn("[LINE] missing x-line-signature header");
     throw new HTTPException(401, { message: "Missing x-line-signature" });
   }
 
   const rawBody = await c.req.text();
 
   if (!validateSignature(rawBody, c.env.LINE_CHANNEL_SECRET, signature)) {
+    logger.warn("[LINE] invalid signature");
     throw new HTTPException(401, { message: "Invalid signature" });
   }
 

--- a/server/src/middleware/session-auth.ts
+++ b/server/src/middleware/session-auth.ts
@@ -2,6 +2,7 @@ import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import type { AdminUser } from "~/db";
 import { getTokenFromHeader } from "~/lib/auth-header";
+import { logger } from "~/lib/logger";
 import { getUserFromSession } from "~/services/auth/session";
 
 type SessionVariables = {
@@ -15,12 +16,14 @@ export const sessionAuth = createMiddleware<{
   const sessionId = getTokenFromHeader(c);
 
   if (!sessionId) {
+    logger.warn("[Auth] missing session token");
     throw new HTTPException(401, { message: "セッションがありません" });
   }
 
   const user = await getUserFromSession(c.env.DB, sessionId);
 
   if (!user) {
+    logger.warn("[Auth] invalid or expired session");
     throw new HTTPException(401, { message: "無効なセッションです" });
   }
 

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -4,6 +4,7 @@ import { Mastra } from "@mastra/core/mastra";
 import { createUIMessageStreamResponse, type UIMessage } from "ai";
 
 import { getTokenFromHeader } from "~/lib/auth-header";
+import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
 import { createRequestContext } from "~/mastra/request-context";
@@ -53,6 +54,8 @@ const chatRoute = createRoute({
 
 chatRoutes.openapi(chatRoute, async (c) => {
   const { message, resourceId, threadId } = c.req.valid("json");
+  logger.info(`[Chat] request received`, { threadId, resourceId });
+
   const storage = await getStorage(c.env.DB);
 
   const sessionId = getTokenFromHeader(c);

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import type { WebhookEvent, WebhookRequestBody } from "@line/bot-sdk";
 
+import { logger } from "~/lib/logger";
 import { lineSignatureVerify } from "~/middleware";
 import type { LineEventMessage } from "~/schemas/line-schema";
 
@@ -13,8 +14,10 @@ lineRoutes.use("/*", lineSignatureVerify);
 
 lineRoutes.post("/webhook", async (c) => {
   const body = c.get("parsedBody") as WebhookRequestBody;
+  const eventCount = body.events?.length ?? 0;
+  logger.info(`[LINE] webhook received`, { eventCount });
 
-  if (!body.events || body.events.length === 0) {
+  if (!body.events || eventCount === 0) {
     return c.json({ status: "ok" });
   }
 

--- a/server/src/services/knowledge/embedding.ts
+++ b/server/src/services/knowledge/embedding.ts
@@ -3,6 +3,7 @@ import { MDocument } from "@mastra/rag";
 import { embedMany } from "ai";
 import matter from "gray-matter";
 import { GEMINI_EMBEDDING } from "~/lib/llm-models";
+import { logger } from "~/lib/logger";
 
 const EMBEDDING_DIMENSIONS = 1536;
 const BATCH_SIZE = 100;
@@ -88,7 +89,7 @@ const chunkDocument = async (
     };
   });
 
-  console.log(
+  logger.info(
     `[Knowledge Sync] ${filename}: ${allTexts.length} chunks -> ${texts.length} after filtering (min ${MIN_CHUNK_LENGTH} chars)`,
   );
 

--- a/server/src/services/knowledge/files.ts
+++ b/server/src/services/knowledge/files.ts
@@ -1,3 +1,4 @@
+import { logger } from "~/lib/logger";
 import { deleteKnowledgeBySource } from "./embedding";
 
 const EDIT_THRESHOLD_MS = 5000;
@@ -208,7 +209,7 @@ export const deleteFile = async (
 
   // 1. Markdownファイルを削除
   await bucket.delete(mdKey);
-  console.log(`[Delete] Deleted ${mdKey} from R2`);
+  logger.info(`[Delete] Deleted ${mdKey} from R2`);
 
   // 2. 元ファイル（originals/）を検索して削除
   const listed = await bucket.list({ prefix: `originals/${baseName}` });
@@ -216,11 +217,11 @@ export const deleteFile = async (
     const objBaseName = extractBaseName(obj.key);
     if (objBaseName === baseName) {
       await bucket.delete(obj.key);
-      console.log(`[Delete] Deleted ${obj.key} from R2`);
+      logger.info(`[Delete] Deleted ${obj.key} from R2`);
     }
   }
 
   // 3. Vectorize から削除
   await deleteKnowledgeBySource(vectorize, mdKey);
-  console.log(`[Delete] Deleted ${mdKey} from Vectorize`);
+  logger.info(`[Delete] Deleted ${mdKey} from Vectorize`);
 };

--- a/server/src/services/knowledge/search.ts
+++ b/server/src/services/knowledge/search.ts
@@ -3,6 +3,7 @@ import { ModelRouterLanguageModel } from "@mastra/core/llm";
 import { MastraAgentRelevanceScorer, rerankWithScorer } from "@mastra/rag";
 import { embed } from "ai";
 import { GEMINI_EMBEDDING, GEMINI_FLASH } from "~/lib/llm-models";
+import { logger } from "~/lib/logger";
 
 const EMBEDDING_DIMENSIONS = 1536;
 
@@ -103,7 +104,7 @@ export const searchKnowledge = async (
       results: knowledgeResults,
     };
   } catch (error) {
-    console.error("Knowledge search error:", error);
+    logger.error("Knowledge search error", error);
     return {
       results: [],
       error: error instanceof Error ? error.message : "Unknown error",

--- a/server/src/services/knowledge/sync.ts
+++ b/server/src/services/knowledge/sync.ts
@@ -1,3 +1,4 @@
+import { logger } from "~/lib/logger";
 import { deleteKnowledgeBySource, processKnowledgeFile } from "./embedding";
 
 const EDIT_THRESHOLD_MS = 5000;
@@ -60,7 +61,7 @@ export const syncAll = async ({
   );
   const originalsMap = buildOriginalsMap(allObjects);
 
-  console.log(`[Sync] Found ${mdFiles.length} markdown files`);
+  logger.info(`[Sync] Found ${mdFiles.length} markdown files`);
 
   const results: SyncResult[] = [];
 
@@ -73,7 +74,7 @@ export const syncAll = async ({
 
     const edited = isFileEdited(obj, originalsMap);
     const content = await file.text();
-    console.log(
+    logger.info(
       `[Sync] Processing ${obj.key} (${content.length} bytes)${edited ? " [EDITED]" : ""}`,
     );
 

--- a/server/src/services/knowledge/upload.ts
+++ b/server/src/services/knowledge/upload.ts
@@ -1,3 +1,4 @@
+import { logger } from "~/lib/logger";
 import { convertToMarkdown, isSupportedMimeType } from "./converter";
 import { syncFile } from "./sync";
 
@@ -47,7 +48,7 @@ export const uploadMarkdownFile = async (
     httpMetadata: { contentType: "text/markdown" },
   });
 
-  console.log(`[Upload] Uploaded ${key} (${content.length} bytes)`);
+  logger.info(`[Upload] Uploaded ${key} (${content.length} bytes)`);
 
   const result = await syncFile(key, content, {
     vectorize: deps.vectorize,
@@ -83,12 +84,12 @@ export const convertAndUpload = async (
     key = `${key}.md`;
   }
 
-  console.log(`[Convert] Converting ${file.name} (${mimeType}) to ${key}`);
+  logger.info(`[Convert] Converting ${file.name} (${mimeType}) to ${key}`);
 
   const fileData = await file.arrayBuffer();
   const markdown = await convertToMarkdown(fileData, mimeType);
 
-  console.log(`[Convert] Generated ${markdown.length} bytes of markdown`);
+  logger.info(`[Convert] Generated ${markdown.length} bytes of markdown`);
 
   // 元ファイルを originals/ に保存
   const originalExtension = file.name.split(".").pop() || "bin";
@@ -96,7 +97,7 @@ export const convertAndUpload = async (
   await deps.bucket.put(originalKey, fileData, {
     httpMetadata: { contentType: mimeType },
   });
-  console.log(`[Convert] Saved original to ${originalKey}`);
+  logger.info(`[Convert] Saved original to ${originalKey}`);
 
   // Markdown を R2 に保存
   await deps.bucket.put(key, markdown, {
@@ -140,12 +141,12 @@ export const reconvertFromOriginal = async (
     key = `${key}.md`;
   }
 
-  console.log(`[Reconvert] Converting ${originalKey} (${mimeType}) to ${key}`);
+  logger.info(`[Reconvert] Converting ${originalKey} (${mimeType}) to ${key}`);
 
   const fileData = await object.arrayBuffer();
   const markdown = await convertToMarkdown(fileData, mimeType);
 
-  console.log(`[Reconvert] Generated ${markdown.length} bytes of markdown`);
+  logger.info(`[Reconvert] Generated ${markdown.length} bytes of markdown`);
 
   await deps.bucket.put(key, markdown, {
     httpMetadata: { contentType: "text/markdown" },

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -31,6 +31,7 @@ export const generateReply = async (params: {
     storage,
   });
   const agent = mastra.getAgent("neppChanAgent");
+  logger.info(`[LINE] generating reply`, { threadId: params.threadId });
 
   const response = await agent.generate(params.userMessage, {
     requestContext,
@@ -44,6 +45,9 @@ export const generateReply = async (params: {
   const texts = splitMessagesForLine(stepTexts);
 
   if (texts.length === 0 && response.text) {
+    logger.warn(`[LINE] step texts empty, using fallback`, {
+      threadId: params.threadId,
+    });
     return splitMessagesForLine([response.text]).map(stripMarkdown);
   }
 

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -1,6 +1,7 @@
 import { messagingApi } from "@line/bot-sdk";
 import { Mastra } from "@mastra/core/mastra";
 
+import { logger } from "~/lib/logger";
 import { splitMessagesForLine } from "~/lib/split-message";
 import { getStorage } from "~/lib/storage";
 import { stripMarkdown } from "~/lib/strip-markdown";
@@ -65,13 +66,12 @@ export const sendLineMessages = async (params: {
       replyToken: params.replyToken,
       messages,
     });
-    console.log(`LINE replyMessage sent to ${params.userId}`);
-  } catch (replyError) {
-    console.log(
-      `LINE replyMessage failed for ${params.userId}, falling back to pushMessage:`,
-      replyError,
+    logger.info(`LINE replyMessage sent to ${params.userId}`);
+  } catch {
+    logger.warn(
+      `LINE replyMessage failed for ${params.userId}, falling back to pushMessage`,
     );
     await params.client.pushMessage({ to: params.userId, messages });
-    console.log(`LINE pushMessage sent to ${params.userId}`);
+    logger.info(`LINE pushMessage sent to ${params.userId}`);
   }
 };

--- a/server/src/services/persona-extractor.ts
+++ b/server/src/services/persona-extractor.ts
@@ -4,6 +4,7 @@ import { count, desc, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
 import { createDb, mastraThreads, persona, threadPersonaStatus } from "~/db";
+import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
 import { personaAgent } from "~/mastra/agents/persona-agent";
 import { getWorkingMemoryByThread } from "~/mastra/memory";
@@ -113,7 +114,7 @@ export const extractPersonaFromThread = async (
       };
     }
     // その他のエラーはログに出力してスキップ
-    console.error(`Persona extraction failed for thread ${threadId}:`, error);
+    logger.error(`Persona extraction failed for thread ${threadId}`, error);
     return {
       skipped: true,
       reason: "extraction_error",

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -3,6 +3,14 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      "@sentry/cloudflare": new URL(
+        "./__mocks__/@sentry/cloudflare.ts",
+        import.meta.url,
+      ).pathname,
+    },
+  },
   test: {
     globals: true,
   },


### PR DESCRIPTION
## Summary
- `server/src/lib/logger.ts` に Sentry Logs ラッパーを新規作成（console + Sentry デュアル出力）
- 全 `console.*` 呼び出し（約40箇所）を `logger.*` 経由に統一
- 未ログだった重要パス（Chat リクエスト、LINE webhook/返信生成、署名検証、セッション認証、CORS 拒否）にログを追加

## Test plan
- [x] `pnpm lint` — Biome チェック通過
- [x] `pnpm format` — フォーマット通過
- [x] `pnpm test` — 全266テスト通過
- [ ] dev デプロイ後、Sentry ダッシュボードの Logs セクションでログ表示を確認
- [ ] `wrangler tail` で console 出力が従来通り確認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)