### PR TITLE
feat(db): drizzle-kit studio で dev/prd D1 に接続可能にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "db:migrate:prd": "pnpm --filter @nepp-chan/server db:migrate:prd",
     "db:migrate:local": "pnpm --filter @nepp-chan/server db:migrate:local",
     "db:studio": "pnpm --filter @nepp-chan/server db:studio",
+    "db:studio:dev": "pnpm --filter @nepp-chan/server db:studio:dev",
+    "db:studio:prd": "pnpm --filter @nepp-chan/server db:studio:prd",
     "db:push": "pnpm --filter @nepp-chan/server db:push",
     "db:check": "pnpm --filter @nepp-chan/server db:check",
     "knowledge:upload:local": "tsx --env-file=.env.local scripts/upload-knowledge.ts",

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,3 +2,4 @@
 GOOGLE_GENERATIVE_AI_API_KEY=your-api-key
 GOOGLE_SEARCH_ENGINE_ID=your-search-engine-id
 WEB_URL=http://localhost:5173
+CLOUDFLARE_API_TOKEN=your-cloudflare-api-token

--- a/server/drizzle.config.ts
+++ b/server/drizzle.config.ts
@@ -1,8 +1,24 @@
 import { defineConfig } from "drizzle-kit";
 
+const D1_DATABASE_IDS = {
+  dev: "bd4f1aee-768d-4273-ab72-5aef42f1c199",
+  prd: "239abba6-e30a-4628-97fc-20bf49ca8404",
+} as const;
+
+const d1Env = process.env.D1_ENV as keyof typeof D1_DATABASE_IDS | undefined;
+const databaseId = d1Env ? D1_DATABASE_IDS[d1Env] : undefined;
+
 export default defineConfig({
   schema: "./src/db/schema.ts",
   out: "./src/db/migrations",
   dialect: "sqlite",
   tablesFilter: ["!mastra_*"],
+  ...(databaseId && {
+    driver: "d1-http",
+    dbCredentials: {
+      accountId: "51544998e04526c4d6cc9e3e08653361",
+      databaseId,
+      token: process.env.CLOUDFLARE_API_TOKEN!,
+    },
+  }),
 });

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,8 @@
     "db:migrate:prd": "wrangler d1 migrations apply nepp-chan-db-prd --remote --env production",
     "db:migrate:local": "wrangler d1 migrations apply nepp-chan-db-dev --local --env local",
     "db:studio": "drizzle-kit studio",
+    "db:studio:dev": "D1_ENV=dev drizzle-kit studio",
+    "db:studio:prd": "D1_ENV=prd drizzle-kit studio",
     "db:push": "drizzle-kit push",
     "db:check": "drizzle-kit check",
     "eval:run": "tsx scripts/run-eval.ts",


### PR DESCRIPTION
## Summary

- drizzle-kit 0.31.9 の D1 HTTP ドライバーを活用し、`drizzle-kit studio` からリモート D1 に接続可能にした
- `D1_ENV` 環境変数で dev/prd を切り替え。未指定時は従来通りローカル動作
- `pnpm db:studio:dev` / `pnpm db:studio:prd` をルート・server 両方に追加

## Test plan

- [x] `pnpm db:studio:dev` で dev 環境の D1 テーブルが閲覧できること
- [x] `pnpm db:studio:prd` で prd 環境の D1 テーブルが閲覧できること
- [x] `pnpm db:studio`（D1_ENV未指定）が従来通り動作すること
- [x] `pnpm db:generate` / `pnpm db:check` に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)