### PR TITLE
feat: LINEアンケート機能の実装

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -64,6 +64,11 @@ server/src/
 | `/admin/broadcast/:id/send`        | POST     | 配信即時送信                   |
 | `/admin/broadcast/upload-image`    | POST     | 配信用画像アップロード         |
 | `/broadcast/media/:key`            | GET      | 配信画像取得                   |
+| `/admin/questionnaires`            | GET/POST | アンケート一覧・作成           |
+| `/admin/questionnaires/:id`        | GET/PUT/DELETE | アンケート詳細・更新・削除 |
+| `/admin/questionnaires/:id/send`   | POST     | アンケートLINE配信             |
+| `/admin/questionnaires/:id/results`| GET      | アンケート回答結果             |
+| `/admin/questionnaires/:id/close`  | POST     | アンケート締切                 |
 | `/admin/invitations`               | GET/POST | 招待一覧・作成                 |
 | `/admin/invitations/:id`           | DELETE   | 招待削除                       |
 | `/auth/register`                   | POST     | ユーザー登録（招待トークン+パスワード） |
@@ -308,6 +313,60 @@ throw new HTTPException(404, { message: "Not found" });
 | created_at    | TEXT | 作成日時（NOT NULL）                        |
 | updated_at    | TEXT | 更新日時                                    |
 
+### questionnaires
+
+| カラム        | 型      | 説明                                          |
+| ------------- | ------- | --------------------------------------------- |
+| id            | TEXT    | PRIMARY KEY                                   |
+| title         | TEXT    | タイトル（NOT NULL）                          |
+| description   | TEXT    | 説明                                          |
+| is_anonymous  | INTEGER | 無記名フラグ（1=無記名, 0=記名、NOT NULL）    |
+| status        | TEXT    | ステータス（draft/scheduled/sent/closed）     |
+| created_by    | TEXT    | 作成者 admin ID（NOT NULL）                   |
+| created_at    | TEXT    | 作成日時（NOT NULL）                          |
+| updated_at    | TEXT    | 更新日時                                      |
+| scheduled_at  | TEXT    | 予約配信日時                                  |
+| sent_at       | TEXT    | 配信日時                                      |
+| closed_at     | TEXT    | 締切日時                                      |
+
+### questionnaire_questions
+
+| カラム           | 型      | 説明                                              |
+| ---------------- | ------- | ------------------------------------------------- |
+| id               | TEXT    | PRIMARY KEY                                       |
+| questionnaire_id | TEXT    | アンケートID（NOT NULL）                          |
+| order            | INTEGER | 表示順（NOT NULL）                                |
+| text             | TEXT    | 質問文（NOT NULL）                                |
+| type             | TEXT    | 種別（single_choice/multiple_choice/free_text/rating） |
+| required         | INTEGER | 必須フラグ（1=必須, 0=任意、NOT NULL）            |
+| choices          | TEXT    | 選択肢（JSON配列）                                |
+| created_at       | TEXT    | 作成日時（NOT NULL）                              |
+
+### questionnaire_submissions
+
+| カラム                 | 型      | 説明                        |
+| ---------------------- | ------- | --------------------------- |
+| id                     | TEXT    | PRIMARY KEY                 |
+| questionnaire_id       | TEXT    | アンケートID（NOT NULL）    |
+| user_id                | TEXT    | LINE ユーザーID（NOT NULL） |
+| current_question_order | INTEGER | 現在の設問番号（NOT NULL）  |
+| completed_at           | TEXT    | 回答完了日時                |
+| created_at             | TEXT    | 作成日時（NOT NULL）        |
+
+UNIQUE INDEX: `(questionnaire_id, user_id)` で重複回答を防止
+
+### questionnaire_answers
+
+| カラム           | 型      | 説明                     |
+| ---------------- | ------- | ------------------------ |
+| id               | TEXT    | PRIMARY KEY              |
+| submission_id    | TEXT    | 提出ID（NOT NULL）       |
+| question_id      | TEXT    | 設問ID（NOT NULL）       |
+| answer_text      | TEXT    | 自由記述の回答           |
+| answer_number    | INTEGER | 評価の回答（1-5）        |
+| selected_choices | TEXT    | 選択肢の回答（JSON配列） |
+| created_at       | TEXT    | 作成日時（NOT NULL）     |
+
 ## Drizzle ORM
 
 ### スキーマ定義
@@ -416,8 +475,9 @@ thread_persona_status 更新
 
 | スケジュール   | ハンドラー           | 説明                          |
 | -------------- | -------------------- | ----------------------------- |
-| `*/5 * * * *`  | handleBroadcastCheck | 配信予約チェック（5分ごと）   |
-| `0 18 * * *`   | handlePersonaExtract | ペルソナ抽出（毎日03:00 JST） |
+| `*/5 * * * *`  | handleBroadcastCheck | 配信予約チェック（5分ごと）        |
+| `*/5 * * * *`  | handleQuestionnaireCheck | アンケート予約配信チェック（5分ごと） |
+| `0 18 * * *`   | handlePersonaExtract | ペルソナ抽出（毎日03:00 JST）      |
 
 ## デプロイ環境
 

--- a/server/src/db/migrations/0010_questionnaires.sql
+++ b/server/src/db/migrations/0010_questionnaires.sql
@@ -1,0 +1,44 @@
+CREATE TABLE `questionnaires` (
+	`id` text PRIMARY KEY NOT NULL,
+	`title` text NOT NULL,
+	`description` text,
+	`is_anonymous` integer DEFAULT 1 NOT NULL,
+	`status` text DEFAULT 'draft' NOT NULL,
+	`created_by` text NOT NULL,
+	`created_at` text NOT NULL,
+	`updated_at` text,
+	`sent_at` text,
+	`closed_at` text
+);
+
+CREATE TABLE `questionnaire_questions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`questionnaire_id` text NOT NULL,
+	`order` integer NOT NULL,
+	`text` text NOT NULL,
+	`type` text NOT NULL,
+	`required` integer DEFAULT 1 NOT NULL,
+	`choices` text,
+	`created_at` text NOT NULL
+);
+
+CREATE TABLE `questionnaire_submissions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`questionnaire_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`current_question_order` integer DEFAULT 1 NOT NULL,
+	`completed_at` text,
+	`created_at` text NOT NULL
+);
+
+CREATE UNIQUE INDEX `idx_submissions_unique` ON `questionnaire_submissions` (`questionnaire_id`, `user_id`);
+
+CREATE TABLE `questionnaire_answers` (
+	`id` text PRIMARY KEY NOT NULL,
+	`submission_id` text NOT NULL,
+	`question_id` text NOT NULL,
+	`answer_text` text,
+	`answer_number` integer,
+	`selected_choices` text,
+	`created_at` text NOT NULL
+);

--- a/server/src/db/migrations/0011_questionnaire_scheduled_at.sql
+++ b/server/src/db/migrations/0011_questionnaire_scheduled_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `questionnaires` ADD COLUMN `scheduled_at` text;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -115,3 +115,76 @@ export const broadcastMessages = sqliteTable("broadcast_messages", {
 
 export type BroadcastMessage = typeof broadcastMessages.$inferSelect;
 export type NewBroadcastMessage = typeof broadcastMessages.$inferInsert;
+
+// アンケート
+export const questionnaires = sqliteTable("questionnaires", {
+  id: text("id").primaryKey(),
+  title: text("title").notNull(),
+  description: text("description"),
+  isAnonymous: integer("is_anonymous").notNull().default(1), // 1=無記名, 0=記名
+  status: text("status")
+    .$type<"draft" | "scheduled" | "sent" | "closed">()
+    .notNull()
+    .default("draft"),
+  createdBy: text("created_by").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at"),
+  scheduledAt: text("scheduled_at"),
+  sentAt: text("sent_at"),
+  closedAt: text("closed_at"),
+});
+
+export type Questionnaire = typeof questionnaires.$inferSelect;
+export type NewQuestionnaire = typeof questionnaires.$inferInsert;
+
+// アンケート設問
+export const questionnaireQuestions = sqliteTable("questionnaire_questions", {
+  id: text("id").primaryKey(),
+  questionnaireId: text("questionnaire_id").notNull(),
+  order: integer("order").notNull(),
+  text: text("text").notNull(),
+  type: text("type")
+    .$type<"single_choice" | "multiple_choice" | "free_text" | "rating">()
+    .notNull(),
+  required: integer("required").notNull().default(1), // 1=必須, 0=任意
+  choices: text("choices"), // JSON: string[] (選択式の場合)
+  createdAt: text("created_at").notNull(),
+});
+
+export type QuestionnaireQuestion = typeof questionnaireQuestions.$inferSelect;
+export type NewQuestionnaireQuestion =
+  typeof questionnaireQuestions.$inferInsert;
+
+// アンケート提出（ユーザーごとの重複防止）
+export const questionnaireSubmissions = sqliteTable(
+  "questionnaire_submissions",
+  {
+    id: text("id").primaryKey(),
+    questionnaireId: text("questionnaire_id").notNull(),
+    userId: text("user_id").notNull(),
+    currentQuestionOrder: integer("current_question_order")
+      .notNull()
+      .default(1),
+    completedAt: text("completed_at"),
+    createdAt: text("created_at").notNull(),
+  },
+);
+
+export type QuestionnaireSubmission =
+  typeof questionnaireSubmissions.$inferSelect;
+export type NewQuestionnaireSubmission =
+  typeof questionnaireSubmissions.$inferInsert;
+
+// アンケート回答
+export const questionnaireAnswers = sqliteTable("questionnaire_answers", {
+  id: text("id").primaryKey(),
+  submissionId: text("submission_id").notNull(),
+  questionId: text("question_id").notNull(),
+  answerText: text("answer_text"), // free_text の回答
+  answerNumber: integer("answer_number"), // rating の回答
+  selectedChoices: text("selected_choices"), // JSON: string[] (選択式の回答)
+  createdAt: text("created_at").notNull(),
+});
+
+export type QuestionnaireAnswer = typeof questionnaireAnswers.$inferSelect;
+export type NewQuestionnaireAnswer = typeof questionnaireAnswers.$inferInsert;

--- a/server/src/handlers/questionnaire-handler.ts
+++ b/server/src/handlers/questionnaire-handler.ts
@@ -1,0 +1,30 @@
+import { logger } from "~/lib/logger";
+import { questionnaireRepository } from "~/repository/questionnaire-repository";
+import { sendQuestionnaire } from "~/services/questionnaire-delivery";
+
+export const handleQuestionnaireCheck: ExportedHandlerScheduledHandler<
+  CloudflareBindings
+> = async (_event, env, _ctx) => {
+  const ready = await questionnaireRepository.findScheduledReady(env.DB);
+
+  if (ready.length === 0) {
+    return;
+  }
+
+  logger.info(
+    `[Questionnaire] Found ${ready.length} scheduled questionnaire(s) to send`,
+  );
+
+  for (const questionnaire of ready) {
+    const result = await sendQuestionnaire(env, questionnaire.id);
+    if (result.success) {
+      logger.info(
+        `[Questionnaire] Sent: ${questionnaire.id} "${questionnaire.title}"`,
+      );
+    } else {
+      logger.error(
+        `[Questionnaire] Failed: ${questionnaire.id} "${questionnaire.title}" - ${result.error}`,
+      );
+    }
+  }
+};

--- a/server/src/handlers/scheduled-handler.ts
+++ b/server/src/handlers/scheduled-handler.ts
@@ -1,12 +1,15 @@
 import { handleBroadcastCheck } from "~/handlers/broadcast-handler";
 import { handlePersonaExtract } from "~/handlers/persona-extract-handler";
+import { handleQuestionnaireCheck } from "~/handlers/questionnaire-handler";
 
 export const handleScheduled: ExportedHandlerScheduledHandler<
   CloudflareBindings
 > = async (event, env, ctx) => {
   switch (event.cron) {
     case "*/5 * * * *":
-      return handleBroadcastCheck(event, env, ctx);
+      await handleBroadcastCheck(event, env, ctx);
+      await handleQuestionnaireCheck(event, env, ctx);
+      return;
     case "0 18 * * *":
       return handlePersonaExtract(event, env, ctx);
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,7 @@ import {
   knowledgeAdminRoutes,
   lineRoutes,
   personaAdminRoutes,
+  questionnaireAdminRoutes,
   threadsRoutes,
 } from "~/routes";
 import type { LineEventMessage } from "~/schemas/line-schema";
@@ -47,6 +48,7 @@ app.route("/admin/knowledge", knowledgeAdminRoutes);
 app.route("/admin/persona", personaAdminRoutes);
 app.route("/admin/emergency", emergencyAdminRoutes);
 app.route("/admin/invitations", invitationRoutes);
+app.route("/admin/questionnaires", questionnaireAdminRoutes);
 app.route("/auth", authRoutes);
 app.route("/line", lineRoutes);
 

--- a/server/src/repository/questionnaire-repository.ts
+++ b/server/src/repository/questionnaire-repository.ts
@@ -1,0 +1,311 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+
+import {
+  createDb,
+  type Questionnaire,
+  type QuestionnaireAnswer,
+  type QuestionnaireQuestion,
+  type QuestionnaireSubmission,
+  questionnaireAnswers,
+  questionnaireQuestions,
+  questionnaireSubmissions,
+  questionnaires,
+} from "~/db";
+
+type QuestionnaireStatus = Questionnaire["status"];
+type QuestionTypeValue = QuestionnaireQuestion["type"];
+
+type CreateQuestionnaireInput = {
+  id: string;
+  title: string;
+  description?: string | null;
+  isAnonymous: number;
+  status: QuestionnaireStatus;
+  createdBy: string;
+  createdAt: string;
+};
+
+type CreateQuestionInput = {
+  id: string;
+  questionnaireId: string;
+  order: number;
+  text: string;
+  type: QuestionTypeValue;
+  required: number;
+  choices?: string | null;
+  createdAt: string;
+};
+
+type ListOptions = {
+  limit?: number;
+  cursor?: string;
+  status?: QuestionnaireStatus;
+};
+
+export const questionnaireRepository = {
+  // --- Questionnaire CRUD ---
+
+  async create(d1: D1Database, input: CreateQuestionnaireInput) {
+    const db = createDb(d1);
+    await db.insert(questionnaires).values({
+      id: input.id,
+      title: input.title,
+      description: input.description ?? null,
+      isAnonymous: input.isAnonymous,
+      status: input.status,
+      createdBy: input.createdBy,
+      createdAt: input.createdAt,
+    });
+    return input.id;
+  },
+
+  async update(
+    d1: D1Database,
+    id: string,
+    input: Partial<{
+      title: string;
+      description: string | null;
+      isAnonymous: number;
+      status: QuestionnaireStatus;
+      scheduledAt: string | null;
+      sentAt: string | null;
+      closedAt: string | null;
+    }>,
+  ) {
+    const db = createDb(d1);
+    await db
+      .update(questionnaires)
+      .set({ ...input, updatedAt: new Date().toISOString() })
+      .where(eq(questionnaires.id, id));
+  },
+
+  async findById(d1: D1Database, id: string) {
+    const db = createDb(d1);
+    return (
+      (await db
+        .select()
+        .from(questionnaires)
+        .where(eq(questionnaires.id, id))
+        .get()) ?? null
+    );
+  },
+
+  async findAll(d1: D1Database, options: ListOptions = {}) {
+    const db = createDb(d1);
+    const limit = options.limit ?? 30;
+
+    const conditions = [];
+    if (options.status) {
+      conditions.push(eq(questionnaires.status, options.status));
+    }
+    if (options.cursor) {
+      conditions.push(sql`${questionnaires.createdAt} < ${options.cursor}`);
+    }
+
+    const items = await db
+      .select()
+      .from(questionnaires)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(desc(questionnaires.createdAt))
+      .limit(limit + 1)
+      .all();
+
+    const hasMore = items.length > limit;
+    const result = hasMore ? items.slice(0, limit) : items;
+    const nextCursor = hasMore ? result[result.length - 1]?.createdAt : null;
+
+    return { questionnaires: result, nextCursor, hasMore };
+  },
+
+  async delete(d1: D1Database, id: string) {
+    const db = createDb(d1);
+    await db
+      .delete(questionnaireAnswers)
+      .where(
+        sql`${questionnaireAnswers.submissionId} IN (SELECT id FROM questionnaire_submissions WHERE questionnaire_id = ${id})`,
+      );
+    await db
+      .delete(questionnaireSubmissions)
+      .where(eq(questionnaireSubmissions.questionnaireId, id));
+    await db
+      .delete(questionnaireQuestions)
+      .where(eq(questionnaireQuestions.questionnaireId, id));
+    await db.delete(questionnaires).where(eq(questionnaires.id, id));
+  },
+
+  async count(d1: D1Database, status?: QuestionnaireStatus) {
+    const db = createDb(d1);
+    const result = await db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(questionnaires)
+      .where(status ? eq(questionnaires.status, status) : undefined)
+      .get();
+    return result?.count ?? 0;
+  },
+
+  async findScheduledReady(d1: D1Database) {
+    const db = createDb(d1);
+    const now = new Date().toISOString();
+    return db
+      .select()
+      .from(questionnaires)
+      .where(
+        and(
+          eq(questionnaires.status, "scheduled"),
+          sql`${questionnaires.scheduledAt} <= ${now}`,
+        ),
+      )
+      .all();
+  },
+
+  // --- Questions ---
+
+  async createQuestions(d1: D1Database, inputs: CreateQuestionInput[]) {
+    const db = createDb(d1);
+    if (inputs.length === 0) return;
+    await db.insert(questionnaireQuestions).values(inputs);
+  },
+
+  async findQuestionsByQuestionnaireId(
+    d1: D1Database,
+    questionnaireId: string,
+  ) {
+    const db = createDb(d1);
+    return db
+      .select()
+      .from(questionnaireQuestions)
+      .where(eq(questionnaireQuestions.questionnaireId, questionnaireId))
+      .orderBy(questionnaireQuestions.order)
+      .all();
+  },
+
+  async deleteQuestionsByQuestionnaireId(
+    d1: D1Database,
+    questionnaireId: string,
+  ) {
+    const db = createDb(d1);
+    await db
+      .delete(questionnaireQuestions)
+      .where(eq(questionnaireQuestions.questionnaireId, questionnaireId));
+  },
+
+  // --- Submissions ---
+
+  async findSubmission(
+    d1: D1Database,
+    questionnaireId: string,
+    userId: string,
+  ) {
+    const db = createDb(d1);
+    return (
+      (await db
+        .select()
+        .from(questionnaireSubmissions)
+        .where(
+          and(
+            eq(questionnaireSubmissions.questionnaireId, questionnaireId),
+            eq(questionnaireSubmissions.userId, userId),
+          ),
+        )
+        .get()) ?? null
+    );
+  },
+
+  async createSubmission(
+    d1: D1Database,
+    input: {
+      id: string;
+      questionnaireId: string;
+      userId: string;
+      currentQuestionOrder: number;
+      createdAt: string;
+    },
+  ) {
+    const db = createDb(d1);
+    await db.insert(questionnaireSubmissions).values(input);
+    return input.id;
+  },
+
+  async updateSubmission(
+    d1: D1Database,
+    id: string,
+    input: Partial<{
+      currentQuestionOrder: number;
+      completedAt: string | null;
+    }>,
+  ) {
+    const db = createDb(d1);
+    await db
+      .update(questionnaireSubmissions)
+      .set(input)
+      .where(eq(questionnaireSubmissions.id, id));
+  },
+
+  async countSubmissions(d1: D1Database, questionnaireId: string) {
+    const db = createDb(d1);
+    const total = await db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(questionnaireSubmissions)
+      .where(eq(questionnaireSubmissions.questionnaireId, questionnaireId))
+      .get();
+
+    const completed = await db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(questionnaireSubmissions)
+      .where(
+        and(
+          eq(questionnaireSubmissions.questionnaireId, questionnaireId),
+          sql`${questionnaireSubmissions.completedAt} IS NOT NULL`,
+        ),
+      )
+      .get();
+
+    return {
+      total: total?.count ?? 0,
+      completed: completed?.count ?? 0,
+    };
+  },
+
+  // --- Answers ---
+
+  async createAnswer(
+    d1: D1Database,
+    input: {
+      id: string;
+      submissionId: string;
+      questionId: string;
+      answerText?: string | null;
+      answerNumber?: number | null;
+      selectedChoices?: string | null;
+      createdAt: string;
+    },
+  ) {
+    const db = createDb(d1);
+    await db.insert(questionnaireAnswers).values(input);
+  },
+
+  async findAnswersByQuestionId(d1: D1Database, questionId: string) {
+    const db = createDb(d1);
+    return db
+      .select()
+      .from(questionnaireAnswers)
+      .where(eq(questionnaireAnswers.questionId, questionId))
+      .all();
+  },
+
+  async findAnswersBySubmissionId(d1: D1Database, submissionId: string) {
+    const db = createDb(d1);
+    return db
+      .select()
+      .from(questionnaireAnswers)
+      .where(eq(questionnaireAnswers.submissionId, submissionId))
+      .all();
+  },
+};
+
+export type {
+  Questionnaire,
+  QuestionnaireAnswer,
+  QuestionnaireQuestion,
+  QuestionnaireSubmission,
+};

--- a/server/src/routes/admin/index.ts
+++ b/server/src/routes/admin/index.ts
@@ -4,3 +4,4 @@ export { feedbackAdminRoutes } from "./feedback";
 export { invitationRoutes } from "./invitations";
 export { knowledgeAdminRoutes } from "./knowledge";
 export { personaAdminRoutes } from "./persona";
+export { questionnaireAdminRoutes } from "./questionnaire";

--- a/server/src/routes/admin/questionnaire.ts
+++ b/server/src/routes/admin/questionnaire.ts
@@ -1,0 +1,425 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+
+import { errorResponse } from "~/lib/openapi-errors";
+import { type AuthVariables, requireAuth } from "~/middleware/auth";
+import { questionnaireRepository } from "~/repository/questionnaire-repository";
+import {
+  createQuestionnaireSchema,
+  questionnaireResponseSchema,
+  questionnaireResultsSchema,
+  questionnaireStatusSchema,
+  updateQuestionnaireSchema,
+} from "~/schemas/questionnaire-schema";
+import {
+  createQuestionnaire,
+  getQuestionnaireWithQuestions,
+  updateQuestionnaire,
+} from "~/services/questionnaire";
+import { sendQuestionnaire } from "~/services/questionnaire-delivery";
+import { getQuestionnaireResults } from "~/services/questionnaire-response";
+
+export const questionnaireAdminRoutes = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: AuthVariables;
+}>();
+
+questionnaireAdminRoutes.use("*", requireAuth);
+
+// --- 一覧取得 ---
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  summary: "アンケート一覧を取得",
+  description: "アンケートの一覧を取得します",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    query: z.object({
+      limit: z.coerce.number().int().min(1).optional().default(30),
+      cursor: z.string().optional(),
+      status: questionnaireStatusSchema.optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": {
+          schema: z.object({
+            questionnaires: z.array(questionnaireResponseSchema),
+            total: z.number(),
+            nextCursor: z.string().nullable(),
+            hasMore: z.boolean(),
+          }),
+        },
+      },
+    },
+    401: errorResponse(401),
+  },
+});
+
+questionnaireAdminRoutes.openapi(listRoute, async (c) => {
+  const { limit, cursor, status } = c.req.valid("query");
+
+  const result = await questionnaireRepository.findAll(c.env.DB, {
+    limit,
+    cursor: cursor ?? undefined,
+    status: status ?? undefined,
+  });
+  const total = await questionnaireRepository.count(c.env.DB);
+
+  // 各アンケートに設問を付与
+  const withQuestions = (
+    await Promise.all(
+      result.questionnaires.map((q) =>
+        getQuestionnaireWithQuestions(c.env.DB, q.id),
+      ),
+    )
+  ).filter((q) => q !== null);
+
+  return c.json(
+    {
+      questionnaires: withQuestions,
+      total,
+      nextCursor: result.nextCursor,
+      hasMore: result.hasMore,
+    },
+    200,
+  );
+});
+
+// --- 作成 ---
+
+const createRoute_ = createRoute({
+  method: "post",
+  path: "/",
+  summary: "アンケートを作成",
+  description: "アンケートを作成します",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: createQuestionnaireSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    201: {
+      description: "作成成功",
+      content: {
+        "application/json": {
+          schema: questionnaireResponseSchema,
+        },
+      },
+    },
+    401: errorResponse(401),
+  },
+});
+
+questionnaireAdminRoutes.openapi(createRoute_, async (c) => {
+  const body = c.req.valid("json");
+  const adminUser = c.get("adminUser");
+
+  try {
+    const questionnaire = await createQuestionnaire(c.env, {
+      ...body,
+      createdBy: adminUser.id,
+    });
+
+    if (!questionnaire) {
+      throw new HTTPException(500, {
+        message: "アンケートの作成に失敗しました",
+      });
+    }
+
+    return c.json(questionnaire, 201);
+  } catch (error) {
+    throw new HTTPException(500, {
+      message: `アンケートの作成に失敗しました: ${error instanceof Error ? error.message : "Unknown error"}`,
+    });
+  }
+});
+
+// --- 詳細取得 ---
+
+const getDetailRoute = createRoute({
+  method: "get",
+  path: "/{id}",
+  summary: "アンケート詳細を取得",
+  description: "アンケートの詳細情報を取得します",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": {
+          schema: questionnaireResponseSchema,
+        },
+      },
+    },
+    401: errorResponse(401),
+    404: errorResponse(404),
+  },
+});
+
+questionnaireAdminRoutes.openapi(getDetailRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const questionnaire = await getQuestionnaireWithQuestions(c.env.DB, id);
+
+  if (!questionnaire) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+
+  return c.json(questionnaire, 200);
+});
+
+// --- 更新 ---
+
+const updateRoute = createRoute({
+  method: "put",
+  path: "/{id}",
+  summary: "アンケートを更新",
+  description: "アンケートを更新します（draftのみ）",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+    body: {
+      content: {
+        "application/json": {
+          schema: updateQuestionnaireSchema,
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: {
+        "application/json": {
+          schema: questionnaireResponseSchema,
+        },
+      },
+    },
+    400: errorResponse(400),
+    401: errorResponse(401),
+    404: errorResponse(404),
+  },
+});
+
+questionnaireAdminRoutes.openapi(updateRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const body = c.req.valid("json");
+
+  const existing = await questionnaireRepository.findById(c.env.DB, id);
+  if (!existing) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+  if (existing.status !== "draft") {
+    throw new HTTPException(400, {
+      message: "下書き状態のアンケートのみ更新できます",
+    });
+  }
+
+  const updated = await updateQuestionnaire(c.env.DB, id, body);
+
+  if (!updated) {
+    throw new HTTPException(500, { message: "アンケートの更新に失敗しました" });
+  }
+
+  return c.json(updated, 200);
+});
+
+// --- 削除 ---
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  summary: "アンケートを削除",
+  description: "アンケートを削除します（draftのみ）",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "削除成功",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string() }),
+        },
+      },
+    },
+    400: errorResponse(400),
+    401: errorResponse(401),
+    404: errorResponse(404),
+  },
+});
+
+questionnaireAdminRoutes.openapi(deleteRoute, async (c) => {
+  const { id } = c.req.valid("param");
+
+  const existing = await questionnaireRepository.findById(c.env.DB, id);
+  if (!existing) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+  if (existing.status !== "draft" && existing.status !== "scheduled") {
+    throw new HTTPException(400, {
+      message: "下書きまたは予約済みのアンケートのみ削除できます",
+    });
+  }
+
+  await questionnaireRepository.delete(c.env.DB, id);
+  return c.json({ message: "アンケートを削除しました" }, 200);
+});
+
+// --- LINE配信 ---
+
+const sendRoute = createRoute({
+  method: "post",
+  path: "/{id}/send",
+  summary: "アンケートをLINEに配信",
+  description: "アンケートをLINE全ユーザーに配信します",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "配信成功",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string() }),
+        },
+      },
+    },
+    400: errorResponse(400),
+    401: errorResponse(401),
+    404: errorResponse(404),
+    500: errorResponse(500),
+  },
+});
+
+questionnaireAdminRoutes.openapi(sendRoute, async (c) => {
+  const { id } = c.req.valid("param");
+
+  const result = await sendQuestionnaire(c.env, id);
+  if (!result.success) {
+    const status = result.error?.includes("見つかりません") ? 404 : 400;
+    throw new HTTPException(status, {
+      message: result.error ?? "配信に失敗しました",
+    });
+  }
+
+  return c.json({ message: "アンケートを配信しました" }, 200);
+});
+
+// --- 結果取得 ---
+
+const resultsRoute = createRoute({
+  method: "get",
+  path: "/{id}/results",
+  summary: "アンケート結果を取得",
+  description: "アンケートの回答結果を集計して取得します",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": {
+          schema: questionnaireResultsSchema,
+        },
+      },
+    },
+    401: errorResponse(401),
+    404: errorResponse(404),
+  },
+});
+
+questionnaireAdminRoutes.openapi(resultsRoute, async (c) => {
+  const { id } = c.req.valid("param");
+
+  const results = await getQuestionnaireResults(c.env.DB, id);
+  if (!results) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+
+  return c.json(results, 200);
+});
+
+// --- 締切 ---
+
+const closeRoute = createRoute({
+  method: "post",
+  path: "/{id}/close",
+  summary: "アンケートを締切",
+  description: "アンケートの回答受付を締め切ります",
+  tags: ["Admin - Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "締切成功",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string() }),
+        },
+      },
+    },
+    400: errorResponse(400),
+    401: errorResponse(401),
+    404: errorResponse(404),
+  },
+});
+
+questionnaireAdminRoutes.openapi(closeRoute, async (c) => {
+  const { id } = c.req.valid("param");
+
+  const existing = await questionnaireRepository.findById(c.env.DB, id);
+  if (!existing) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+  if (existing.status !== "sent") {
+    throw new HTTPException(400, {
+      message: "配信済みのアンケートのみ締切できます",
+    });
+  }
+
+  await questionnaireRepository.update(c.env.DB, id, {
+    status: "closed",
+    closedAt: new Date().toISOString(),
+  });
+
+  return c.json({ message: "アンケートを締め切りました" }, 200);
+});

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -5,6 +5,7 @@ export {
   invitationRoutes,
   knowledgeAdminRoutes,
   personaAdminRoutes,
+  questionnaireAdminRoutes,
 } from "./admin";
 export { authRoutes } from "./auth";
 export { broadcastMediaRoutes } from "./broadcast-media";

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -4,6 +4,7 @@ import type { WebhookEvent, WebhookRequestBody } from "@line/bot-sdk";
 import { logger } from "~/lib/logger";
 import { lineSignatureVerify } from "~/middleware";
 import type { LineEventMessage } from "~/schemas/line-schema";
+import { handleQuestionnairePostback } from "~/services/questionnaire-response";
 
 export const lineRoutes = new OpenAPIHono<{
   Bindings: CloudflareBindings;
@@ -31,6 +32,25 @@ const enqueueLineEvents = async (
   env: CloudflareBindings,
 ) => {
   for (const event of events) {
+    // Postback イベント（アンケート回答）
+    if (event.type === "postback") {
+      if (!event.source.userId || !event.replyToken) continue;
+      if (!event.postback.data.startsWith("qnr=")) continue;
+
+      try {
+        await handleQuestionnairePostback(
+          env,
+          event.source.userId,
+          event.postback.data,
+          event.replyToken,
+        );
+      } catch (error) {
+        logger.error("[LINE] Questionnaire postback error", error);
+      }
+      continue;
+    }
+
+    // Message イベント（既存のチャット処理）
     if (event.type !== "message" || event.message.type !== "text") continue;
     if (!("replyToken" in event) || !event.replyToken) continue;
     if (!event.source.userId) continue;

--- a/server/src/schemas/questionnaire-schema.ts
+++ b/server/src/schemas/questionnaire-schema.ts
@@ -1,0 +1,99 @@
+import { z } from "zod";
+
+export const questionTypeSchema = z.enum([
+  "single_choice",
+  "multiple_choice",
+  "free_text",
+  "rating",
+]);
+
+export type QuestionType = z.infer<typeof questionTypeSchema>;
+
+export const questionnaireStatusSchema = z.enum([
+  "draft",
+  "scheduled",
+  "sent",
+  "closed",
+]);
+
+export type QuestionnaireStatus = z.infer<typeof questionnaireStatusSchema>;
+
+// 設問定義（作成/更新用）
+export const questionInputSchema = z.object({
+  text: z.string().min(1).max(500),
+  type: questionTypeSchema,
+  required: z.boolean().optional().default(true),
+  choices: z.array(z.string().min(1).max(100)).optional(),
+});
+
+export type QuestionInput = z.infer<typeof questionInputSchema>;
+
+// アンケート作成
+export const createQuestionnaireSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().max(1000).optional(),
+  isAnonymous: z.boolean().optional().default(true),
+  questions: z.array(questionInputSchema).min(1).max(20),
+  scheduledAt: z.string().datetime().optional(),
+  sendNow: z.boolean().optional(),
+});
+
+// アンケート更新
+export const updateQuestionnaireSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(1000).nullable().optional(),
+  isAnonymous: z.boolean().optional(),
+  questions: z.array(questionInputSchema).min(1).max(20).optional(),
+});
+
+// レスポンス用
+export const questionResponseSchema = z.object({
+  id: z.string(),
+  questionnaireId: z.string(),
+  order: z.number(),
+  text: z.string(),
+  type: questionTypeSchema,
+  required: z.boolean(),
+  choices: z.array(z.string()).nullable(),
+});
+
+export const questionnaireResponseSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  isAnonymous: z.boolean(),
+  status: questionnaireStatusSchema,
+  questions: z.array(questionResponseSchema),
+  createdBy: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string().nullable(),
+  scheduledAt: z.string().nullable(),
+  sentAt: z.string().nullable(),
+  closedAt: z.string().nullable(),
+});
+
+// 集計結果
+export const choiceResultSchema = z.object({
+  choice: z.string(),
+  count: z.number(),
+  percentage: z.number(),
+});
+
+export const questionResultSchema = z.object({
+  questionId: z.string(),
+  questionText: z.string(),
+  questionType: questionTypeSchema,
+  totalResponses: z.number(),
+  choiceResults: z.array(choiceResultSchema).optional(),
+  averageRating: z.number().optional(),
+  ratingDistribution: z.record(z.string(), z.number()).optional(),
+  freeTextAnswers: z.array(z.string()).optional(),
+});
+
+export const questionnaireResultsSchema = z.object({
+  questionnaireId: z.string(),
+  title: z.string(),
+  totalSubmissions: z.number(),
+  completedSubmissions: z.number(),
+  questionResults: z.array(questionResultSchema),
+});

--- a/server/src/services/questionnaire-delivery.ts
+++ b/server/src/services/questionnaire-delivery.ts
@@ -1,0 +1,204 @@
+import type { messagingApi } from "@line/bot-sdk";
+
+import { logger } from "~/lib/logger";
+import {
+  type Questionnaire,
+  type QuestionnaireQuestion,
+  questionnaireRepository,
+} from "~/repository/questionnaire-repository";
+import { createLineClient } from "~/services/line-messaging";
+
+// --- LINE配信 ---
+
+export const sendQuestionnaire = async (
+  env: CloudflareBindings,
+  questionnaireId: string,
+): Promise<{ success: boolean; error?: string }> => {
+  const questionnaire = await questionnaireRepository.findById(
+    env.DB,
+    questionnaireId,
+  );
+  if (!questionnaire) {
+    return { success: false, error: "アンケートが見つかりません" };
+  }
+  if (questionnaire.status === "sent") {
+    return { success: false, error: "既に配信済みです" };
+  }
+  if (questionnaire.status === "closed") {
+    return { success: false, error: "締切済みのアンケートは配信できません" };
+  }
+
+  const questions =
+    await questionnaireRepository.findQuestionsByQuestionnaireId(
+      env.DB,
+      questionnaireId,
+    );
+  if (questions.length === 0) {
+    return { success: false, error: "設問がありません" };
+  }
+
+  try {
+    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+    const retryKey = crypto.randomUUID();
+    const firstQuestion = questions[0];
+    const message = buildQuestionFlexMessage(
+      questionnaire,
+      firstQuestion,
+      1,
+      questions.length,
+    );
+
+    await client.broadcast({ messages: [message] }, retryKey);
+
+    await questionnaireRepository.update(env.DB, questionnaireId, {
+      status: "sent",
+      sentAt: new Date().toISOString(),
+    });
+
+    logger.info(`[Questionnaire] Sent successfully: ${questionnaireId}`);
+    return { success: true };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    logger.error(`[Questionnaire] Failed to send: ${questionnaireId}`, error);
+    return { success: false, error: errorMessage };
+  }
+};
+
+// --- Flex Message生成 ---
+
+export const buildQuestionFlexMessage = (
+  questionnaire: Questionnaire,
+  question: QuestionnaireQuestion,
+  currentOrder: number,
+  totalQuestions: number,
+): messagingApi.FlexMessage => {
+  const choices = question.choices
+    ? (JSON.parse(question.choices) as string[])
+    : [];
+
+  const bodyContents: messagingApi.FlexComponent[] = [
+    {
+      type: "text",
+      text: questionnaire.title,
+      weight: "bold",
+      size: "sm",
+      color: "#1DB446",
+    },
+    {
+      type: "text",
+      text: `Q${currentOrder}/${totalQuestions}`,
+      size: "xs",
+      color: "#aaaaaa",
+      margin: "md",
+    },
+    {
+      type: "text",
+      text: question.text,
+      weight: "bold",
+      size: "md",
+      wrap: true,
+      margin: "md",
+    },
+  ];
+
+  let footerContents: messagingApi.FlexComponent[];
+
+  switch (question.type) {
+    case "single_choice":
+    case "multiple_choice":
+      footerContents = choices.map((choice) => ({
+        type: "button" as const,
+        action: {
+          type: "postback" as const,
+          label: choice.slice(0, 20),
+          data: `qnr=${questionnaire.id}&qid=${question.id}&ans=${encodeURIComponent(choice)}`,
+          displayText: choice,
+        },
+        style: "primary" as const,
+        color: "#4A90D9",
+        margin: "sm" as const,
+        height: "sm" as const,
+      }));
+      break;
+    case "rating":
+      footerContents = [
+        {
+          type: "box" as const,
+          layout: "horizontal" as const,
+          spacing: "sm" as const,
+          contents: [1, 2, 3, 4, 5].map((n) => ({
+            type: "button" as const,
+            action: {
+              type: "postback" as const,
+              label: String(n),
+              data: `qnr=${questionnaire.id}&qid=${question.id}&ans=${n}`,
+              displayText: `${n}`,
+            },
+            style: "primary" as const,
+            color: "#4A90D9",
+            height: "sm" as const,
+            flex: 1,
+          })),
+        },
+        {
+          type: "box" as const,
+          layout: "horizontal" as const,
+          margin: "xs" as const,
+          contents: [
+            {
+              type: "text" as const,
+              text: "低い",
+              size: "xxs" as const,
+              color: "#aaaaaa",
+              align: "start" as const,
+            },
+            {
+              type: "text" as const,
+              text: "高い",
+              size: "xxs" as const,
+              color: "#aaaaaa",
+              align: "end" as const,
+            },
+          ],
+        },
+      ];
+      break;
+    case "free_text":
+      bodyContents.push({
+        type: "text",
+        text: "テキストで回答を入力してください",
+        size: "xs",
+        color: "#888888",
+        margin: "md",
+        wrap: true,
+      });
+      footerContents = [];
+      break;
+    default:
+      footerContents = [];
+  }
+
+  const bubble: messagingApi.FlexBubble = {
+    type: "bubble",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: bodyContents,
+    },
+    ...(footerContents.length > 0 && {
+      footer: {
+        type: "box",
+        layout: "vertical",
+        spacing: "sm",
+        contents: footerContents,
+      },
+    }),
+  };
+
+  return {
+    type: "flex",
+    altText: `アンケート: ${questionnaire.title} (Q${currentOrder}/${totalQuestions})`,
+    contents: bubble,
+  };
+};

--- a/server/src/services/questionnaire-response.ts
+++ b/server/src/services/questionnaire-response.ts
@@ -1,0 +1,276 @@
+import {
+  type QuestionnaireQuestion,
+  questionnaireRepository,
+} from "~/repository/questionnaire-repository";
+import { createLineClient } from "~/services/line-messaging";
+import { buildQuestionFlexMessage } from "~/services/questionnaire-delivery";
+
+// --- Postback回答処理 ---
+
+export const handleQuestionnairePostback = async (
+  env: CloudflareBindings,
+  userId: string,
+  data: string,
+  replyToken: string,
+) => {
+  const params = new URLSearchParams(data);
+  const questionnaireId = params.get("qnr");
+  const questionId = params.get("qid");
+  const answer = params.get("ans");
+
+  if (!questionnaireId || !questionId || answer === null) return;
+
+  const questionnaire = await questionnaireRepository.findById(
+    env.DB,
+    questionnaireId,
+  );
+  if (!questionnaire || questionnaire.status !== "sent") return;
+
+  const questions =
+    await questionnaireRepository.findQuestionsByQuestionnaireId(
+      env.DB,
+      questionnaireId,
+    );
+  const question = questions.find((q) => q.id === questionId);
+  if (!question) return;
+
+  // 提出を取得 or 作成
+  let submission = await questionnaireRepository.findSubmission(
+    env.DB,
+    questionnaireId,
+    userId,
+  );
+
+  if (submission?.completedAt) {
+    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+    await client.replyMessage({
+      replyToken,
+      messages: [
+        {
+          type: "text",
+          text: "このアンケートには既に回答済みです。ありがとうございます！",
+        },
+      ],
+    });
+    return;
+  }
+
+  const now = new Date().toISOString();
+
+  if (!submission) {
+    submission = {
+      id: crypto.randomUUID(),
+      questionnaireId,
+      userId,
+      currentQuestionOrder: question.order,
+      completedAt: null,
+      createdAt: now,
+    };
+    await questionnaireRepository.createSubmission(env.DB, {
+      id: submission.id,
+      questionnaireId,
+      userId,
+      currentQuestionOrder: question.order,
+      createdAt: now,
+    });
+  }
+
+  // 回答を保存
+  const answerData = buildAnswerData(question, answer);
+  await questionnaireRepository.createAnswer(env.DB, {
+    id: crypto.randomUUID(),
+    submissionId: submission.id,
+    questionId,
+    ...answerData,
+    createdAt: now,
+  });
+
+  const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+
+  // 次の質問を送信 or 完了
+  const nextQuestion = questions.find((q) => q.order === question.order + 1);
+
+  if (nextQuestion) {
+    await questionnaireRepository.updateSubmission(env.DB, submission.id, {
+      currentQuestionOrder: nextQuestion.order,
+    });
+
+    const message = buildQuestionFlexMessage(
+      questionnaire,
+      nextQuestion,
+      nextQuestion.order,
+      questions.length,
+    );
+
+    try {
+      await client.replyMessage({ replyToken, messages: [message] });
+    } catch {
+      await client.pushMessage({
+        to: userId,
+        messages: [message],
+      });
+    }
+  } else {
+    // 全問回答完了
+    await questionnaireRepository.updateSubmission(env.DB, submission.id, {
+      completedAt: now,
+    });
+
+    try {
+      await client.replyMessage({
+        replyToken,
+        messages: [
+          {
+            type: "text",
+            text: `「${questionnaire.title}」へのご回答ありがとうございました！`,
+          },
+        ],
+      });
+    } catch {
+      await client.pushMessage({
+        to: userId,
+        messages: [
+          {
+            type: "text",
+            text: `「${questionnaire.title}」へのご回答ありがとうございました！`,
+          },
+        ],
+      });
+    }
+  }
+};
+
+const buildAnswerData = (
+  question: QuestionnaireQuestion,
+  answer: string,
+): {
+  answerText?: string | null;
+  answerNumber?: number | null;
+  selectedChoices?: string | null;
+} => {
+  switch (question.type) {
+    case "free_text":
+      return { answerText: answer };
+    case "rating":
+      return { answerNumber: Number.parseInt(answer, 10) };
+    case "single_choice":
+      return { selectedChoices: JSON.stringify([answer]) };
+    case "multiple_choice":
+      return { selectedChoices: answer };
+    default:
+      return { answerText: answer };
+  }
+};
+
+// --- 集計 ---
+
+export const getQuestionnaireResults = async (
+  db: D1Database,
+  questionnaireId: string,
+) => {
+  const questionnaire = await questionnaireRepository.findById(
+    db,
+    questionnaireId,
+  );
+  if (!questionnaire) return null;
+
+  const questions =
+    await questionnaireRepository.findQuestionsByQuestionnaireId(
+      db,
+      questionnaireId,
+    );
+  const submissionCounts = await questionnaireRepository.countSubmissions(
+    db,
+    questionnaireId,
+  );
+
+  const questionResults = await Promise.all(
+    questions.map(async (q) => {
+      const answers = await questionnaireRepository.findAnswersByQuestionId(
+        db,
+        q.id,
+      );
+      return buildQuestionResult(q, answers);
+    }),
+  );
+
+  return {
+    questionnaireId,
+    title: questionnaire.title,
+    totalSubmissions: submissionCounts.total,
+    completedSubmissions: submissionCounts.completed,
+    questionResults,
+  };
+};
+
+const buildQuestionResult = (
+  question: QuestionnaireQuestion,
+  answers: {
+    answerText: string | null;
+    answerNumber: number | null;
+    selectedChoices: string | null;
+  }[],
+) => {
+  const totalResponses = answers.length;
+  const base = {
+    questionId: question.id,
+    questionText: question.text,
+    questionType: question.type,
+    totalResponses,
+  };
+
+  switch (question.type) {
+    case "single_choice":
+    case "multiple_choice": {
+      const choices = question.choices
+        ? (JSON.parse(question.choices) as string[])
+        : [];
+      const counts: Record<string, number> = {};
+      for (const c of choices) counts[c] = 0;
+
+      for (const a of answers) {
+        if (!a.selectedChoices) continue;
+        const selected = JSON.parse(a.selectedChoices) as string[];
+        for (const s of selected) {
+          counts[s] = (counts[s] ?? 0) + 1;
+        }
+      }
+
+      const choiceResults = choices.map((c) => ({
+        choice: c,
+        count: counts[c] ?? 0,
+        percentage:
+          totalResponses > 0
+            ? Math.round(((counts[c] ?? 0) / totalResponses) * 100)
+            : 0,
+      }));
+
+      return { ...base, choiceResults };
+    }
+    case "rating": {
+      const ratings = answers
+        .map((a) => a.answerNumber)
+        .filter((n): n is number => n !== null);
+      const avg =
+        ratings.length > 0
+          ? Math.round(
+              (ratings.reduce((s, n) => s + n, 0) / ratings.length) * 10,
+            ) / 10
+          : 0;
+      const distribution: Record<string, number> = {};
+      for (const r of ratings) {
+        const key = String(r);
+        distribution[key] = (distribution[key] ?? 0) + 1;
+      }
+      return { ...base, averageRating: avg, ratingDistribution: distribution };
+    }
+    case "free_text": {
+      const texts = answers
+        .map((a) => a.answerText)
+        .filter((t): t is string => t !== null);
+      return { ...base, freeTextAnswers: texts };
+    }
+    default:
+      return base;
+  }
+};

--- a/server/src/services/questionnaire.ts
+++ b/server/src/services/questionnaire.ts
@@ -1,0 +1,156 @@
+import {
+  type Questionnaire,
+  type QuestionnaireQuestion,
+  questionnaireRepository,
+} from "~/repository/questionnaire-repository";
+import type { QuestionInput } from "~/schemas/questionnaire-schema";
+import { sendQuestionnaire } from "~/services/questionnaire-delivery";
+
+// --- アンケート作成 ---
+
+type CreateInput = {
+  title: string;
+  description?: string;
+  isAnonymous?: boolean;
+  questions: QuestionInput[];
+  scheduledAt?: string;
+  sendNow?: boolean;
+  createdBy: string;
+};
+
+export const createQuestionnaire = async (
+  env: CloudflareBindings,
+  input: CreateInput,
+) => {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const status = input.sendNow
+    ? "draft"
+    : input.scheduledAt
+      ? "scheduled"
+      : "draft";
+
+  await questionnaireRepository.create(env.DB, {
+    id,
+    title: input.title,
+    description: input.description,
+    isAnonymous: input.isAnonymous === false ? 0 : 1,
+    status,
+    createdBy: input.createdBy,
+    createdAt: now,
+  });
+
+  if (input.scheduledAt) {
+    await questionnaireRepository.update(env.DB, id, {
+      scheduledAt: input.scheduledAt,
+    });
+  }
+
+  const questionInputs = input.questions.map((q, i) => ({
+    id: crypto.randomUUID(),
+    questionnaireId: id,
+    order: i + 1,
+    text: q.text,
+    type: q.type,
+    required: q.required === false ? 0 : 1,
+    choices: q.choices ? JSON.stringify(q.choices) : null,
+    createdAt: now,
+  }));
+
+  await questionnaireRepository.createQuestions(env.DB, questionInputs);
+
+  if (input.sendNow) {
+    const result = await sendQuestionnaire(env, id);
+    if (!result.success) {
+      throw new Error(result.error);
+    }
+  }
+
+  return getQuestionnaireWithQuestions(env.DB, id);
+};
+
+// --- アンケート更新 ---
+
+type UpdateInput = {
+  title?: string;
+  description?: string | null;
+  isAnonymous?: boolean;
+  questions?: QuestionInput[];
+};
+
+export const updateQuestionnaire = async (
+  db: D1Database,
+  id: string,
+  input: UpdateInput,
+) => {
+  const updateData: Parameters<typeof questionnaireRepository.update>[2] = {};
+
+  if (input.title !== undefined) updateData.title = input.title;
+  if (input.description !== undefined)
+    updateData.description = input.description;
+  if (input.isAnonymous !== undefined)
+    updateData.isAnonymous = input.isAnonymous ? 1 : 0;
+
+  if (Object.keys(updateData).length > 0) {
+    await questionnaireRepository.update(db, id, updateData);
+  }
+
+  if (input.questions) {
+    const now = new Date().toISOString();
+    await questionnaireRepository.deleteQuestionsByQuestionnaireId(db, id);
+    const questionInputs = input.questions.map((q, i) => ({
+      id: crypto.randomUUID(),
+      questionnaireId: id,
+      order: i + 1,
+      text: q.text,
+      type: q.type,
+      required: q.required === false ? 0 : 1,
+      choices: q.choices ? JSON.stringify(q.choices) : null,
+      createdAt: now,
+    }));
+    await questionnaireRepository.createQuestions(db, questionInputs);
+  }
+
+  return getQuestionnaireWithQuestions(db, id);
+};
+
+// --- アンケート詳細取得 ---
+
+export const getQuestionnaireWithQuestions = async (
+  db: D1Database,
+  id: string,
+) => {
+  const questionnaire = await questionnaireRepository.findById(db, id);
+  if (!questionnaire) return null;
+
+  const questions =
+    await questionnaireRepository.findQuestionsByQuestionnaireId(db, id);
+
+  return formatQuestionnaireResponse(questionnaire, questions);
+};
+
+export const formatQuestionnaireResponse = (
+  q: Questionnaire,
+  questions: QuestionnaireQuestion[],
+) => ({
+  id: q.id,
+  title: q.title,
+  description: q.description,
+  isAnonymous: q.isAnonymous === 1,
+  status: q.status,
+  questions: questions.map((qq) => ({
+    id: qq.id,
+    questionnaireId: qq.questionnaireId,
+    order: qq.order,
+    text: qq.text,
+    type: qq.type,
+    required: qq.required === 1,
+    choices: qq.choices ? (JSON.parse(qq.choices) as string[]) : null,
+  })),
+  createdBy: q.createdBy,
+  createdAt: q.createdAt,
+  updatedAt: q.updatedAt,
+  scheduledAt: q.scheduledAt,
+  sentAt: q.sentAt,
+  closedAt: q.closedAt,
+});

--- a/web/src/app/dashboard/App.tsx
+++ b/web/src/app/dashboard/App.tsx
@@ -3,6 +3,7 @@ import {
   Bars3Icon,
   BookOpenIcon,
   ChatBubbleLeftIcon,
+  ClipboardDocumentListIcon,
   EnvelopeIcon,
   ExclamationTriangleIcon,
   MegaphoneIcon,
@@ -21,6 +22,7 @@ import { FeedbackPanel } from "./components/FeedbackPanel";
 import { InvitationsPanel } from "./components/InvitationsPanel";
 import { KnowledgePanel } from "./components/KnowledgePanel";
 import { PersonaPanel } from "./components/PersonaPanel";
+import { QuestionnairePanel } from "./components/QuestionnairePanel";
 import { useAuth } from "./contexts/AuthContext";
 
 type Tab =
@@ -29,6 +31,7 @@ type Tab =
   | "feedback"
   | "emergency"
   | "broadcast"
+  | "questionnaire"
   | "invitations";
 
 type AdminRole = AdminUser["role"];
@@ -66,6 +69,11 @@ const tabs: {
     id: "broadcast",
     label: "LINE配信",
     icon: <MegaphoneIcon className="w-5 h-5" aria-hidden="true" />,
+  },
+  {
+    id: "questionnaire",
+    label: "アンケート",
+    icon: <ClipboardDocumentListIcon className="w-5 h-5" aria-hidden="true" />,
   },
   {
     id: "invitations",
@@ -225,6 +233,7 @@ export const App = () => {
             {activeTab === "feedback" && <FeedbackPanel />}
             {activeTab === "emergency" && <EmergencyPanel />}
             {activeTab === "broadcast" && <BroadcastPanel />}
+            {activeTab === "questionnaire" && <QuestionnairePanel />}
             {activeTab === "invitations" && <InvitationsPanel />}
           </div>
         </div>

--- a/web/src/app/dashboard/components/QuestionnairePanel.tsx
+++ b/web/src/app/dashboard/components/QuestionnairePanel.tsx
@@ -1,0 +1,911 @@
+import {
+  ChartBarIcon,
+  ClockIcon,
+  LockClosedIcon,
+  PaperAirplaneIcon,
+  PencilSquareIcon,
+  PlusIcon,
+  TrashIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { useCallback, useState } from "react";
+
+import {
+  useCloseQuestionnaire,
+  useCreateQuestionnaire,
+  useDeleteQuestionnaire,
+  useQuestionnaireResults,
+  useQuestionnaires,
+  useSendQuestionnaire,
+  useUpdateQuestionnaire,
+} from "~/hooks/useDashboard";
+import { useInfiniteScroll } from "~/hooks/useInfiniteScroll";
+import { formatDateTime } from "~/lib/format";
+import type {
+  CreateQuestionnaireRequest,
+  QuestionnaireMessage,
+  QuestionnaireStatus,
+  QuestionResult,
+  QuestionType,
+} from "~/types";
+
+const STATUS_LABELS: Record<QuestionnaireStatus, string> = {
+  draft: "下書き",
+  scheduled: "予約済み",
+  sent: "配信中",
+  closed: "締切",
+};
+
+const STATUS_STYLES: Record<QuestionnaireStatus, string> = {
+  draft: "bg-stone-100 text-stone-600",
+  scheduled: "bg-blue-100 text-blue-700",
+  sent: "bg-green-100 text-green-700",
+  closed: "bg-stone-200 text-stone-500",
+};
+
+type SendTiming = "draft" | "now" | "schedule";
+
+const QUESTION_TYPE_LABELS: Record<QuestionType, string> = {
+  single_choice: "単一選択",
+  multiple_choice: "複数選択",
+  free_text: "自由記述",
+  rating: "評価（5段階）",
+};
+
+// --- 作成/編集フォーム ---
+
+let formIdCounter = 0;
+const nextFormId = () => `qf-${++formIdCounter}`;
+
+type ChoiceFormState = { id: string; value: string };
+
+type QuestionFormState = {
+  id: string;
+  text: string;
+  type: QuestionType;
+  required: boolean;
+  choices: ChoiceFormState[];
+};
+
+const emptyChoice = (): ChoiceFormState => ({ id: nextFormId(), value: "" });
+
+const emptyQuestion = (): QuestionFormState => ({
+  id: nextFormId(),
+  text: "",
+  type: "single_choice",
+  required: true,
+  choices: [emptyChoice(), emptyChoice()],
+});
+
+type FormModalProps = {
+  mode: "create" | "edit";
+  questionnaire?: QuestionnaireMessage;
+  onClose: () => void;
+};
+
+const FormModal = ({ mode, questionnaire, onClose }: FormModalProps) => {
+  const [title, setTitle] = useState(questionnaire?.title ?? "");
+  const [description, setDescription] = useState(
+    questionnaire?.description ?? "",
+  );
+  const [isAnonymous, setIsAnonymous] = useState(
+    questionnaire?.isAnonymous ?? true,
+  );
+  const [questions, setQuestions] = useState<QuestionFormState[]>(() => {
+    if (questionnaire?.questions.length) {
+      return questionnaire.questions.map((q) => ({
+        id: nextFormId(),
+        text: q.text,
+        type: q.type as QuestionType,
+        required: q.required,
+        choices: (q.choices ?? []).map((c) => ({ id: nextFormId(), value: c })),
+      }));
+    }
+    return [emptyQuestion()];
+  });
+
+  const [timing, setTiming] = useState<SendTiming>(
+    questionnaire?.scheduledAt ? "schedule" : "draft",
+  );
+  const [scheduledAt, setScheduledAt] = useState(
+    questionnaire?.scheduledAt?.slice(0, 16) ?? "",
+  );
+
+  const createMutation = useCreateQuestionnaire();
+  const updateMutation = useUpdateQuestionnaire();
+
+  const isSubmitting = createMutation.isPending || updateMutation.isPending;
+
+  const addQuestion = () => {
+    if (questions.length >= 20) return;
+    setQuestions([...questions, emptyQuestion()]);
+  };
+
+  const removeQuestion = (index: number) => {
+    if (questions.length <= 1) return;
+    setQuestions(questions.filter((_, i) => i !== index));
+  };
+
+  const updateQuestion = (
+    index: number,
+    field: keyof QuestionFormState,
+    value: unknown,
+  ) => {
+    setQuestions(
+      questions.map((q, i) => (i === index ? { ...q, [field]: value } : q)),
+    );
+  };
+
+  const updateChoice = (qIndex: number, choiceId: string, value: string) => {
+    setQuestions(
+      questions.map((q, i) =>
+        i === qIndex
+          ? {
+              ...q,
+              choices: q.choices.map((c) =>
+                c.id === choiceId ? { ...c, value } : c,
+              ),
+            }
+          : q,
+      ),
+    );
+  };
+
+  const addChoice = (qIndex: number) => {
+    setQuestions(
+      questions.map((q, i) =>
+        i === qIndex ? { ...q, choices: [...q.choices, emptyChoice()] } : q,
+      ),
+    );
+  };
+
+  const removeChoice = (qIndex: number, choiceId: string) => {
+    setQuestions(
+      questions.map((q, i) =>
+        i === qIndex
+          ? { ...q, choices: q.choices.filter((c) => c.id !== choiceId) }
+          : q,
+      ),
+    );
+  };
+
+  const handleSubmit = async () => {
+    if (timing === "now") {
+      if (!confirm("このアンケートをLINE全フォロワーに即時配信しますか？"))
+        return;
+    }
+
+    const payload: CreateQuestionnaireRequest = {
+      title,
+      description: description || undefined,
+      isAnonymous,
+      questions: questions.map((q) => ({
+        text: q.text,
+        type: q.type,
+        required: q.required,
+        ...(q.type === "single_choice" || q.type === "multiple_choice"
+          ? { choices: q.choices.map((c) => c.value).filter((v) => v.trim()) }
+          : {}),
+      })),
+      ...(timing === "now" && { sendNow: true }),
+      ...(timing === "schedule" && {
+        scheduledAt: new Date(scheduledAt).toISOString(),
+      }),
+    };
+
+    if (mode === "edit" && questionnaire) {
+      await updateMutation.mutateAsync({ id: questionnaire.id, data: payload });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+    onClose();
+  };
+
+  const isValid =
+    title.trim() &&
+    questions.every(
+      (q) =>
+        q.text.trim() &&
+        (q.type === "free_text" ||
+          q.type === "rating" ||
+          q.choices.filter((c) => c.value.trim()).length >= 2),
+    ) &&
+    (timing !== "schedule" || scheduledAt.length > 0);
+
+  return (
+    <div className="fixed inset-0 bg-stone-900/30 backdrop-blur-[2px] z-50 flex items-start justify-center pt-8 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 mb-8">
+        <div className="flex items-center justify-between p-5 border-b border-stone-200">
+          <h3 className="text-lg font-semibold text-stone-800">
+            {mode === "create" ? "アンケート作成" : "アンケート編集"}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 hover:bg-stone-100 rounded-lg"
+          >
+            <XMarkIcon className="w-5 h-5 text-stone-500" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-5 max-h-[70dvh] overflow-y-auto">
+          {/* タイトル */}
+          <div>
+            <label
+              htmlFor="questionnaire-title"
+              className="block text-sm font-medium text-stone-700 mb-1"
+            >
+              タイトル
+            </label>
+            <input
+              id="questionnaire-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="アンケートのタイトル"
+              className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+            />
+          </div>
+
+          {/* 説明 */}
+          <div>
+            <label
+              htmlFor="questionnaire-description"
+              className="block text-sm font-medium text-stone-700 mb-1"
+            >
+              説明（任意）
+            </label>
+            <textarea
+              id="questionnaire-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="アンケートの説明文"
+              rows={2}
+              className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 resize-none"
+            />
+          </div>
+
+          {/* 無記名/記名 */}
+          <div className="flex items-center gap-3">
+            <label className="flex items-center gap-2 text-sm text-stone-700">
+              <input
+                type="checkbox"
+                checked={isAnonymous}
+                onChange={(e) => setIsAnonymous(e.target.checked)}
+                className="rounded border-stone-300 text-teal-600 focus:ring-teal-500"
+              />
+              無記名アンケート
+            </label>
+          </div>
+
+          {/* 設問一覧 */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-medium text-stone-700">
+                設問（{questions.length}/20）
+              </h4>
+              <button
+                type="button"
+                onClick={addQuestion}
+                disabled={questions.length >= 20}
+                className="flex items-center gap-1 text-sm text-teal-700 hover:text-teal-800 disabled:text-stone-400"
+              >
+                <PlusIcon className="w-4 h-4" />
+                設問追加
+              </button>
+            </div>
+
+            {questions.map((q, qIndex) => (
+              <div
+                key={q.id}
+                className="border border-stone-200 rounded-lg p-4 space-y-3"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-sm font-medium text-stone-500 mt-1">
+                    Q{qIndex + 1}
+                  </span>
+                  {questions.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeQuestion(qIndex)}
+                      className="p-1 hover:bg-red-50 rounded text-stone-400 hover:text-red-500"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                    </button>
+                  )}
+                </div>
+
+                <input
+                  type="text"
+                  value={q.text}
+                  onChange={(e) =>
+                    updateQuestion(qIndex, "text", e.target.value)
+                  }
+                  placeholder="質問文を入力"
+                  className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+                />
+
+                <div className="flex items-center gap-3">
+                  <select
+                    value={q.type}
+                    onChange={(e) =>
+                      updateQuestion(qIndex, "type", e.target.value)
+                    }
+                    className="px-3 py-1.5 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+                  >
+                    {(
+                      Object.entries(QUESTION_TYPE_LABELS) as [
+                        QuestionType,
+                        string,
+                      ][]
+                    ).map(([value, label]) => (
+                      <option key={value} value={value}>
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+
+                  <label className="flex items-center gap-1.5 text-sm text-stone-600">
+                    <input
+                      type="checkbox"
+                      checked={q.required}
+                      onChange={(e) =>
+                        updateQuestion(qIndex, "required", e.target.checked)
+                      }
+                      className="rounded border-stone-300 text-teal-600 focus:ring-teal-500"
+                    />
+                    必須
+                  </label>
+                </div>
+
+                {/* 選択肢（choice系のみ） */}
+                {(q.type === "single_choice" ||
+                  q.type === "multiple_choice") && (
+                  <div className="space-y-2 pl-2">
+                    {q.choices.map((choice, cIndex) => (
+                      <div key={choice.id} className="flex items-center gap-2">
+                        <span className="text-sm text-stone-400 w-4">
+                          {cIndex + 1}.
+                        </span>
+                        <input
+                          type="text"
+                          value={choice.value}
+                          onChange={(e) =>
+                            updateChoice(qIndex, choice.id, e.target.value)
+                          }
+                          placeholder={`選択肢${cIndex + 1}`}
+                          className="flex-1 px-2.5 py-1.5 border border-stone-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+                        />
+                        {q.choices.length > 2 && (
+                          <button
+                            type="button"
+                            onClick={() => removeChoice(qIndex, choice.id)}
+                            className="p-1 hover:bg-red-50 rounded text-stone-400 hover:text-red-500"
+                          >
+                            <XMarkIcon className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => addChoice(qIndex)}
+                      className="text-sm text-teal-700 hover:text-teal-800 pl-6"
+                    >
+                      + 選択肢を追加
+                    </button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* 配信タイミング */}
+        <div className="p-5 border-t border-stone-200 space-y-4">
+          <div>
+            <span className="block text-sm font-medium text-stone-700 mb-2">
+              配信タイミング
+            </span>
+            <div className="flex rounded-lg border border-stone-300 overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setTiming("draft")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors flex items-center justify-center gap-1.5 ${
+                  timing === "draft"
+                    ? "bg-stone-600 text-white"
+                    : "bg-white text-stone-600 hover:bg-stone-50"
+                }`}
+              >
+                <PencilSquareIcon className="w-4 h-4" />
+                下書き保存
+              </button>
+              <button
+                type="button"
+                onClick={() => setTiming("now")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors border-l border-stone-300 flex items-center justify-center gap-1.5 ${
+                  timing === "now"
+                    ? "bg-teal-600 text-white"
+                    : "bg-white text-stone-600 hover:bg-stone-50"
+                }`}
+              >
+                <PaperAirplaneIcon className="w-4 h-4" />
+                今すぐ配信
+              </button>
+              <button
+                type="button"
+                onClick={() => setTiming("schedule")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium transition-colors border-l border-stone-300 flex items-center justify-center gap-1.5 ${
+                  timing === "schedule"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white text-stone-600 hover:bg-stone-50"
+                }`}
+              >
+                <ClockIcon className="w-4 h-4" />
+                スケジュール
+              </button>
+            </div>
+          </div>
+
+          {timing === "schedule" && (
+            <div>
+              <label
+                htmlFor="questionnaire-scheduled"
+                className="block text-sm font-medium text-stone-700 mb-1"
+              >
+                配信日時
+              </label>
+              <input
+                id="questionnaire-scheduled"
+                type="datetime-local"
+                value={scheduledAt}
+                onChange={(e) => setScheduledAt(e.target.value)}
+                className="w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+              />
+            </div>
+          )}
+
+          <div className="flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-stone-600 hover:bg-stone-100 rounded-lg"
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={!isValid || isSubmitting}
+              className={`px-5 py-2 text-sm font-medium text-white rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-1.5 ${
+                timing === "now"
+                  ? "bg-teal-600 hover:bg-teal-700"
+                  : timing === "schedule"
+                    ? "bg-blue-600 hover:bg-blue-700"
+                    : "bg-stone-600 hover:bg-stone-700"
+              }`}
+            >
+              {isSubmitting ? (
+                "処理中..."
+              ) : timing === "now" ? (
+                <>
+                  <PaperAirplaneIcon className="w-4 h-4" />
+                  配信する
+                </>
+              ) : timing === "schedule" ? (
+                <>
+                  <ClockIcon className="w-4 h-4" />
+                  予約する
+                </>
+              ) : (
+                "保存する"
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// --- 結果モーダル ---
+
+const ResultsModal = ({
+  questionnaireId,
+  onClose,
+}: {
+  questionnaireId: string;
+  onClose: () => void;
+}) => {
+  const { data: results, isLoading } = useQuestionnaireResults(questionnaireId);
+
+  return (
+    <div className="fixed inset-0 bg-stone-900/30 backdrop-blur-[2px] z-50 flex items-start justify-center pt-8 overflow-y-auto">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-2xl mx-4 mb-8">
+        <div className="flex items-center justify-between p-5 border-b border-stone-200">
+          <h3 className="text-lg font-semibold text-stone-800">
+            回答結果
+            {results && (
+              <span className="text-sm font-normal text-stone-500 ml-2">
+                {results.completedSubmissions}件完了 /{" "}
+                {results.totalSubmissions}
+                件回答中
+              </span>
+            )}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 hover:bg-stone-100 rounded-lg"
+          >
+            <XMarkIcon className="w-5 h-5 text-stone-500" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-6 max-h-[70dvh] overflow-y-auto">
+          {isLoading && (
+            <p className="text-sm text-stone-500 text-center py-8">
+              読み込み中...
+            </p>
+          )}
+
+          {results?.questionResults.map((qr: QuestionResult, index: number) => (
+            <QuestionResultCard key={qr.questionId} result={qr} index={index} />
+          ))}
+
+          {results && results.questionResults.length === 0 && (
+            <p className="text-sm text-stone-500 text-center py-8">
+              まだ回答がありません
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const QuestionResultCard = ({
+  result,
+  index,
+}: {
+  result: QuestionResult;
+  index: number;
+}) => (
+  <div className="border border-stone-200 rounded-lg p-4 space-y-3">
+    <div className="flex items-center justify-between">
+      <h4 className="text-base font-medium text-stone-800">
+        Q{index + 1}. {result.questionText}
+      </h4>
+      <span className="text-sm text-stone-500">
+        {result.totalResponses}件回答
+      </span>
+    </div>
+
+    {/* 選択式 → 棒グラフ */}
+    {result.choiceResults && (
+      <div className="space-y-2">
+        {result.choiceResults.map((cr) => (
+          <div key={cr.choice} className="space-y-1">
+            <div className="flex items-center justify-between text-sm text-stone-600">
+              <span>{cr.choice}</span>
+              <span>
+                {cr.count}件（{cr.percentage}%）
+              </span>
+            </div>
+            <div className="h-5 bg-stone-100 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-teal-500 rounded-full transition-all"
+                style={{ width: `${cr.percentage}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    )}
+
+    {/* 評価 → 平均 + 分布 */}
+    {result.averageRating !== undefined && (
+      <div className="space-y-2">
+        <p className="text-2xl font-bold text-teal-700">
+          {result.averageRating}
+          <span className="text-sm font-normal text-stone-500"> / 5</span>
+        </p>
+        {result.ratingDistribution && (
+          <div className="flex items-end gap-1 h-16">
+            {[1, 2, 3, 4, 5].map((n) => {
+              const count = result.ratingDistribution?.[String(n)] ?? 0;
+              const max = Math.max(
+                ...Object.values(result.ratingDistribution ?? {}),
+                1,
+              );
+              const height = (count / max) * 100;
+              return (
+                <div
+                  key={n}
+                  className="flex-1 flex flex-col items-center gap-1"
+                >
+                  <div
+                    className="w-full bg-teal-400 rounded-t transition-all"
+                    style={{ height: `${height}%` }}
+                  />
+                  <span className="text-[10px] text-stone-500">{n}</span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    )}
+
+    {/* 自由記述 → テキストリスト */}
+    {result.freeTextAnswers && result.freeTextAnswers.length > 0 && (
+      <div className="space-y-1.5 max-h-40 overflow-y-auto">
+        {result.freeTextAnswers.map((text) => (
+          <p
+            key={text}
+            className="text-sm text-stone-700 bg-stone-50 rounded px-3 py-2"
+          >
+            {text}
+          </p>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+// --- メインパネル ---
+
+export const QuestionnairePanel = () => {
+  const [statusFilter, setStatusFilter] = useState<
+    QuestionnaireStatus | undefined
+  >();
+  const [modal, setModal] = useState<
+    | { type: "create" }
+    | { type: "edit"; questionnaire: QuestionnaireMessage }
+    | { type: "results"; id: string }
+    | null
+  >(null);
+
+  const { data, isLoading, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useQuestionnaires(30, {
+      status: statusFilter,
+    });
+
+  const deleteMutation = useDeleteQuestionnaire();
+  const sendMutation = useSendQuestionnaire();
+  const closeMutation = useCloseQuestionnaire();
+
+  const loadMoreRef = useInfiniteScroll({
+    hasNextPage: hasNextPage ?? false,
+    isFetching: isFetchingNextPage,
+    onFetch: fetchNextPage,
+  });
+
+  const questionnaires = data?.pages.flatMap((p) => p.questionnaires) ?? [];
+
+  const handleSend = useCallback(
+    async (id: string) => {
+      if (!confirm("このアンケートをLINEに配信しますか？")) return;
+      await sendMutation.mutateAsync(id);
+    },
+    [sendMutation],
+  );
+
+  const handleClose = useCallback(
+    async (id: string) => {
+      if (!confirm("このアンケートの回答受付を締め切りますか？")) return;
+      await closeMutation.mutateAsync(id);
+    },
+    [closeMutation],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      if (!confirm("このアンケートを削除しますか？")) return;
+      await deleteMutation.mutateAsync(id);
+    },
+    [deleteMutation],
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          {(
+            [undefined, "draft", "scheduled", "sent", "closed"] as (
+              | QuestionnaireStatus
+              | undefined
+            )[]
+          ).map((status) => (
+            <button
+              key={status ?? "all"}
+              type="button"
+              onClick={() => setStatusFilter(status)}
+              className={`px-3 py-1.5 text-xs rounded-full transition-colors ${
+                statusFilter === status
+                  ? "bg-teal-600 text-white"
+                  : "bg-stone-100 text-stone-600 hover:bg-stone-200"
+              }`}
+            >
+              {status ? STATUS_LABELS[status] : "すべて"}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => setModal({ type: "create" })}
+          className="flex items-center gap-1.5 px-4 py-2 text-sm text-white bg-teal-700 hover:bg-teal-800 rounded-lg"
+        >
+          <PlusIcon className="w-4 h-4" />
+          新規作成
+        </button>
+      </div>
+
+      {/* 一覧 */}
+      {isLoading && (
+        <p className="text-sm text-stone-500 text-center py-8">読み込み中...</p>
+      )}
+
+      {!isLoading && questionnaires.length === 0 && (
+        <p className="text-sm text-stone-500 text-center py-8">
+          アンケートはまだありません
+        </p>
+      )}
+
+      <div className="space-y-3">
+        {questionnaires.map((q) => (
+          <div
+            key={q.id}
+            className="bg-white border border-stone-200 rounded-lg p-4 space-y-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-base font-semibold text-stone-800 truncate">
+                    {q.title}
+                  </h3>
+                  <span
+                    className={`px-2 py-0.5 text-xs rounded-full font-medium ${STATUS_STYLES[q.status as QuestionnaireStatus]}`}
+                  >
+                    {STATUS_LABELS[q.status as QuestionnaireStatus]}
+                  </span>
+                </div>
+                {q.description && (
+                  <p className="text-sm text-stone-500 mt-1 line-clamp-2">
+                    {q.description}
+                  </p>
+                )}
+                <div className="flex items-center gap-3 mt-2 text-xs text-stone-400">
+                  <span>{q.questions.length}問</span>
+                  <span>{formatDateTime(q.createdAt)}</span>
+                  {q.scheduledAt && (
+                    <span className="text-blue-600">
+                      予約: {formatDateTime(q.scheduledAt)}
+                    </span>
+                  )}
+                  {q.sentAt && <span>配信: {formatDateTime(q.sentAt)}</span>}
+                  {q.isAnonymous && <span>無記名</span>}
+                </div>
+              </div>
+
+              {/* アクションボタン */}
+              <div className="flex items-center gap-1 shrink-0">
+                {(q.status === "sent" || q.status === "closed") && (
+                  <button
+                    type="button"
+                    onClick={() => setModal({ type: "results", id: q.id })}
+                    className="p-2 hover:bg-stone-100 rounded-lg text-teal-700"
+                    title="結果を見る"
+                  >
+                    <ChartBarIcon className="w-4 h-4" />
+                  </button>
+                )}
+                {q.status === "draft" && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setModal({ type: "edit", questionnaire: q })
+                      }
+                      className="p-2 hover:bg-stone-100 rounded-lg text-stone-600"
+                      title="編集"
+                    >
+                      <PencilSquareIcon className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleSend(q.id)}
+                      disabled={sendMutation.isPending}
+                      className="p-2 hover:bg-teal-50 rounded-lg text-teal-700 disabled:opacity-50"
+                      title="配信"
+                    >
+                      <PaperAirplaneIcon className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(q.id)}
+                      disabled={deleteMutation.isPending}
+                      className="p-2 hover:bg-red-50 rounded-lg text-stone-400 hover:text-red-500 disabled:opacity-50"
+                      title="削除"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                    </button>
+                  </>
+                )}
+                {q.status === "scheduled" && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => handleSend(q.id)}
+                      disabled={sendMutation.isPending}
+                      className="p-2 hover:bg-teal-50 rounded-lg text-teal-700 disabled:opacity-50"
+                      title="今すぐ配信"
+                    >
+                      <PaperAirplaneIcon className="w-4 h-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(q.id)}
+                      disabled={deleteMutation.isPending}
+                      className="p-2 hover:bg-red-50 rounded-lg text-stone-400 hover:text-red-500 disabled:opacity-50"
+                      title="削除"
+                    >
+                      <TrashIcon className="w-4 h-4" />
+                    </button>
+                  </>
+                )}
+                {q.status === "sent" && (
+                  <button
+                    type="button"
+                    onClick={() => handleClose(q.id)}
+                    disabled={closeMutation.isPending}
+                    className="p-2 hover:bg-stone-100 rounded-lg text-stone-600 disabled:opacity-50"
+                    title="締切"
+                  >
+                    <LockClosedIcon className="w-4 h-4" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* 設問プレビュー */}
+            <div className="flex flex-wrap gap-1.5">
+              {q.questions.map((qq, i) => (
+                <span
+                  key={qq.id}
+                  className="text-xs text-stone-500 bg-stone-50 rounded px-2 py-0.5"
+                >
+                  Q{i + 1}: {QUESTION_TYPE_LABELS[qq.type as QuestionType]}
+                </span>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div ref={loadMoreRef} />
+      {isFetchingNextPage && (
+        <p className="text-xs text-stone-400 text-center py-2">読み込み中...</p>
+      )}
+
+      {/* モーダル */}
+      {modal?.type === "create" && (
+        <FormModal mode="create" onClose={() => setModal(null)} />
+      )}
+      {modal?.type === "edit" && (
+        <FormModal
+          mode="edit"
+          questionnaire={modal.questionnaire}
+          onClose={() => setModal(null)}
+        />
+      )}
+      {modal?.type === "results" && (
+        <ResultsModal
+          questionnaireId={modal.id}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/web/src/hooks/useDashboard.ts
+++ b/web/src/hooks/useDashboard.ts
@@ -37,6 +37,15 @@ import {
   extractPersonas,
   fetchPersonas,
 } from "~/repository/persona-repository";
+import {
+  closeQuestionnaire,
+  createQuestionnaire,
+  deleteQuestionnaire,
+  fetchQuestionnaireResults,
+  fetchQuestionnaires,
+  sendQuestionnaireNow,
+  updateQuestionnaire,
+} from "~/repository/questionnaire-repository";
 
 export const dashboardKeys = {
   broadcasts: ["dashboard", "broadcasts"] as const,
@@ -49,6 +58,9 @@ export const dashboardKeys = {
   knowledgeUnifiedFiles: ["dashboard", "knowledge", "unified"] as const,
   knowledgeFile: (key: string) =>
     ["dashboard", "knowledge", "file", key] as const,
+  questionnaires: ["dashboard", "questionnaires"] as const,
+  questionnaireResults: (id: string) =>
+    ["dashboard", "questionnaire", "results", id] as const,
 };
 
 export const usePersonas = (limit = 30) =>
@@ -307,3 +319,96 @@ export const useSendBroadcast = () => {
 
 export const useUploadBroadcastImage = () =>
   useMutation({ mutationFn: uploadBroadcastImage });
+
+// アンケート関連 hooks
+export const useQuestionnaires = (
+  limit = 30,
+  options?: { status?: "draft" | "scheduled" | "sent" | "closed" },
+) =>
+  useInfiniteQuery({
+    queryKey: [...dashboardKeys.questionnaires, limit, options?.status],
+    queryFn: ({ pageParam }) =>
+      fetchQuestionnaires({
+        limit,
+        cursor: pageParam,
+        status: options?.status,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+  });
+
+export const useCreateQuestionnaire = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createQuestionnaire,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.questionnaires,
+      });
+    },
+  });
+};
+
+export const useUpdateQuestionnaire = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: Parameters<typeof updateQuestionnaire>[1];
+    }) => updateQuestionnaire(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.questionnaires,
+      });
+    },
+  });
+};
+
+export const useDeleteQuestionnaire = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteQuestionnaire,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.questionnaires,
+      });
+    },
+  });
+};
+
+export const useSendQuestionnaire = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: sendQuestionnaireNow,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.questionnaires,
+      });
+    },
+  });
+};
+
+export const useCloseQuestionnaire = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: closeQuestionnaire,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.questionnaires,
+      });
+    },
+  });
+};
+
+export const useQuestionnaireResults = (id: string | null) =>
+  useQuery({
+    queryKey: dashboardKeys.questionnaireResults(id ?? ""),
+    queryFn: () => {
+      if (!id) throw new Error("ID is required");
+      return fetchQuestionnaireResults(id);
+    },
+    enabled: !!id,
+  });

--- a/web/src/repository/questionnaire-repository.ts
+++ b/web/src/repository/questionnaire-repository.ts
@@ -1,0 +1,90 @@
+import { client } from "~/lib/api/client";
+import type {
+  CreateQuestionnaireRequest,
+  QuestionnaireStatus,
+  UpdateQuestionnaireRequest,
+} from "~/types";
+
+type FetchQuestionnairesParams = {
+  limit?: number;
+  cursor?: string;
+  status?: QuestionnaireStatus;
+};
+
+export const fetchQuestionnaires = async (
+  params: FetchQuestionnairesParams = {},
+) => {
+  const { data, error } = await client.GET("/admin/questionnaires", {
+    params: {
+      query: {
+        limit: params.limit ?? 30,
+        cursor: params.cursor,
+        status: params.status,
+      },
+    },
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const fetchQuestionnaireById = async (id: string) => {
+  const { data, error } = await client.GET("/admin/questionnaires/{id}", {
+    params: { path: { id } },
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const createQuestionnaire = async (body: CreateQuestionnaireRequest) => {
+  const { data, error } = await client.POST("/admin/questionnaires", {
+    body,
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const updateQuestionnaire = async (
+  id: string,
+  body: UpdateQuestionnaireRequest,
+) => {
+  const { data, error } = await client.PUT("/admin/questionnaires/{id}", {
+    params: { path: { id } },
+    body,
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const deleteQuestionnaire = async (id: string) => {
+  const { data, error } = await client.DELETE("/admin/questionnaires/{id}", {
+    params: { path: { id } },
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const sendQuestionnaireNow = async (id: string) => {
+  const { data, error } = await client.POST("/admin/questionnaires/{id}/send", {
+    params: { path: { id } },
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const closeQuestionnaire = async (id: string) => {
+  const { data, error } = await client.POST(
+    "/admin/questionnaires/{id}/close",
+    { params: { path: { id } } },
+  );
+  if (error) throw error;
+  return data;
+};
+
+export const fetchQuestionnaireResults = async (id: string) => {
+  const { data, error } = await client.GET(
+    "/admin/questionnaires/{id}/results",
+    { params: { path: { id } } },
+  );
+  if (error) throw error;
+  return data;
+};

--- a/web/src/types/api.d.ts
+++ b/web/src/types/api.d.ts
@@ -82,6 +82,8 @@ export interface paths {
                         };
                         resourceId: string;
                         threadId: string;
+                        /** @enum {string} */
+                        intent?: "casual" | "normal" | "thinking";
                     };
                 };
             };
@@ -2935,6 +2937,713 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/questionnaires": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * アンケート一覧を取得
+         * @description アンケートの一覧を取得します
+         */
+        get: {
+            parameters: {
+                query?: {
+                    limit?: number;
+                    cursor?: string;
+                    status?: "draft" | "scheduled" | "sent" | "closed";
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 取得成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            questionnaires: {
+                                id: string;
+                                title: string;
+                                description: string | null;
+                                isAnonymous: boolean;
+                                /** @enum {string} */
+                                status: "draft" | "scheduled" | "sent" | "closed";
+                                questions: {
+                                    id: string;
+                                    questionnaireId: string;
+                                    order: number;
+                                    text: string;
+                                    /** @enum {string} */
+                                    type: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                                    required: boolean;
+                                    choices: string[] | null;
+                                }[];
+                                createdBy: string;
+                                createdAt: string;
+                                updatedAt: string | null;
+                                scheduledAt: string | null;
+                                sentAt: string | null;
+                                closedAt: string | null;
+                            }[];
+                            total: number;
+                            nextCursor: string | null;
+                            hasMore: boolean;
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * アンケートを作成
+         * @description アンケートを作成します
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title: string;
+                        description?: string;
+                        /** @default true */
+                        isAnonymous?: boolean;
+                        questions: {
+                            text: string;
+                            /** @enum {string} */
+                            type: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                            /** @default true */
+                            required?: boolean;
+                            choices?: string[];
+                        }[];
+                        /** Format: date-time */
+                        scheduledAt?: string;
+                        sendNow?: boolean;
+                    };
+                };
+            };
+            responses: {
+                /** @description 作成成功 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            isAnonymous: boolean;
+                            /** @enum {string} */
+                            status: "draft" | "scheduled" | "sent" | "closed";
+                            questions: {
+                                id: string;
+                                questionnaireId: string;
+                                order: number;
+                                text: string;
+                                /** @enum {string} */
+                                type: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                                required: boolean;
+                                choices: string[] | null;
+                            }[];
+                            createdBy: string;
+                            createdAt: string;
+                            updatedAt: string | null;
+                            scheduledAt: string | null;
+                            sentAt: string | null;
+                            closedAt: string | null;
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/questionnaires/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * アンケート詳細を取得
+         * @description アンケートの詳細情報を取得します
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 取得成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            isAnonymous: boolean;
+                            /** @enum {string} */
+                            status: "draft" | "scheduled" | "sent" | "closed";
+                            questions: {
+                                id: string;
+                                questionnaireId: string;
+                                order: number;
+                                text: string;
+                                /** @enum {string} */
+                                type: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                                required: boolean;
+                                choices: string[] | null;
+                            }[];
+                            createdBy: string;
+                            createdAt: string;
+                            updatedAt: string | null;
+                            scheduledAt: string | null;
+                            sentAt: string | null;
+                            closedAt: string | null;
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        /**
+         * アンケートを更新
+         * @description アンケートを更新します（draftのみ）
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: {
+                content: {
+                    "application/json": {
+                        title?: string;
+                        description?: string | null;
+                        isAnonymous?: boolean;
+                        questions?: {
+                            text: string;
+                            /** @enum {string} */
+                            type: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                            /** @default true */
+                            required?: boolean;
+                            choices?: string[];
+                        }[];
+                    };
+                };
+            };
+            responses: {
+                /** @description 更新成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            title: string;
+                            description: string | null;
+                            isAnonymous: boolean;
+                            /** @enum {string} */
+                            status: "draft" | "scheduled" | "sent" | "closed";
+                            questions: {
+                                id: string;
+                                questionnaireId: string;
+                                order: number;
+                                text: string;
+                                /** @enum {string} */
+                                type: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                                required: boolean;
+                                choices: string[] | null;
+                            }[];
+                            createdBy: string;
+                            createdAt: string;
+                            updatedAt: string | null;
+                            scheduledAt: string | null;
+                            sentAt: string | null;
+                            closedAt: string | null;
+                        };
+                    };
+                };
+                /** @description リクエストエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * アンケートを削除
+         * @description アンケートを削除します（draftのみ）
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 削除成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description リクエストエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/questionnaires/{id}/send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * アンケートをLINEに配信
+         * @description アンケートをLINE全ユーザーに配信します
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 配信成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description リクエストエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description サーバーエラー */
+                500: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/questionnaires/{id}/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * アンケート結果を取得
+         * @description アンケートの回答結果を集計して取得します
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 取得成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            questionnaireId: string;
+                            title: string;
+                            totalSubmissions: number;
+                            completedSubmissions: number;
+                            questionResults: {
+                                questionId: string;
+                                questionText: string;
+                                /** @enum {string} */
+                                questionType: "single_choice" | "multiple_choice" | "free_text" | "rating";
+                                totalResponses: number;
+                                choiceResults?: {
+                                    choice: string;
+                                    count: number;
+                                    percentage: number;
+                                }[];
+                                averageRating?: number;
+                                ratingDistribution?: {
+                                    [key: string]: number;
+                                };
+                                freeTextAnswers?: string[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/questionnaires/{id}/close": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * アンケートを締切
+         * @description アンケートの回答受付を締め切ります
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 締切成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description リクエストエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -115,3 +115,21 @@ export type ReconvertFileResponse = PostOk<"/admin/knowledge/reconvert">;
 export type InvitationsResponse = GetOk<"/admin/invitations">;
 export type Invitation = InvitationsResponse["invitations"][number];
 export type CreateInvitationResponse = PostCreated<"/admin/invitations">;
+
+// アンケート
+export type QuestionnairesResponse = GetOk<"/admin/questionnaires">;
+export type QuestionnaireMessage =
+  QuestionnairesResponse["questionnaires"][number];
+export type QuestionnaireQuestion = QuestionnaireMessage["questions"][number];
+export type QuestionnaireStatus = "draft" | "scheduled" | "sent" | "closed";
+export type QuestionType =
+  | "single_choice"
+  | "multiple_choice"
+  | "free_text"
+  | "rating";
+export type CreateQuestionnaireRequest = PostBody<"/admin/questionnaires">;
+export type UpdateQuestionnaireRequest = PutBody<"/admin/questionnaires/{id}">;
+export type QuestionnaireResultsResponse =
+  GetOk<"/admin/questionnaires/{id}/results">;
+export type QuestionResult =
+  QuestionnaireResultsResponse["questionResults"][number];


### PR DESCRIPTION
## Summary
- 管理画面でアンケートを作成・編集し、LINEに配信する機能を実装
- Flex Message + Postback で LINE トーク画面内で回答を完結
- 回答結果の集計・グラフ表示を管理画面で確認可能

## 主な変更内容

### サーバー
- **DB**: questionnaires, questionnaire_questions, questionnaire_submissions, questionnaire_answers の4テーブル追加
- **API**: アンケートCRUD、LINE配信、回答結果取得、締切のエンドポイント
- **LINE配信**: Flex Message で設問UI（選択式・評価・自由記述）を生成、broadcast APIで全フォロワーに配信
- **回答処理**: Postbackイベントで回答を受信、1問ずつ次の質問を送信するフロー
- **スケジュール配信**: Cron（5分間隔）で予約時刻を過ぎたアンケートを自動配信
- **集計**: 選択式（件数・割合）、評価（平均・分布）、自由記述（テキスト一覧）

### フロントエンド
- ダッシュボードに「アンケート」タブを追加
- 作成フォーム: 設問の動的増減、質問形式選択、無記名/記名切替
- 配信タイミング: 下書き保存 / 今すぐ配信 / スケジュール（LINE配信と同じUI）
- 結果画面: 棒グラフ・評価分布・自由記述一覧

### 設計判断
- 無記名/記名は `is_anonymous` フラグで切替可能（デフォルト無記名、後から記名に変更可）
- userId は内部的に常に保存（重複回答防止）、管理画面では集計のみ表示
- ねっぷちゃんへのコンテキスト注入は別Issue（#412）で検討中

## Related
- #394
- #412

## Test plan
- [ ] アンケート作成（各質問形式: 単一選択、複数選択、自由記述、評価）
- [ ] アンケート編集・削除（draft のみ）
- [ ] LINE配信（即時・スケジュール）
- [ ] LINE上での回答フロー（1問ずつ送信 → 完了メッセージ）
- [ ] 重複回答の防止
- [ ] 回答結果の集計・グラフ表示
- [ ] アンケート締切
- [ ] ステータスフィルタリング