### PR TITLE
fix(server): ペルソナ一括抽出で処理済みスレッドのスキップコストを削減

### DIFF
--- a/server/scripts/data/eval-test-cases.ts
+++ b/server/scripts/data/eval-test-cases.ts
@@ -990,9 +990,7 @@ export const evalTestCases: TestCaseV3[] = [
     input: "おと高の資料請求ページのURLを教えてください",
     groundTruth:
       "おと高の資料請求ページはこちらです: https://www.otoineppu-h.ed.jp/contact/shiryou.html",
-    requiredKeywords: [
-      "https://www.otoineppu-h.ed.jp/contact/shiryou.html",
-    ],
+    requiredKeywords: ["https://www.otoineppu-h.ed.jp/contact/shiryou.html"],
     threshold: 0.3,
     expectedUrl: "https://www.otoineppu-h.ed.jp/contact/shiryou.html",
   },
@@ -1003,9 +1001,7 @@ export const evalTestCases: TestCaseV3[] = [
     input: "おと高のお問い合わせフォームはどこですか？",
     groundTruth:
       "お問い合わせフォームはこちらです: https://www.otoineppu-h.ed.jp/contact/otoiawase.html",
-    requiredKeywords: [
-      "https://www.otoineppu-h.ed.jp/contact/otoiawase.html",
-    ],
+    requiredKeywords: ["https://www.otoineppu-h.ed.jp/contact/otoiawase.html"],
     threshold: 0.3,
     expectedUrl: "https://www.otoineppu-h.ed.jp/contact/otoiawase.html",
   },
@@ -1049,9 +1045,7 @@ export const evalTestCases: TestCaseV3[] = [
     input: "おと高の学校見学について知りたいのですが、ページはありますか？",
     groundTruth:
       "学校見学のページはこちらです: https://www.otoineppu-h.ed.jp/junior/kengaku.html",
-    requiredKeywords: [
-      "https://www.otoineppu-h.ed.jp/junior/kengaku.html",
-    ],
+    requiredKeywords: ["https://www.otoineppu-h.ed.jp/junior/kengaku.html"],
     threshold: 0.3,
     expectedUrl: "https://www.otoineppu-h.ed.jp/junior/kengaku.html",
   },
@@ -1073,9 +1067,7 @@ export const evalTestCases: TestCaseV3[] = [
     input: "おと高のギャラリーで工芸作品を見たいのですが",
     groundTruth:
       "工芸作品のギャラリーはこちらです: https://www.otoineppu-h.ed.jp/gallery/crafts.html",
-    requiredKeywords: [
-      "https://www.otoineppu-h.ed.jp/gallery/crafts.html",
-    ],
+    requiredKeywords: ["https://www.otoineppu-h.ed.jp/gallery/crafts.html"],
     threshold: 0.3,
     expectedUrl: "https://www.otoineppu-h.ed.jp/gallery/crafts.html",
   },

--- a/server/scripts/run-eval-v3.ts
+++ b/server/scripts/run-eval-v3.ts
@@ -1566,7 +1566,8 @@ const main = async () => {
     ];
   } else if (args.caseId) {
     // 前方一致: "ur-" で ur-01〜ur-25 全てにマッチ
-    const matched = evalV3TestCases.filter((c) => c.id.startsWith(args.caseId!));
+    const caseId = args.caseId as string;
+    const matched = evalV3TestCases.filter((c) => c.id.startsWith(caseId));
     if (matched.length === 0) {
       // 完全一致フォールバック
       const tc = evalV3TestCases.find((c) => c.id === args.caseId);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -40,6 +40,11 @@ export const mastraThreads = sqliteTable("mastra_threads", {
   resourceId: text("resourceId"),
 });
 
+export const mastraMessages = sqliteTable("mastra_messages", {
+  id: text("id").primaryKey(),
+  threadId: text("thread_id").notNull(),
+});
+
 // 型エクスポート
 export type EmergencyReport = typeof emergencyReports.$inferSelect;
 export type NewEmergencyReport = typeof emergencyReports.$inferInsert;

--- a/server/src/services/persona-extractor.ts
+++ b/server/src/services/persona-extractor.ts
@@ -3,7 +3,13 @@ import { Memory } from "@mastra/memory";
 import { count, desc, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { createDb, mastraThreads, persona, threadPersonaStatus } from "~/db";
+import {
+  createDb,
+  mastraMessages,
+  mastraThreads,
+  persona,
+  threadPersonaStatus,
+} from "~/db";
 import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
 import { personaAgent } from "~/mastra/agents/persona-agent";
@@ -142,11 +148,29 @@ const getAllThreads = async (d1: D1Database): Promise<ThreadInfo[]> => {
   return results.filter((t): t is ThreadInfo => t.resourceId !== null);
 };
 
+const getMessageCountsByThread = async (
+  d1: D1Database,
+): Promise<Map<string, number>> => {
+  const db = createDb(d1);
+
+  const results = await db
+    .select({
+      threadId: mastraMessages.threadId,
+      count: count(),
+    })
+    .from(mastraMessages)
+    .groupBy(mastraMessages.threadId)
+    .all();
+
+  return new Map(results.map((r) => [r.threadId, r.count]));
+};
+
 export const extractAllPendingThreads = async (env: CloudflareBindings) => {
   const allStatus = await threadPersonaStatusRepository.findAll(env.DB);
   const statusMap = new Map(allStatus.map((s) => [s.threadId, s]));
 
   const threads = await getAllThreads(env.DB);
+  const messageCountMap = await getMessageCountsByThread(env.DB);
 
   const results: Array<{
     threadId: string;
@@ -156,6 +180,16 @@ export const extractAllPendingThreads = async (env: CloudflareBindings) => {
   for (const thread of threads) {
     const status = statusMap.get(thread.id);
     const lastMessageCount = status?.lastMessageCount ?? 0;
+    const currentMessageCount = messageCountMap.get(thread.id) ?? 0;
+
+    // DB のメッセージ数で事前フィルタ（memory.recall() を呼ばずにスキップ）
+    if (currentMessageCount <= lastMessageCount) {
+      results.push({
+        threadId: thread.id,
+        result: { skipped: true, reason: "no_new_messages" },
+      });
+      continue;
+    }
 
     const result = await extractPersonaFromThread(
       thread.id,


### PR DESCRIPTION
## Summary
- ペルソナ一括抽出（`extractAllPendingThreads`）で、処理済みスレッドのスキップに `memory.recall()` を呼んでいたため、スレッド数が増えるほど CPU 時間を消費しタイムアウトまでの処理量が減少していた問題を修正
- `mastra_messages` テーブルからメッセージ数を一括取得して事前フィルタすることで、スキップ時の `memory.recall()` 呼び出しを回避

## 主な変更内容
- `server/src/db/schema.ts`: `mastra_messages` の読み取り専用 Drizzle スキーマを追加
- `server/src/services/persona-extractor.ts`:
  - `getMessageCountsByThread()` を追加（`GROUP BY thread_id` で全スレッドのメッセージ数を1クエリで取得）
  - `extractAllPendingThreads()` のループ内で、DB のメッセージ数と `lastMessageCount` を比較し、一致する場合は `extractPersonaFromThread()` を呼ばずに `continue`

## Test plan
- [x] `pnpm --filter server test` 全251テスト通過
- [x] `pnpm lint` エラーなし
- [x] `tsc --noEmit` 型チェック通過
- [ ] dev 環境でペルソナ全削除 → 「会話から抽出」を複数回実行し、処理量が減少しないことを確認