### PR TITLE
feat(agent): Intent ルーターによるモデル動的切り替え

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,19 +125,19 @@ importers:
         version: 2.0.122(react@19.2.4)(zod@4.3.6)
       '@assistant-ui/react':
         specifier: ^0.11.53
-        version: 0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
       '@assistant-ui/react-ai-sdk':
         specifier: ^1.1.20
-        version: 1.1.20(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react@19.2.14)(assistant-cloud@0.1.12)(react@19.2.4)
+        version: 1.1.20(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react@19.2.14)(assistant-cloud@0.1.12)(react@19.2.4)
       '@assistant-ui/react-markdown':
         specifier: ^0.12.1
-        version: 0.12.1(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+        version: 0.12.1(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@astrojs/check':
         specifier: ^0.9.8
         version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
       '@astrojs/react':
         specifier: ^5.0.1
-        version: 5.0.1(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.3)
+        version: 5.0.1(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.3)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.4)
@@ -146,7 +146,7 @@ importers:
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@sentry/react':
         specifier: ^10.43.0
         version: 10.43.0(react@19.2.4)
@@ -175,11 +175,11 @@ importers:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
-        specifier: ^19.2.0
-        version: 19.2.1(react@19.2.4)
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
       recharts:
         specifier: ^3.7.0
-        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react-is@19.2.3)(react@19.2.4)(redux@5.0.1)
+        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.3)(react@19.2.4)(redux@5.0.1)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -5020,10 +5020,10 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@19.2.1:
-    resolution: {integrity: sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==}
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
-      react: ^19.2.1
+      react: ^19.2.4
 
   react-is@19.2.3:
     resolution: {integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==}
@@ -6328,10 +6328,10 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
-  '@assistant-ui/react-ai-sdk@1.1.20(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react@19.2.14)(assistant-cloud@0.1.12)(react@19.2.4)':
+  '@assistant-ui/react-ai-sdk@1.1.20(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react@19.2.14)(assistant-cloud@0.1.12)(react@19.2.4)':
     dependencies:
       '@ai-sdk/react': 2.0.122(react@19.2.4)(zod@4.3.6)
-      '@assistant-ui/react': 0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+      '@assistant-ui/react': 0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
       ai: 5.0.120(zod@4.3.6)
       react: 19.2.4
       zod: 4.3.6
@@ -6339,10 +6339,10 @@ snapshots:
       '@types/react': 19.2.14
       assistant-cloud: 0.1.12
 
-  '@assistant-ui/react-markdown@0.12.1(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@assistant-ui/react-markdown@0.12.1(@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@assistant-ui/react': 0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@assistant-ui/react': 0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       classnames: 2.5.1
       react: 19.2.4
@@ -6354,14 +6354,14 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))':
+  '@assistant-ui/react@0.11.53(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))':
     dependencies:
       '@assistant-ui/tap': 0.3.5(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
@@ -6369,7 +6369,7 @@ snapshots:
       assistant-stream: 0.2.46
       nanoid: 5.1.6
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       react-textarea-autosize: 8.5.9(@types/react@19.2.14)(react@19.2.4)
       zod: 4.3.6
       zustand: 5.0.10(@types/react@19.2.14)(immer@11.1.3)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -6463,7 +6463,7 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@5.0.1(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.3)':
+  '@astrojs/react@5.0.1(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
       '@astrojs/internal-helpers': 0.8.0
       '@types/react': 19.2.14
@@ -6471,7 +6471,7 @@ snapshots:
       '@vitejs/plugin-react': 5.2.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       devalue: 5.6.4
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       ultrahtml: 1.6.0
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
@@ -7139,11 +7139,11 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.6(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@floating-ui/react-dom@2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@floating-ui/dom': 1.7.4
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
 
   '@floating-ui/utils@0.2.10': {}
 
@@ -7647,11 +7647,11 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -7674,15 +7674,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -7693,13 +7693,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -7711,81 +7711,81 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
       aria-hidden: 1.2.6
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/rect': 1.1.1
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -7804,22 +7804,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -7872,11 +7872,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -11088,7 +11088,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@19.2.1(react@19.2.4):
+  react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
@@ -11168,7 +11168,7 @@ snapshots:
 
   real-require@0.2.0: {}
 
-  recharts@3.7.0(@types/react@19.2.14)(react-dom@19.2.1(react@19.2.4))(react-is@19.2.3)(react@19.2.4)(redux@5.0.1):
+  recharts@3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.3)(react@19.2.4)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
       clsx: 2.1.1
@@ -11177,7 +11177,7 @@ snapshots:
       eventemitter3: 5.0.4
       immer: 10.2.0
       react: 19.2.4
-      react-dom: 19.2.1(react@19.2.4)
+      react-dom: 19.2.4(react@19.2.4)
       react-is: 19.2.3
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
       reselect: 5.1.1

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -78,15 +78,20 @@ server/src/
 
 ### nep-chan（動的生成）
 
-メインキャラクター「ねっぷちゃん」は `createNeppChanAgent({ isAdmin, channel })` で動的に生成される。
+メインキャラクター「ねっぷちゃん」は `createNeppChanAgent({ isAdmin, platform, modelConfig })` で動的に生成される。
+`modelConfig` は `resolveModelTier()` で Intent（casual/normal/thinking）× プラットフォーム × 管理者フラグから決定する。
 
 - **一般ユーザー**: 基本機能のみ（天気、Web検索、ナレッジ、緊急報告）
 - **管理者**: 基本機能 + 管理者専用エージェント（emergency, feedback, persona-analyst）
 
 ```typescript
+import { classifyIntent } from "~/lib/classify-intent";
+import { resolveModelTier } from "~/lib/llm-models";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
 
-const agent = createNeppChanAgent({ isAdmin: true });
+const intent = await classifyIntent(userText);
+const modelConfig = resolveModelTier({ intent, platform: "web", isAdmin: false });
+const agent = createNeppChanAgent({ modelConfig });
 ```
 
 ### エージェント一覧
@@ -94,6 +99,7 @@ const agent = createNeppChanAgent({ isAdmin: true });
 | ID                         | 説明                               |
 | -------------------------- | ---------------------------------- |
 | `nep-chan`                 | メインキャラクター（ねっぷちゃん） |
+| `intent-router`            | Intent 分類（モデルティア決定用）   |
 | `web-researcher`           | Web 検索（Google Grounding）       |
 | `emergency-reporter-agent` | 緊急事態報告（一般ユーザー）       |
 | `emergency-agent`          | 緊急報告取得（管理者専用）         |

--- a/server/src/__tests__/intent-router.test.ts
+++ b/server/src/__tests__/intent-router.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  GEMINI_FLASH,
+  GEMINI_FLASH_LITE,
+  type Intent,
+  resolveModelTier,
+} from "~/lib/llm-models";
+
+describe("resolveModelTier", () => {
+  describe("Admin は常に thinking/web ティア", () => {
+    const intents: Intent[] = ["casual", "normal", "thinking"];
+    const platforms = ["web", "line"] as const;
+
+    for (const intent of intents) {
+      for (const platform of platforms) {
+        it(`intent=${intent}, platform=${platform} でも FLASH + high`, () => {
+          const tier = resolveModelTier({ intent, platform, isAdmin: true });
+          expect(tier.model).toBe(GEMINI_FLASH);
+          expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+            "high",
+          );
+        });
+      }
+    }
+  });
+
+  describe("Web プラットフォーム（非 Admin）", () => {
+    it("casual → FLASH_LITE + low", () => {
+      const tier = resolveModelTier({
+        intent: "casual",
+        platform: "web",
+        isAdmin: false,
+      });
+      expect(tier.model).toBe(GEMINI_FLASH_LITE);
+      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+        "low",
+      );
+    });
+
+    it("normal → FLASH + medium", () => {
+      const tier = resolveModelTier({
+        intent: "normal",
+        platform: "web",
+        isAdmin: false,
+      });
+      expect(tier.model).toBe(GEMINI_FLASH);
+      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+        "medium",
+      );
+    });
+
+    it("thinking → FLASH + high", () => {
+      const tier = resolveModelTier({
+        intent: "thinking",
+        platform: "web",
+        isAdmin: false,
+      });
+      expect(tier.model).toBe(GEMINI_FLASH);
+      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+        "high",
+      );
+    });
+  });
+
+  describe("LINE プラットフォーム（非 Admin）", () => {
+    it("casual → FLASH_LITE + low", () => {
+      const tier = resolveModelTier({
+        intent: "casual",
+        platform: "line",
+        isAdmin: false,
+      });
+      expect(tier.model).toBe(GEMINI_FLASH_LITE);
+      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+        "low",
+      );
+    });
+
+    it("normal → FLASH_LITE + medium", () => {
+      const tier = resolveModelTier({
+        intent: "normal",
+        platform: "line",
+        isAdmin: false,
+      });
+      expect(tier.model).toBe(GEMINI_FLASH_LITE);
+      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+        "medium",
+      );
+    });
+
+    it("thinking → FLASH + medium", () => {
+      const tier = resolveModelTier({
+        intent: "thinking",
+        platform: "line",
+        isAdmin: false,
+      });
+      expect(tier.model).toBe(GEMINI_FLASH);
+      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
+        "medium",
+      );
+    });
+  });
+});

--- a/server/src/lib/classify-intent.ts
+++ b/server/src/lib/classify-intent.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import type { Intent } from "~/lib/llm-models";
+import { intentRouterAgent } from "~/mastra/agents/intent-router-agent";
+
+const intentSchema = z.object({
+  intent: z.enum(["casual", "normal", "thinking"]),
+});
+
+/**
+ * ユーザーメッセージの意図を軽量モデル（intent-router-agent）で分類する。
+ * 分類結果は resolveModelTier と組み合わせてメインエージェントのモデルティアを決定する。
+ * 分類失敗時は "normal" にフォールバックする。
+ */
+export const classifyIntent = async (message: string): Promise<Intent> => {
+  try {
+    const result = await intentRouterAgent.generate(message, {
+      structuredOutput: { schema: intentSchema },
+    });
+    return result.object?.intent ?? "normal";
+  } catch {
+    return "normal";
+  }
+};

--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -24,3 +24,43 @@ export const geminiModelWithThinking = ({
     },
   },
 });
+
+export type Intent = "casual" | "normal" | "thinking";
+
+export type ModelTierConfig = ReturnType<typeof geminiModelWithThinking>;
+
+const MODEL_TIERS: Record<Intent, Record<"web" | "line", ModelTierConfig>> = {
+  casual: {
+    web: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "low" }),
+    line: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "low" }),
+  },
+  normal: {
+    web: geminiModelWithThinking({ model: GEMINI_FLASH, level: "medium" }),
+    line: geminiModelWithThinking({
+      model: GEMINI_FLASH_LITE,
+      level: "medium",
+    }),
+  },
+  thinking: {
+    web: geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
+    line: geminiModelWithThinking({ model: GEMINI_FLASH, level: "medium" }),
+  },
+};
+
+/**
+ * Intent・プラットフォーム・管理者フラグからモデル設定を解決する
+ */
+export const resolveModelTier = ({
+  intent,
+  platform,
+  isAdmin,
+}: {
+  intent: Intent;
+  platform: "web" | "line";
+  isAdmin: boolean;
+}): ModelTierConfig => {
+  if (isAdmin) {
+    return MODEL_TIERS.thinking.web;
+  }
+  return MODEL_TIERS[intent][platform];
+};

--- a/server/src/mastra/agents/intent-router-agent.ts
+++ b/server/src/mastra/agents/intent-router-agent.ts
@@ -1,0 +1,23 @@
+import { Agent } from "@mastra/core/agent";
+import { GEMINI_FLASH_LITE } from "~/lib/llm-models";
+
+const routerModelConfig = {
+  model: GEMINI_FLASH_LITE,
+  providerOptions: {
+    google: {
+      thinkingConfig: { thinkingLevel: "none" as const },
+      generationConfig: { temperature: 0 },
+    },
+  },
+};
+
+export const intentRouterAgent = new Agent({
+  id: "intent-router",
+  name: "Intent Router",
+  ...routerModelConfig,
+  instructions: `ユーザーのメッセージの意図を分類してください。
+
+- "casual": 挨拶、雑談、相槌、リアクション、感想、日常の報告など。情報検索が不要なもの
+- "normal": 簡単な質問、事実確認、天気、雑学など。軽い検索で済むもの
+- "thinking": 複雑な質問、詳細な情報要求、分析依頼、複数の情報源が必要なもの。深い思考やツール使い分けが必要`,
+});

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -2,11 +2,7 @@ import type { AgentConfig } from "@mastra/core/agent";
 import { Agent } from "@mastra/core/agent";
 import type { RequestContext } from "@mastra/core/request-context";
 import { getCurrentDateInfo } from "~/lib/date";
-import {
-  GEMINI_FLASH,
-  GEMINI_FLASH_LITE,
-  geminiModelWithThinking,
-} from "~/lib/llm-models";
+import { type ModelTierConfig, resolveModelTier } from "~/lib/llm-models";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
 import { emergencyReporterAgent } from "~/mastra/agents/emergency-reporter-agent";
 import { feedbackAgent } from "~/mastra/agents/feedback-agent";
@@ -187,13 +183,15 @@ const lineInstructions = `
 type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   isAdmin?: boolean;
   platform?: "web" | "line";
+  modelConfig: ModelTierConfig;
 };
 
 export const createNeppChanAgent = ({
   isAdmin = false,
   platform = "web",
+  modelConfig,
   ...agentOptions
-}: Props = {}) => {
+}: Props) => {
   const agents = isAdmin ? adminAgents : baseAgents;
   const tools = getTools(platform);
 
@@ -234,11 +232,7 @@ export const createNeppChanAgent = ({
     id: "nep-chan",
     name: "ねっぷちゃん",
     instructions,
-    ...geminiModelWithThinking(
-      platform === "web"
-        ? { model: GEMINI_FLASH, level: "high" }
-        : { model: GEMINI_FLASH_LITE, level: "medium" },
-    ),
+    ...modelConfig,
     agents,
     tools,
     memory: ({ requestContext }) =>
@@ -255,7 +249,12 @@ export const createNeppChanAgent = ({
   });
 };
 
-// Playground 用（管理者モード）
+// Playground 用（管理者モード・thinking ティア）
 export const neppChanAgent = createNeppChanAgent({
   isAdmin: true,
+  modelConfig: resolveModelTier({
+    intent: "thinking",
+    platform: "web",
+    isAdmin: true,
+  }),
 });

--- a/server/src/routes/chat.ts
+++ b/server/src/routes/chat.ts
@@ -2,7 +2,8 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { handleChatStream } from "@mastra/ai-sdk";
 import { Mastra } from "@mastra/core/mastra";
 import { createUIMessageStreamResponse, type UIMessage } from "ai";
-
+import { classifyIntent } from "~/lib/classify-intent";
+import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
@@ -18,6 +19,7 @@ const ChatSendRequestSchema = z.object({
   }),
   resourceId: z.string().min(1, "resourceId is required"),
   threadId: z.string().min(1, "threadId is required"),
+  intent: z.enum(["casual", "normal", "thinking"]).optional(),
 });
 
 export const chatRoutes = new OpenAPIHono<{
@@ -55,13 +57,34 @@ const chatRoute = createRoute({
 });
 
 chatRoutes.openapi(chatRoute, async (c) => {
-  const { message, resourceId, threadId } = c.req.valid("json");
+  const {
+    message,
+    resourceId,
+    threadId,
+    intent: fixedIntent,
+  } = c.req.valid("json");
   logger.info(`[Chat] request received`, { threadId, resourceId });
 
   const storage = await getStorage(c.env.DB);
   const adminUser = c.get("adminUser");
+  const isAdmin = !!adminUser;
 
-  const neppChanAgent = createNeppChanAgent({ isAdmin: !!adminUser });
+  // Intent 分類でモデルティアを決定（fixedIntent 指定時はルータースキップ）
+  const userText = (
+    message.parts.find((p) => p.type === "text") as
+      | { type: string; text: string }
+      | undefined
+  )?.text;
+  const intent =
+    fixedIntent ??
+    (isAdmin ? "thinking" : await classifyIntent(userText ?? ""));
+  const modelConfig = resolveModelTier({ intent, platform: "web", isAdmin });
+  logger.info(`[Chat] intent: ${intent}`, { threadId });
+
+  const neppChanAgent = createNeppChanAgent({
+    isAdmin,
+    modelConfig,
+  });
   const mastra = new Mastra({
     agents: { neppChanAgent },
     storage,

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -1,6 +1,7 @@
 import { messagingApi } from "@line/bot-sdk";
 import { Mastra } from "@mastra/core/mastra";
-
+import { classifyIntent } from "~/lib/classify-intent";
+import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { splitMessagesForLine } from "~/lib/split-message";
 import { getStorage } from "~/lib/storage";
@@ -25,7 +26,21 @@ export const generateReply = async (params: {
     env: params.env,
   });
 
-  const neppChanAgent = createNeppChanAgent({ platform: "line" });
+  // Intent 分類でモデルティアを決定（非テキストメッセージは normal 直行）
+  const intent = params.userMessage
+    ? await classifyIntent(params.userMessage)
+    : "normal";
+  const modelConfig = resolveModelTier({
+    intent,
+    platform: "line",
+    isAdmin: false,
+  });
+  logger.info(`[LINE] intent: ${intent}`, { threadId: params.threadId });
+
+  const neppChanAgent = createNeppChanAgent({
+    platform: "line",
+    modelConfig,
+  });
   const mastra = new Mastra({
     agents: { neppChanAgent },
     storage,

--- a/web/package.json
+++ b/web/package.json
@@ -31,7 +31,7 @@
     "lucide-react": "^0.562.0",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.4",
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0"

--- a/web/src/app/chat/AssistantProvider.tsx
+++ b/web/src/app/chat/AssistantProvider.tsx
@@ -48,11 +48,21 @@ export const AssistantProvider = ({
           },
           prepareSendMessagesRequest({ messages }) {
             const lastMessage = messages[messages.length - 1];
+            const lastText = lastMessage?.parts
+              ?.filter(
+                (p): p is { type: "text"; text: string } => p.type === "text",
+              )
+              .map((p) => p.text)
+              .join("");
+            const intent = GREETING_PROMPTS.includes(lastText ?? "")
+              ? "casual"
+              : undefined;
             return {
               body: {
                 message: lastMessage,
                 resourceId,
                 threadId,
+                intent,
               },
             };
           },


### PR DESCRIPTION
## Summary
- ユーザーメッセージの意図を casual/normal/thinking の3段階で分類する Intent ルーターエージェントを追加
- 分類結果 × プラットフォーム × 管理者フラグでメインエージェントのモデルティアを動的に決定
- フロントから intent を固定指定可能（挨拶プロンプトは casual 固定）
- react-dom のバージョン不一致を修正

## 主な変更内容

### Intent ルーター
- `intent-router-agent`: FLASH_LITE（thinkingLevel: none, temperature: 0）でメッセージを分類
- `classifyIntent()`: エージェント呼び出し + フォールバック（`lib/classify-intent.ts`）
- `resolveModelTier()`: Intent × platform × isAdmin → モデル設定を解決（`lib/llm-models.ts`）

### モデルティア

| Intent | Web | LINE |
|--------|-----|------|
| casual | FLASH_LITE + low | FLASH_LITE + low |
| normal | FLASH + medium | FLASH_LITE + medium |
| thinking | FLASH + high | FLASH + medium |
| Admin | 常に FLASH + high | - |

### ルール
- Admin → ルータースキップ、常に thinking
- LINE 非テキスト → ルータースキップ、normal
- LLM 分類失敗時 → normal フォールバック
- フロントから `intent` パラメータで固定指定可能

## Test plan
- [x] `resolveModelTier` の単体テスト（platform × intent × isAdmin 全組み合わせ）
- [ ] ローカル起動で挨拶 → casual ティアをログ確認
- [ ] 質問メッセージ → normal/thinking ティアをログ確認
- [ ] Admin ログイン時 → 常に thinking をログ確認