### PR TITLE
fix(auth): 管理者トークンの有効期限を8時間から7日に延長

### DIFF
--- a/server/src/services/auth/token.ts
+++ b/server/src/services/auth/token.ts
@@ -4,7 +4,7 @@ import type { AuthUser } from "~/schemas/auth-schema";
 
 const JWT_ISSUER = "nepp-chan";
 const JWT_AUDIENCE = "nepp-chan-admin";
-const ACCESS_TOKEN_EXPIRY_SECONDS = 8 * 60 * 60; // 8時間
+const ACCESS_TOKEN_EXPIRY_SECONDS = 7 * 24 * 60 * 60; // 7日
 
 type JwtPayload = JWTPayload &
   Omit<AuthUser, "id"> & {


### PR DESCRIPTION
## Summary
- 管理者モードの JWT アクセストークン有効期限を 8 時間から 7 日に延長

## 主な変更内容
`server/src/services/auth/token.ts` の `ACCESS_TOKEN_EXPIRY_SECONDS` を `8 * 60 * 60`（8時間）から `7 * 24 * 60 * 60`（7日）に変更。
管理画面利用時に頻繁な再ログインが不要になる。

## Test plan
- [x] ログイン後、管理者モードが有効になることを確認
- [x] トークンの有効期限が 7 日に設定されていることを確認（JWT デコードで検証）