### PR TITLE
feat: ロールベースアクセス制御(RBAC)の追加

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -203,6 +203,7 @@ throw new HTTPException(404, { message: "Not found" });
 - エラー: `throw new HTTPException(code, { message })` でスロー（グローバルエラーハンドラーが `{ error: { code, message } }` 形式に変換）
 - OpenAPI エラーレスポンス: `lib/openapi-errors.ts` の `errorResponse(code)` を使用
 - 認証必須ルート: `requireAuth` ミドルウェアを適用
+- ロール制限ルート: `requireRole("admin")` 等を `requireAuth` の後に適用（`middleware/require-role.ts`）
 - 共通スキーマ: `schemas/` から import（インライン定義を避ける）
 
 ## データベーステーブル
@@ -225,7 +226,7 @@ throw new HTTPException(404, { message: "Not found" });
 | id            | TEXT | PRIMARY KEY                        |
 | username      | TEXT | ユーザー名（UNIQUE NOT NULL）      |
 | name          | TEXT | 表示名                             |
-| role          | TEXT | 役割（admin/super_admin）          |
+| role          | TEXT | 役割（super_admin/admin/staff）    |
 | password_hash | TEXT | パスワードハッシュ（NOT NULL）      |
 | created_at    | TEXT | 作成日時（NOT NULL）               |
 | updated_at    | TEXT | 更新日時                           |

--- a/server/src/__tests__/knowledge-routes.test.ts
+++ b/server/src/__tests__/knowledge-routes.test.ts
@@ -46,7 +46,7 @@ const testUser = {
   id: "user-1",
   username: "admin01",
   name: "管理者",
-  role: "admin" as const,
+  role: "super_admin",
   passwordHash: "100000:salt:hash",
   createdAt: "2024-01-01T00:00:00Z",
   updatedAt: null,

--- a/server/src/__tests__/require-role.test.ts
+++ b/server/src/__tests__/require-role.test.ts
@@ -1,0 +1,136 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as tokenService from "~/services/auth/token";
+
+vi.mock("~/services/auth/token", () => ({
+  verifyAccessToken: vi.fn(),
+}));
+
+const { resolveAuth, requireAuth } = await import("~/middleware/auth");
+const { requireRole } = await import("~/middleware/require-role");
+
+describe("requireRole ミドルウェア", () => {
+  const mockEnv = {
+    DB: {} as D1Database,
+    JWT_SECRET: "test-secret-32-chars-long-enough",
+  } as unknown as CloudflareBindings;
+
+  const makeUser = (role: string) => ({
+    id: "user-1",
+    username: "testuser",
+    name: "テスト",
+    role,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createApp = (minRole: "super_admin" | "admin" | "staff") => {
+    const app = new Hono<{
+      Bindings: CloudflareBindings;
+      Variables: { adminUser?: ReturnType<typeof makeUser> };
+    }>();
+    app.use("*", resolveAuth);
+    app.use("*", requireAuth);
+    app.use("*", requireRole(minRole));
+    app.get("/test", (c) => c.json({ ok: true }));
+    return app;
+  };
+
+  // biome-ignore lint/suspicious/noExplicitAny: テスト用ヘルパーのため型制約を緩和
+  const requestWith = (app: Hono<any>, token = "valid-token") =>
+    app.request(
+      new Request("http://localhost/test", {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      {},
+      mockEnv,
+    );
+
+  it("未認証の場合は401を返す", async () => {
+    const app = createApp("staff");
+    const res = await app.request("/test", {}, mockEnv);
+
+    expect(res.status).toBe(401);
+  });
+
+  describe("staff ロール要求", () => {
+    it("staff はアクセスできる", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("staff"),
+      );
+      const res = await requestWith(createApp("staff"));
+      expect(res.status).toBe(200);
+    });
+
+    it("admin はアクセスできる", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("admin"),
+      );
+      const res = await requestWith(createApp("staff"));
+      expect(res.status).toBe(200);
+    });
+
+    it("super_admin はアクセスできる", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("super_admin"),
+      );
+      const res = await requestWith(createApp("staff"));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("admin ロール要求", () => {
+    it("staff は403を返す", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("staff"),
+      );
+      const res = await requestWith(createApp("admin"));
+      expect(res.status).toBe(403);
+    });
+
+    it("admin はアクセスできる", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("admin"),
+      );
+      const res = await requestWith(createApp("admin"));
+      expect(res.status).toBe(200);
+    });
+
+    it("super_admin はアクセスできる", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("super_admin"),
+      );
+      const res = await requestWith(createApp("admin"));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe("super_admin ロール要求", () => {
+    it("staff は403を返す", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("staff"),
+      );
+      const res = await requestWith(createApp("super_admin"));
+      expect(res.status).toBe(403);
+    });
+
+    it("admin は403を返す", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("admin"),
+      );
+      const res = await requestWith(createApp("super_admin"));
+      expect(res.status).toBe(403);
+    });
+
+    it("super_admin はアクセスできる", async () => {
+      vi.mocked(tokenService.verifyAccessToken).mockResolvedValue(
+        makeUser("super_admin"),
+      );
+      const res = await requestWith(createApp("super_admin"));
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -74,7 +74,7 @@ export const adminUsers = sqliteTable("admin_users", {
   id: text("id").primaryKey(),
   username: text("username").notNull().unique(),
   name: text("name"),
-  role: text("role").notNull().default("admin"), // "super_admin" | "admin"
+  role: text("role").notNull().default("admin"), // "super_admin" | "admin" | "staff"
   passwordHash: text("password_hash").notNull(),
   createdAt: text("created_at").notNull(),
   updatedAt: text("updated_at"),

--- a/server/src/middleware/index.ts
+++ b/server/src/middleware/index.ts
@@ -1,6 +1,5 @@
-export { requireAuth, resolveAuth } from "./auth";
+export { resolveAuth } from "./auth";
 export { corsMiddleware } from "./cors";
 export { errorHandler } from "./error-handler";
 export { lineSignatureVerify } from "./line-signature";
-export { requireRole } from "./require-role";
 export { securityHeaders } from "./security-headers";

--- a/server/src/middleware/index.ts
+++ b/server/src/middleware/index.ts
@@ -1,5 +1,6 @@
-export { resolveAuth } from "./auth";
+export { requireAuth, resolveAuth } from "./auth";
 export { corsMiddleware } from "./cors";
 export { errorHandler } from "./error-handler";
 export { lineSignatureVerify } from "./line-signature";
+export { requireRole } from "./require-role";
 export { securityHeaders } from "./security-headers";

--- a/server/src/middleware/require-role.ts
+++ b/server/src/middleware/require-role.ts
@@ -1,0 +1,25 @@
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
+import type { AuthVariables } from "./auth";
+
+const ROLE_LEVEL = { super_admin: 3, admin: 2, staff: 1 } as const;
+
+type AdminRole = keyof typeof ROLE_LEVEL;
+
+export const requireRole = (minRole: AdminRole) =>
+  createMiddleware<{
+    Bindings: CloudflareBindings;
+    Variables: AuthVariables;
+  }>(async (c, next) => {
+    const user = c.get("adminUser");
+    if (!user) {
+      throw new HTTPException(401, { message: "認証が必要です" });
+    }
+    const userLevel = ROLE_LEVEL[user.role as AdminRole] ?? 0;
+    if (userLevel < ROLE_LEVEL[minRole]) {
+      throw new HTTPException(403, {
+        message: "この操作を行う権限がありません",
+      });
+    }
+    await next();
+  });

--- a/server/src/routes/admin/feedback.ts
+++ b/server/src/routes/admin/feedback.ts
@@ -4,6 +4,7 @@ import { HTTPException } from "hono/http-exception";
 import type { MessageFeedback } from "~/db";
 import { errorResponse } from "~/lib/openapi-errors";
 import { requireAuth } from "~/middleware/auth";
+import { requireRole } from "~/middleware/require-role";
 import { feedbackRepository } from "~/repository/feedback-repository";
 import {
   feedbackFullSchema,
@@ -48,6 +49,7 @@ export const feedbackAdminRoutes = new OpenAPIHono<{
 }>();
 
 feedbackAdminRoutes.use("*", requireAuth);
+feedbackAdminRoutes.use("*", requireRole("admin"));
 
 const listRoute = createRoute({
   method: "get",

--- a/server/src/routes/admin/invitations.ts
+++ b/server/src/routes/admin/invitations.ts
@@ -77,7 +77,10 @@ const createInvitationRoute = createRoute({
         "application/json": {
           schema: z.object({
             username: z.string().min(1),
-            role: z.enum(["admin", "staff"]).optional().default("staff"),
+            role: z
+              .enum(["super_admin", "admin", "staff"])
+              .optional()
+              .default("staff"),
           }),
         },
       },
@@ -109,9 +112,9 @@ invitationRoutes.openapi(createInvitationRoute, async (c) => {
   const { username, role } = c.req.valid("json");
   const adminUser = c.get("adminUser");
 
-  if (role === "admin" && adminUser.role !== "super_admin") {
+  if (role !== "staff" && adminUser.role !== "super_admin") {
     throw new HTTPException(403, {
-      message: "管理者の招待はスーパー管理者のみ可能です",
+      message: "管理者・スーパー管理者の招待はスーパー管理者のみ可能です",
     });
   }
 

--- a/server/src/routes/admin/invitations.ts
+++ b/server/src/routes/admin/invitations.ts
@@ -2,7 +2,9 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { HTTPException } from "hono/http-exception";
 import { errorResponse } from "~/lib/openapi-errors";
 import { type AuthVariables, requireAuth } from "~/middleware/auth";
+import { requireRole } from "~/middleware/require-role";
 import { adminInvitationRepository } from "~/repository/admin-invitation-repository";
+import { adminRoleSchema } from "~/schemas/auth-schema";
 import { createInvitation } from "~/services/auth/invitation";
 
 export const invitationRoutes = new OpenAPIHono<{
@@ -11,6 +13,7 @@ export const invitationRoutes = new OpenAPIHono<{
 }>();
 
 invitationRoutes.use("*", requireAuth);
+invitationRoutes.use("*", requireRole("admin"));
 
 const listInvitationsRoute = createRoute({
   method: "get",
@@ -27,7 +30,7 @@ const listInvitationsRoute = createRoute({
               z.object({
                 id: z.string(),
                 username: z.string(),
-                role: z.string(),
+                role: adminRoleSchema,
                 invitedBy: z.string(),
                 expiresAt: z.string(),
                 usedAt: z.string().nullable(),
@@ -50,7 +53,7 @@ invitationRoutes.openapi(listInvitationsRoute, async (c) => {
       invitations: invitations.map((inv) => ({
         id: inv.id,
         username: inv.username,
-        role: inv.role,
+        role: adminRoleSchema.parse(inv.role),
         invitedBy: inv.invitedBy,
         expiresAt: inv.expiresAt,
         usedAt: inv.usedAt,
@@ -74,7 +77,7 @@ const createInvitationRoute = createRoute({
         "application/json": {
           schema: z.object({
             username: z.string().min(1),
-            role: z.enum(["admin", "super_admin"]).optional().default("admin"),
+            role: z.enum(["admin", "staff"]).optional().default("staff"),
           }),
         },
       },
@@ -106,9 +109,9 @@ invitationRoutes.openapi(createInvitationRoute, async (c) => {
   const { username, role } = c.req.valid("json");
   const adminUser = c.get("adminUser");
 
-  if (role === "super_admin" && adminUser.role !== "super_admin") {
+  if (role === "admin" && adminUser.role !== "super_admin") {
     throw new HTTPException(403, {
-      message: "super_admin の招待は super_admin のみ可能です",
+      message: "管理者の招待はスーパー管理者のみ可能です",
     });
   }
 

--- a/server/src/routes/admin/knowledge/index.ts
+++ b/server/src/routes/admin/knowledge/index.ts
@@ -1,6 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 import { requireAuth } from "~/middleware/auth";
+import { requireRole } from "~/middleware/require-role";
 import { knowledgeConvertRoutes } from "./convert";
 import { knowledgeFilesRoutes } from "./files";
 import { knowledgeSyncRoutes } from "./sync";
@@ -10,6 +11,7 @@ export const knowledgeAdminRoutes = new OpenAPIHono<{
 }>();
 
 knowledgeAdminRoutes.use("*", requireAuth);
+knowledgeAdminRoutes.use("*", requireRole("super_admin"));
 
 knowledgeAdminRoutes.route("/", knowledgeSyncRoutes);
 knowledgeAdminRoutes.route("/", knowledgeFilesRoutes);

--- a/server/src/routes/admin/persona.ts
+++ b/server/src/routes/admin/persona.ts
@@ -2,6 +2,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 
 import { errorResponse } from "~/lib/openapi-errors";
 import { requireAuth } from "~/middleware/auth";
+import { requireRole } from "~/middleware/require-role";
 import { personaRepository } from "~/repository/persona-repository";
 import {
   deleteAllPersonas,
@@ -14,6 +15,7 @@ export const personaAdminRoutes = new OpenAPIHono<{
 }>();
 
 personaAdminRoutes.use("*", requireAuth);
+personaAdminRoutes.use("*", requireRole("admin"));
 
 const PersonaSchema = z.object({
   id: z.string(),

--- a/server/src/routes/auth/index.ts
+++ b/server/src/routes/auth/index.ts
@@ -6,7 +6,7 @@ import { hashPassword, verifyPassword } from "~/lib/password";
 import type { AuthVariables } from "~/middleware/auth";
 import { adminInvitationRepository } from "~/repository/admin-invitation-repository";
 import { adminUserRepository } from "~/repository/admin-user-repository";
-import { AdminUserSchema } from "~/schemas/auth-schema";
+import { AdminUserSchema, adminRoleSchema } from "~/schemas/auth-schema";
 import { generateAccessToken } from "~/services/auth/token";
 
 export const authRoutes = new OpenAPIHono<{
@@ -23,7 +23,7 @@ const toUserResponse = (user: {
   id: user.id,
   username: user.username,
   name: user.name,
-  role: user.role,
+  role: adminRoleSchema.parse(user.role),
 });
 
 // --- Register ---

--- a/server/src/schemas/auth-schema.ts
+++ b/server/src/schemas/auth-schema.ts
@@ -1,10 +1,18 @@
 import { z } from "@hono/zod-openapi";
 
+export const adminRoleSchema = z.enum(["super_admin", "admin", "staff"]);
+
 export const AdminUserSchema = z.object({
   id: z.string(),
   username: z.string(),
   name: z.string().nullable(),
-  role: z.string(),
+  role: adminRoleSchema,
 });
 
-export type AuthUser = z.infer<typeof AdminUserSchema>;
+// 内部用: JWT から来る role は string のため、ランタイムでは AdminUserSchema.parse() を通さない限り保証されない
+export type AuthUser = {
+  id: string;
+  username: string;
+  name: string | null;
+  role: string;
+};

--- a/web/src/app/dashboard/App.tsx
+++ b/web/src/app/dashboard/App.tsx
@@ -11,6 +11,7 @@ import {
 } from "@heroicons/react/24/outline";
 import { useMemo, useState } from "react";
 
+import { useRole } from "~/hooks/useRole";
 import type { AdminUser } from "~/lib/api/auth";
 import { cn } from "~/lib/class-merge";
 
@@ -31,12 +32,6 @@ type Tab =
   | "invitations";
 
 type AdminRole = AdminUser["role"];
-
-const ROLE_LEVEL: Record<AdminRole, number> = {
-  super_admin: 3,
-  admin: 2,
-  staff: 1,
-};
 
 const tabs: {
   id: Tab;
@@ -83,11 +78,11 @@ const tabs: {
 export const App = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { user, isAuthenticated, isLoading, logout } = useAuth();
+  const { hasRole } = useRole(user);
 
   const visibleTabs = useMemo(() => {
-    const userLevel = ROLE_LEVEL[user?.role as AdminRole] ?? 0;
-    return tabs.filter((t) => !t.minRole || userLevel >= ROLE_LEVEL[t.minRole]);
-  }, [user?.role]);
+    return tabs.filter((t) => !t.minRole || hasRole(t.minRole));
+  }, [hasRole]);
 
   const [activeTab, setActiveTab] = useState<Tab>(
     visibleTabs[0]?.id ?? "emergency",

--- a/web/src/app/dashboard/App.tsx
+++ b/web/src/app/dashboard/App.tsx
@@ -9,8 +9,9 @@ import {
   UserGroupIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import type { AdminUser } from "~/lib/api/auth";
 import { cn } from "~/lib/class-merge";
 
 import { BroadcastPanel } from "./components/BroadcastPanel";
@@ -29,21 +30,37 @@ type Tab =
   | "broadcast"
   | "invitations";
 
-const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+type AdminRole = AdminUser["role"];
+
+const ROLE_LEVEL: Record<AdminRole, number> = {
+  super_admin: 3,
+  admin: 2,
+  staff: 1,
+};
+
+const tabs: {
+  id: Tab;
+  label: string;
+  icon: React.ReactNode;
+  minRole?: AdminRole;
+}[] = [
   {
     id: "knowledge",
     label: "ナレッジ",
     icon: <BookOpenIcon className="w-5 h-5" aria-hidden="true" />,
+    minRole: "super_admin",
   },
   {
     id: "persona",
     label: "ペルソナ",
     icon: <UserGroupIcon className="w-5 h-5" aria-hidden="true" />,
+    minRole: "admin",
   },
   {
     id: "feedback",
     label: "フィードバック",
     icon: <ChatBubbleLeftIcon className="w-5 h-5" aria-hidden="true" />,
+    minRole: "admin",
   },
   {
     id: "emergency",
@@ -59,13 +76,22 @@ const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
     id: "invitations",
     label: "招待管理",
     icon: <EnvelopeIcon className="w-5 h-5" aria-hidden="true" />,
+    minRole: "admin",
   },
 ];
 
 export const App = () => {
-  const [activeTab, setActiveTab] = useState<Tab>("knowledge");
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const { user, isAuthenticated, isLoading, logout } = useAuth();
+
+  const visibleTabs = useMemo(() => {
+    const userLevel = ROLE_LEVEL[user?.role as AdminRole] ?? 0;
+    return tabs.filter((t) => !t.minRole || userLevel >= ROLE_LEVEL[t.minRole]);
+  }, [user?.role]);
+
+  const [activeTab, setActiveTab] = useState<Tab>(
+    visibleTabs[0]?.id ?? "emergency",
+  );
 
   const handleLogout = async () => {
     await logout();
@@ -136,7 +162,7 @@ export const App = () => {
         </div>
 
         <nav className="flex-1 overflow-y-auto py-2">
-          {tabs.map((tab) => (
+          {visibleTabs.map((tab) => (
             <button
               key={tab.id}
               type="button"
@@ -193,7 +219,7 @@ export const App = () => {
             <Bars3Icon className="w-5 h-5 text-stone-600" aria-hidden="true" />
           </button>
           <h2 className="text-lg font-semibold text-stone-800">
-            {tabs.find((t) => t.id === activeTab)?.label}
+            {visibleTabs.find((t) => t.id === activeTab)?.label}
           </h2>
         </header>
 

--- a/web/src/app/dashboard/components/InvitationsPanel.tsx
+++ b/web/src/app/dashboard/components/InvitationsPanel.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import type { AdminUser } from "~/lib/api/auth";
 import { formatDateTime } from "~/lib/format";
 import {
   createInvitation,
@@ -10,13 +10,21 @@ import {
 } from "~/repository/invitation-repository";
 import { useAuth } from "../contexts/AuthContext";
 
+const ROLE_LABELS: Record<AdminUser["role"], string> = {
+  super_admin: "スーパー管理者",
+  admin: "管理者",
+  staff: "職員",
+};
+
 export const InvitationsPanel = () => {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const { copyToClipboard } = useCopyToClipboard();
   const [username, setUsername] = useState("");
+  const [role, setRole] = useState<"admin" | "staff">("staff");
   const [createdUrl, setCreatedUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const canInviteAdmin = user?.role === "super_admin";
 
   const { data, isLoading } = useQuery({
     queryKey: ["invitations"],
@@ -24,7 +32,13 @@ export const InvitationsPanel = () => {
   });
 
   const createMutation = useMutation({
-    mutationFn: (username: string) => createInvitation(username),
+    mutationFn: ({
+      username,
+      role,
+    }: {
+      username: string;
+      role: "admin" | "staff";
+    }) => createInvitation(username, role),
     onSuccess: (data) => {
       const baseUrl = window.location.origin;
       const url = `${baseUrl}/register?token=${data.invitation.token}`;
@@ -49,7 +63,7 @@ export const InvitationsPanel = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!username.trim()) return;
-    createMutation.mutate(username.trim());
+    createMutation.mutate({ username: username.trim(), role });
   };
 
   const isExpired = (expiresAt: string) => {
@@ -103,6 +117,20 @@ export const InvitationsPanel = () => {
             required
             className="flex-1 px-3 py-2 border border-stone-300 rounded focus:outline-none focus:ring-2 focus:ring-teal-500"
           />
+          {canInviteAdmin ? (
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value as "admin" | "staff")}
+              className="px-3 py-2 border border-stone-300 rounded focus:outline-none focus:ring-2 focus:ring-teal-500"
+            >
+              <option value="staff">職員</option>
+              <option value="admin">管理者</option>
+            </select>
+          ) : (
+            <span className="px-3 py-2 text-sm text-stone-500 self-center whitespace-nowrap">
+              職員として招待
+            </span>
+          )}
           <button
             type="submit"
             disabled={createMutation.isPending}
@@ -153,9 +181,7 @@ export const InvitationsPanel = () => {
                         {inv.username}
                       </td>
                       <td className="px-4 py-3 text-stone-600">
-                        {inv.role === "super_admin"
-                          ? "スーパー管理者"
-                          : "管理者"}
+                        {ROLE_LABELS[inv.role] ?? inv.role}
                       </td>
                       <td className="px-4 py-3">
                         {inv.usedAt ? (
@@ -216,9 +242,7 @@ export const InvitationsPanel = () => {
                     )}
                   </div>
                   <div className="flex items-center justify-between text-xs text-stone-500">
-                    <span>
-                      {inv.role === "super_admin" ? "スーパー管理者" : "管理者"}
-                    </span>
+                    <span>{ROLE_LABELS[inv.role] ?? inv.role}</span>
                     <span>期限: {formatDateTime(inv.expiresAt)}</span>
                   </div>
                   {(!inv.usedAt || user?.role === "super_admin") && (

--- a/web/src/app/dashboard/components/InvitationsPanel.tsx
+++ b/web/src/app/dashboard/components/InvitationsPanel.tsx
@@ -21,7 +21,7 @@ export const InvitationsPanel = () => {
   const { user } = useAuth();
   const { copyToClipboard } = useCopyToClipboard();
   const [username, setUsername] = useState("");
-  const [role, setRole] = useState<"admin" | "staff">("staff");
+  const [role, setRole] = useState<AdminUser["role"]>("staff");
   const [createdUrl, setCreatedUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const canInviteAdmin = user?.role === "super_admin";
@@ -37,7 +37,7 @@ export const InvitationsPanel = () => {
       role,
     }: {
       username: string;
-      role: "admin" | "staff";
+      role: AdminUser["role"];
     }) => createInvitation(username, role),
     onSuccess: (data) => {
       const baseUrl = window.location.origin;
@@ -120,11 +120,12 @@ export const InvitationsPanel = () => {
           {canInviteAdmin ? (
             <select
               value={role}
-              onChange={(e) => setRole(e.target.value as "admin" | "staff")}
+              onChange={(e) => setRole(e.target.value as AdminUser["role"])}
               className="px-3 py-2 border border-stone-300 rounded focus:outline-none focus:ring-2 focus:ring-teal-500"
             >
               <option value="staff">職員</option>
               <option value="admin">管理者</option>
+              <option value="super_admin">スーパー管理者</option>
             </select>
           ) : (
             <span className="px-3 py-2 text-sm text-stone-500 self-center whitespace-nowrap">

--- a/web/src/app/dashboard/components/InvitationsPanel.tsx
+++ b/web/src/app/dashboard/components/InvitationsPanel.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { ROLE_LABELS, useRole } from "~/hooks/useRole";
 import type { AdminUser } from "~/lib/api/auth";
 import { formatDateTime } from "~/lib/format";
 import {
@@ -10,21 +11,15 @@ import {
 } from "~/repository/invitation-repository";
 import { useAuth } from "../contexts/AuthContext";
 
-const ROLE_LABELS: Record<AdminUser["role"], string> = {
-  super_admin: "スーパー管理者",
-  admin: "管理者",
-  staff: "職員",
-};
-
 export const InvitationsPanel = () => {
   const queryClient = useQueryClient();
   const { user } = useAuth();
+  const { isSuperAdmin } = useRole(user);
   const { copyToClipboard } = useCopyToClipboard();
   const [username, setUsername] = useState("");
   const [role, setRole] = useState<AdminUser["role"]>("staff");
   const [createdUrl, setCreatedUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const canInviteAdmin = user?.role === "super_admin";
 
   const { data, isLoading } = useQuery({
     queryKey: ["invitations"],
@@ -117,7 +112,7 @@ export const InvitationsPanel = () => {
             required
             className="flex-1 px-3 py-2 border border-stone-300 rounded focus:outline-none focus:ring-2 focus:ring-teal-500"
           />
-          {canInviteAdmin ? (
+          {isSuperAdmin ? (
             <select
               value={role}
               onChange={(e) => setRole(e.target.value as AdminUser["role"])}
@@ -203,7 +198,7 @@ export const InvitationsPanel = () => {
                         {formatDateTime(inv.expiresAt)}
                       </td>
                       <td className="px-4 py-3">
-                        {(!inv.usedAt || user?.role === "super_admin") && (
+                        {(!inv.usedAt || isSuperAdmin) && (
                           <button
                             type="button"
                             onClick={() => deleteMutation.mutate(inv.id)}
@@ -246,7 +241,7 @@ export const InvitationsPanel = () => {
                     <span>{ROLE_LABELS[inv.role] ?? inv.role}</span>
                     <span>期限: {formatDateTime(inv.expiresAt)}</span>
                   </div>
-                  {(!inv.usedAt || user?.role === "super_admin") && (
+                  {(!inv.usedAt || isSuperAdmin) && (
                     <div className="pt-2">
                       <button
                         type="button"

--- a/web/src/hooks/useRole.ts
+++ b/web/src/hooks/useRole.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+
+import type { AdminUser } from "~/lib/api/auth";
+
+type AdminRole = AdminUser["role"];
+
+const ROLE_LEVEL: Record<AdminRole, number> = {
+  super_admin: 3,
+  admin: 2,
+  staff: 1,
+};
+
+export const ROLE_LABELS: Record<AdminRole, string> = {
+  super_admin: "スーパー管理者",
+  admin: "管理者",
+  staff: "職員",
+};
+
+export const useRole = (user: AdminUser | null | undefined) => {
+  return useMemo(() => {
+    const role = user?.role;
+    const level = role ? ROLE_LEVEL[role] : 0;
+
+    return {
+      role,
+      hasRole: (minRole: AdminRole) => level >= ROLE_LEVEL[minRole],
+      isSuperAdmin: role === "super_admin",
+    };
+  }, [user?.role]);
+};

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -1,12 +1,10 @@
 import { getAuthToken } from "~/lib/auth-token";
+import type { paths } from "~/types/api";
 import { API_BASE, parseErrorResponse } from "./client";
 
-type AdminUser = {
-  id: string;
-  username: string;
-  name: string | null;
-  role: string;
-};
+type AdminUser = NonNullable<
+  paths["/auth/me"]["get"]["responses"]["200"]["content"]["application/json"]["user"]
+>;
 
 type AuthResponse = {
   accessToken: string;

--- a/web/src/repository/invitation-repository.ts
+++ b/web/src/repository/invitation-repository.ts
@@ -1,3 +1,4 @@
+import type { AdminUser } from "~/lib/api/auth";
 import { client } from "~/lib/api/client";
 
 export const fetchInvitations = async () => {
@@ -8,7 +9,7 @@ export const fetchInvitations = async () => {
 
 export const createInvitation = async (
   username: string,
-  role: "admin" | "staff",
+  role: AdminUser["role"],
 ) => {
   const { data, error } = await client.POST("/admin/invitations", {
     body: { username, role },

--- a/web/src/repository/invitation-repository.ts
+++ b/web/src/repository/invitation-repository.ts
@@ -6,9 +6,12 @@ export const fetchInvitations = async () => {
   return data;
 };
 
-export const createInvitation = async (username: string) => {
+export const createInvitation = async (
+  username: string,
+  role: "admin" | "staff",
+) => {
   const { data, error } = await client.POST("/admin/invitations", {
-    body: { username },
+    body: { username, role },
   });
   if (error) throw error;
   return data;

--- a/web/src/types/api.d.ts
+++ b/web/src/types/api.d.ts
@@ -2604,7 +2604,8 @@ export interface paths {
                             invitations: {
                                 id: string;
                                 username: string;
-                                role: string;
+                                /** @enum {string} */
+                                role: "super_admin" | "admin" | "staff";
                                 invitedBy: string;
                                 expiresAt: string;
                                 usedAt: string | null;
@@ -2632,7 +2633,7 @@ export interface paths {
         put?: never;
         /**
          * 新規招待作成
-         * @description 管理者を招待します。super_admin の招待はスクリプト経由でのみ可能です。
+         * @description 管理者を招待します。super_admin ロールの招待は super_admin のみ可能です。
          */
         post: {
             parameters: {
@@ -2645,6 +2646,11 @@ export interface paths {
                 content: {
                     "application/json": {
                         username: string;
+                        /**
+                         * @default staff
+                         * @enum {string}
+                         */
+                        role?: "admin" | "staff";
                     };
                 };
             };
@@ -2681,6 +2687,20 @@ export interface paths {
                 };
                 /** @description 認証エラー */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 権限エラー */
+                403: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -2809,7 +2829,8 @@ export interface paths {
                                 id: string;
                                 username: string;
                                 name: string | null;
-                                role: string;
+                                /** @enum {string} */
+                                role: "super_admin" | "admin" | "staff";
                             };
                         };
                     };
@@ -2874,7 +2895,8 @@ export interface paths {
                                 id: string;
                                 username: string;
                                 name: string | null;
-                                role: string;
+                                /** @enum {string} */
+                                role: "super_admin" | "admin" | "staff";
                             };
                         };
                     };
@@ -2890,44 +2912,6 @@ export interface paths {
                                 code: number;
                                 message: string;
                             };
-                        };
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/logout": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** ログアウト */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description ログアウト成功 */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            message: string;
                         };
                     };
                 };
@@ -2967,7 +2951,8 @@ export interface paths {
                                 id: string;
                                 username: string;
                                 name: string | null;
-                                role: string;
+                                /** @enum {string} */
+                                role: "super_admin" | "admin" | "staff";
                             } | null;
                         };
                     };
@@ -2976,6 +2961,44 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** ログアウト */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description ログアウト成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;

--- a/web/src/types/api.d.ts
+++ b/web/src/types/api.d.ts
@@ -2650,7 +2650,7 @@ export interface paths {
                          * @default staff
                          * @enum {string}
                          */
-                        role?: "admin" | "staff";
+                        role?: "super_admin" | "admin" | "staff";
                     };
                 };
             };


### PR DESCRIPTION
## Summary
- 3段階のロール（super_admin/admin/staff）による認可制御を追加
- ダッシュボードのタブをロールに応じて動的フィルタリング
- 招待作成時にロール選択が可能に（super_adminは全ロール招待可、adminはstaff のみ）
- ロール型をOpenAPI経由でサーバー・フロント間で共通化

## 主な変更内容

### サーバー
- `requireRole` ミドルウェア: 階層型ロールチェック（super_admin > admin > staff）
- 各管理ルートに `requireAuth` + `requireRole` をコロケーション配置
- `adminRoleSchema`: OpenAPIレスポンスにenum型を反映、`adminRoleSchema.parse()` でランタイム検証
- 招待ルート: super_admin/admin/staff選択対応、staff以外の招待はsuper_adminのみ可能

### 権限マッピング

| 機能 | super_admin | admin | staff |
|------|:-----------:|:-----:|:-----:|
| ナレッジ | ✓ | - | - |
| ペルソナ | ✓ | ✓ | - |
| フィードバック | ✓ | ✓ | - |
| 緊急情報 | ✓ | ✓ | ✓ |
| LINE配信 | ✓ | ✓ | ✓ |
| 招待管理 | ✓ | ✓ | - |

### フロントエンド
- `AdminUser` 型をOpenAPI生成型（`api.d.ts`）から導出
- `ROLE_LEVEL` / `ROLE_LABELS` の型を `AdminUser["role"]` で型安全に
- 招待パネルにロール選択UIを追加

## Test plan
- [x] requireRole ミドルウェアのユニットテスト（10ケース）
- [x] knowledge-routes テストのロール対応
- [x] tsc --noEmit パス
- [x] lint / format パス
- [x] web ビルド成功
- [x] 各ロールでログインし、タブの表示/非表示を確認
- [x] staff ロールから knowledge API を直接叩いて 403 が返ることを確認
- [x] 招待作成でロール選択が正しく動作することを確認