### PR TITLE
fix(broadcast): Copilot レビュー指摘を修正

### DIFF
--- a/server/src/schemas/broadcast-schema.ts
+++ b/server/src/schemas/broadcast-schema.ts
@@ -12,7 +12,7 @@ export const broadcastPartSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("image"),
     imageR2Key: z.string().min(1),
-    imageDescription: z.string().optional(),
+    imageDescription: z.string().max(5000).optional(),
   }),
 ]);
 

--- a/server/src/services/broadcast-memory.ts
+++ b/server/src/services/broadcast-memory.ts
@@ -12,7 +12,11 @@ const extractImageDescriptions = (partsJson: string | null): string[] => {
       )
       .map((p) => p.imageDescription)
       .filter((d): d is string => !!d);
-  } catch {
+  } catch (e) {
+    console.warn("Failed to parse broadcast parts JSON", {
+      error: e,
+      partsJson,
+    });
     return [];
   }
 };


### PR DESCRIPTION
## Summary
#367 のCopilotレビュー指摘のうち、対応すべき2件を修正。

- `imageDescription` に `.max(5000)` バリデーションを追加（textパートと同様のガード）
- `extractImageDescriptions` のJSONパース失敗時に `console.warn` でログ出力を追加

### 対応しなかった指摘
- **テンプレート内インデント崩れ**: LLMコンテキスト用テキストのため問題なし
- **ArrayBufferメモリ常駐**: Workers 128MBに対し配信画像は数百KB〜数MB。過剰な最適化

## Test plan
- [x] `pnpm lint` 通過
- [x] `pnpm --filter server test` 全224テスト通過
- [x] `pnpm --filter web build` 通過