### PR TITLE
revert: tagpr PRのCIトリガーステップを削除

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -6,7 +6,6 @@ on:
       - develop
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
@@ -23,13 +22,6 @@ jobs:
         uses: Songmu/tagpr@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Trigger CI for tagpr PR
-        if: steps.tagpr.outputs.pull_request_number != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run ci.yml --ref "tagpr-from-v${{ steps.tagpr.outputs.version }}"
 
       - name: Trigger production deploy
         if: steps.tagpr.outputs.tag != ''

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -21,11 +21,11 @@ jobs:
         id: tagpr
         uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
 
       - name: Trigger production deploy
         if: steps.tagpr.outputs.tag != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TAGPR_TOKEN }}
         run: |
           gh workflow run deploy-prd.yml --ref "${{ steps.tagpr.outputs.tag }}"

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -21,11 +21,11 @@ jobs:
         id: tagpr
         uses: Songmu/tagpr@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Trigger production deploy
         if: steps.tagpr.outputs.tag != ''
         env:
-          GH_TOKEN: ${{ secrets.TAGPR_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run deploy-prd.yml --ref "${{ steps.tagpr.outputs.tag }}"


### PR DESCRIPTION
## Summary
- #414 で追加したtagpr PRのCIトリガーステップを削除

## 主な変更内容
`GITHUB_TOKEN`で起動した`workflow_dispatch`はPRのステータスチェックに紐づかないため、
CIトリガーは意味がなかった。tagpr PRはバージョンバンプのみなのでCIチェックは不要と判断。
不要になった`actions: write`パーミッションも削除。

## Test plan
- [ ] developにpushした際にtagprが正常にPRを作成・更新すること