### PR TITLE
fix(agent): content セクションに名前禁止ルールを直接記載

### DIFF
--- a/server/src/mastra/agents/persona-agent.ts
+++ b/server/src/mastra/agents/persona-agent.ts
@@ -29,7 +29,8 @@ export const personaAgent = new Agent({
 - プロダクト: ねっぷちゃん自体への質問・要望・フィードバック
 
 ### content
-声の内容・文脈を記録する。話者の属性は content に書かず tags / demographicSummary に任せる。
+声の内容・文脈を記録する。名前・ニックネームは括弧書き含め一切書かない。
+話者の属性は content に書かず tags / demographicSummary に任せる。
 季節・時期・背景の文脈があれば積極的に含める。
 
 良い例:


### PR DESCRIPTION
## Summary
- content 生成時に匿名化セクションのルールが見落とされる問題への対策
- content ルール冒頭に名前・ニックネーム禁止を直接明記

## 主な変更内容
content セクションに「名前・ニックネームは括弧書き含め一切書かない」を追加。
匿名化セクションとの距離によるLLMの見落としを防止する。

## Test plan
- [ ] ペルソナ抽出で content に名前・ニックネームが括弧書き含め残らないことを確認