### PR TITLE
feat: LINE 配信メッセージのスレッド注入と検索統合

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -326,6 +326,13 @@ throw new HTTPException(404, { message: "Not found" });
 | created_at    | TEXT | 作成日時（NOT NULL）                        |
 | updated_at    | TEXT | 更新日時                                    |
 
+### user_broadcast_state
+
+| カラム           | 型   | 説明                          |
+| ---------------- | ---- | ----------------------------- |
+| user_id          | TEXT | PRIMARY KEY（LINE userId）    |
+| last_injected_at | TEXT | 最終配信注入日時（NOT NULL）  |
+
 ### questionnaires
 
 | カラム        | 型      | 説明                                          |

--- a/server/src/db/migrations/0015_user_broadcast_state.sql
+++ b/server/src/db/migrations/0015_user_broadcast_state.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS user_broadcast_state (
+  user_id TEXT PRIMARY KEY,
+  last_injected_at TEXT NOT NULL
+);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -204,3 +204,11 @@ export const adminSessions = sqliteTable("admin_sessions", {
 
 export type AdminSession = typeof adminSessions.$inferSelect;
 export type NewAdminSession = typeof adminSessions.$inferInsert;
+
+// ユーザー別配信注入状態
+export const userBroadcastState = sqliteTable("user_broadcast_state", {
+  userId: text("user_id").primaryKey(),
+  lastInjectedAt: text("last_injected_at").notNull(),
+});
+
+export type UserBroadcastState = typeof userBroadcastState.$inferSelect;

--- a/server/src/mastra/agents/knowledge-agent.ts
+++ b/server/src/mastra/agents/knowledge-agent.ts
@@ -1,6 +1,7 @@
 import { Agent } from "@mastra/core/agent";
 import { getCurrentDateInfo } from "~/lib/date";
 import { GEMINI_FLASH, geminiModelWithThinking } from "~/lib/llm-models";
+import { broadcastGetTool } from "~/mastra/tools/broadcast-get-tool";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
 
 const baseInstructions = `
@@ -99,6 +100,10 @@ const baseInstructions = `
 
 検索結果にない情報の推測や捏造は行わない。
 
+## LINE配信メッセージの検索
+broadcast-get ツールで過去にLINEで配信したお知らせを検索できる。
+ナレッジ検索で該当情報が見つからない場合や、ユーザーの質問が「お知らせ」「配信」「通知」に関連しそうな場合はこちらも検索する。
+
 ## URLの取り扱い
 - 検索結果に url フィールドがある場合、回答に関連するものだけを厳選して含める
 - 重複するURLは1つにまとめる
@@ -125,6 +130,7 @@ export const knowledgeAgent = new Agent({
   ...geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
   tools: {
     knowledgeSearchTool,
+    broadcastGetTool,
   },
 });
 
@@ -138,5 +144,6 @@ export const createKnowledgeAgentWithModel = (model: string) =>
     ...geminiModelWithThinking({ model, level: "high" }),
     tools: {
       knowledgeSearchTool,
+      broadcastGetTool,
     },
   });

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -1,6 +1,5 @@
 import type { AgentConfig } from "@mastra/core/agent";
 import { Agent } from "@mastra/core/agent";
-import type { RequestContext } from "@mastra/core/request-context";
 import { getCurrentDateInfo } from "~/lib/date";
 import { type ModelTierConfig, resolveModelTier } from "~/lib/llm-models";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
@@ -16,7 +15,6 @@ import { displayChartTool } from "~/mastra/tools/display-chart-tool";
 import { displayTableTool } from "~/mastra/tools/display-table-tool";
 import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
 import { personaSchema } from "~/schemas/persona-schema";
-import { buildBroadcastMemory } from "~/services/broadcast-memory";
 
 const baseInstructions = (platform: "web" | "line") => `
 あなたは北海道音威子府（おといねっぷ）村に住む17歳の女の子「ねっぷちゃん」。
@@ -175,8 +173,8 @@ const lineInstructions = `
 - 箇条書きには「・」を使い、装飾なしで読みやすく整形する
 
 ### LINE配信の記憶
-ユーザーはあなたが送った配信メッセージをLINEで受信している。
-- 「これ」「さっきの」「最近のお知らせ」→ 記憶セクションの最近の配信を参照
+ユーザーはLINE配信メッセージを受信している。会話履歴に【LINE配信のお知らせ】として含まれている。
+- 「これ」「さっきの」→ 会話履歴内の直近の配信を参照
 - 古い配信の詳細が必要 → broadcast-get ツールを使う
 `;
 
@@ -195,38 +193,15 @@ export const createNeppChanAgent = ({
   const agents = isAdmin ? adminAgents : baseAgents;
   const tools = getTools(platform);
 
-  // instructionsを非同期関数化（リクエスト時に評価され、現在日時とbroadcast記憶が動的に取得される）
-  const instructions = async ({
-    requestContext,
-  }: {
-    requestContext: RequestContext;
-  }) => {
-    let broadcastSection = "";
-    const db = requestContext?.get("db") as D1Database | undefined;
-    if (db) {
-      try {
-        broadcastSection = await buildBroadcastMemory(db);
-      } catch {
-        // broadcast記憶の取得に失敗してもエージェントは動作可能
-      }
-    }
-
-    const webBroadcastNote =
-      platform === "web" && broadcastSection
-        ? "以下はあなたがLINEで配信した公式のお知らせ記録。Webユーザーはこの配信を直接受信していないが、あなたはこれらを自分が発信した情報として認識している。"
-        : "";
-
-    return [
+  const instructions = () =>
+    [
       baseInstructions(platform),
       platform === "line" ? lineInstructions : "",
       `## 現在の日時\n${getCurrentDateInfo()}`,
       isAdmin ? adminInstructions : "",
-      webBroadcastNote,
-      broadcastSection,
     ]
       .filter(Boolean)
       .join("\n");
-  };
 
   return new Agent({
     id: "nep-chan",

--- a/server/src/repository/broadcast-repository.ts
+++ b/server/src/repository/broadcast-repository.ts
@@ -234,6 +234,23 @@ export const broadcastRepository = {
       .all();
   },
 
+  async findSentSince(d1: D1Database, since: string, limit = 10) {
+    const db = createDb(d1);
+
+    return db
+      .select()
+      .from(broadcastMessages)
+      .where(
+        and(
+          eq(broadcastMessages.status, "sent"),
+          sql`${broadcastMessages.sentAt} > ${since}`,
+        ),
+      )
+      .orderBy(broadcastMessages.sentAt)
+      .limit(limit)
+      .all();
+  },
+
   async delete(d1: D1Database, id: string) {
     const db = createDb(d1);
 

--- a/server/src/repository/user-broadcast-state-repository.ts
+++ b/server/src/repository/user-broadcast-state-repository.ts
@@ -1,0 +1,29 @@
+import { eq } from "drizzle-orm";
+
+import { createDb, userBroadcastState } from "~/db";
+
+export const userBroadcastStateRepository = {
+  async findByUserId(d1: D1Database, userId: string) {
+    const db = createDb(d1);
+
+    const result = await db
+      .select()
+      .from(userBroadcastState)
+      .where(eq(userBroadcastState.userId, userId))
+      .get();
+
+    return result ?? null;
+  },
+
+  async upsert(d1: D1Database, userId: string, lastInjectedAt: string) {
+    const db = createDb(d1);
+
+    await db
+      .insert(userBroadcastState)
+      .values({ userId, lastInjectedAt })
+      .onConflictDoUpdate({
+        target: userBroadcastState.userId,
+        set: { lastInjectedAt },
+      });
+  },
+};

--- a/server/src/services/broadcast-thread-injector.ts
+++ b/server/src/services/broadcast-thread-injector.ts
@@ -1,0 +1,69 @@
+import type { D1Store } from "@mastra/cloudflare-d1";
+import { logger } from "~/lib/logger";
+import { broadcastRepository } from "~/repository/broadcast-repository";
+import { userBroadcastStateRepository } from "~/repository/user-broadcast-state-repository";
+
+const DEFAULT_LOOKBACK_DAYS = 7;
+
+const buildSystemContent = (title: string, body: string, sentAt: string) => {
+  const date = sentAt.slice(0, 10);
+  return `【LINE配信のお知らせ（${date}）】${title}\n${body}`;
+};
+
+export const injectBroadcastsToThread = async (params: {
+  d1: D1Database;
+  storage: D1Store;
+  threadId: string;
+  resourceId: string;
+  userId: string;
+}) => {
+  const { d1, storage, threadId, resourceId, userId } = params;
+
+  const memoryStore = await storage.getStore("memory");
+  if (!memoryStore) return;
+
+  // スレッドが存在しない場合はスキップ（初回は agent.generate がスレッド作成する）
+  const thread = await memoryStore.getThreadById({ threadId });
+  if (!thread) return;
+
+  const state = await userBroadcastStateRepository.findByUserId(d1, userId);
+
+  let since: string;
+  if (state) {
+    since = state.lastInjectedAt;
+  } else {
+    const lookback = new Date();
+    lookback.setDate(lookback.getDate() - DEFAULT_LOOKBACK_DAYS);
+    since = lookback.toISOString();
+  }
+
+  const broadcasts = await broadcastRepository.findSentSince(d1, since);
+
+  if (broadcasts.length === 0) return;
+
+  const messages = broadcasts.map((b) => ({
+    id: `broadcast-inject:${b.id}:${threadId}`,
+    role: "system" as const,
+    createdAt: new Date(b.sentAt!),
+    threadId,
+    resourceId,
+    content: {
+      format: 2 as const,
+      parts: [
+        {
+          type: "text" as const,
+          text: buildSystemContent(b.title, b.body, b.sentAt!),
+        },
+      ],
+    },
+  }));
+
+  await memoryStore.saveMessages({ messages });
+
+  const latestSentAt = broadcasts[broadcasts.length - 1]!.sentAt!;
+  await userBroadcastStateRepository.upsert(d1, userId, latestSentAt);
+
+  logger.info(
+    `[broadcast-inject] Injected ${messages.length} broadcast(s) into ${threadId}`,
+  );
+};

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -8,6 +8,7 @@ import { getStorage } from "~/lib/storage";
 import { stripMarkdown } from "~/lib/strip-markdown";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
 import { createRequestContext } from "~/mastra/request-context";
+import { injectBroadcastsToThread } from "~/services/broadcast-thread-injector";
 
 export const createLineClient = (token: string) =>
   new messagingApi.MessagingApiClient({ channelAccessToken: token });
@@ -24,6 +25,16 @@ export const generateReply = async (params: {
     storage,
     db: params.env.DB,
     env: params.env,
+  });
+
+  // 未注入の配信メッセージをスレッドに system メッセージとして追加
+  const lineUserId = params.threadId.replace("line-thread:", "");
+  await injectBroadcastsToThread({
+    d1: params.env.DB,
+    storage,
+    threadId: params.threadId,
+    resourceId: params.resourceId,
+    userId: lineUserId,
   });
 
   // Intent 分類でモデルティアを決定（非テキストメッセージは casual 直行）


### PR DESCRIPTION
## Summary
- LINE 配信メッセージの instruction 注入（instruction 汚染）を廃止し、webhook 受信時にユーザーのスレッドへ system メッセージとして Lazy 注入する方式に変更
- knowledgeAgent に broadcastGetTool を追加し、検索フローで配信内容も探索可能に

## 主な変更内容

### スレッド注入（Lazy Join 方式）
- `user_broadcast_state` テーブルでユーザーごとの配信注入状態を管理
- `broadcast-thread-injector` サービスが webhook 受信時に未注入の配信を `system` ロールのメッセージとしてスレッドに追加
- 初回メッセージ時（スレッド未作成）はスキップし、2回目以降に注入
- 初回の lookback は直近7日分

### instruction 汚染の解消
- `buildBroadcastMemory()` による instruction への配信本文埋め込みを削除
- `nepp-chan-agent` の instructions を同期関数に簡素化

### 検索統合
- `knowledgeAgent` に `broadcastGetTool` を追加
- ナレッジ検索と並行して配信内容も検索可能に

## Test plan
- [ ] LINE で配信送信後、ユーザーが「これなに？」と返信 → 配信内容を参照した回答が返る
- [ ] 2つ前の配信について質問 → 該当する配信内容で回答
- [ ] 初回メッセージのユーザー → エラーなく通常の会話が成立
- [ ] Web チャットから「最近のお知らせは？」→ broadcastGetTool 経由で取得
- [ ] 既存テスト 251 件 pass、lint・tsc エラーなし