### PR TITLE
feat: アンケート投票結果の公開ページを追加

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -70,6 +70,7 @@ server/src/
 | `/admin/questionnaires/:id/send`   | POST     | アンケートLINE配信             |
 | `/admin/questionnaires/:id/results`| GET      | アンケート回答結果             |
 | `/admin/questionnaires/:id/close`  | POST     | アンケート締切                 |
+| `/questionnaires/:id/poll`         | GET      | アンケート投票結果             |
 | `/admin/invitations`               | GET/POST | 招待一覧・作成                 |
 | `/admin/invitations/:id`           | DELETE   | 招待削除                       |
 | `/auth/anonymous-session`          | POST     | 匿名セッショントークン取得（JWT発行） |

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,6 +24,7 @@ import {
   lineRoutes,
   personaAdminRoutes,
   questionnaireAdminRoutes,
+  questionnairePublicRoutes,
   threadsRoutes,
 } from "~/routes";
 import type { LineEventMessage } from "~/schemas/line-schema";
@@ -47,6 +48,7 @@ app.route("/admin/persona", personaAdminRoutes);
 app.route("/admin/emergency", emergencyAdminRoutes);
 app.route("/admin/invitations", invitationRoutes);
 app.route("/admin/questionnaires", questionnaireAdminRoutes);
+app.route("/questionnaires", questionnairePublicRoutes);
 app.route("/auth", authRoutes);
 app.route("/line", lineRoutes);
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -12,4 +12,5 @@ export { broadcastMediaRoutes } from "./broadcast-media";
 export { feedbackRoutes } from "./feedback";
 export { healthRoutes } from "./health";
 export { lineRoutes } from "./line";
+export { questionnairePublicRoutes } from "./questionnaire-public";
 export { threadsRoutes } from "./threads";

--- a/server/src/routes/questionnaire-public.ts
+++ b/server/src/routes/questionnaire-public.ts
@@ -1,0 +1,109 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+
+import { errorResponse } from "~/lib/openapi-errors";
+import { questionnaireRepository } from "~/repository/questionnaire-repository";
+import { getQuestionnaireResults } from "~/services/questionnaire-response";
+
+export const questionnairePublicRoutes = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+}>();
+
+const pollResultSchema = z.object({
+  questionnaireId: z.string(),
+  title: z.string(),
+  totalSubmissions: z.number(),
+  completedSubmissions: z.number(),
+  questionResults: z.array(
+    z.object({
+      questionId: z.string(),
+      questionText: z.string(),
+      questionType: z.enum(["single_choice", "multiple_choice"]),
+      totalResponses: z.number(),
+      choiceResults: z.array(
+        z.object({
+          choice: z.string(),
+          count: z.number(),
+          percentage: z.number(),
+        }),
+      ),
+    }),
+  ),
+});
+
+const pollRoute = createRoute({
+  method: "get",
+  path: "/{id}/poll",
+  summary: "アンケート投票結果を公開取得",
+  description:
+    "選択式設問の集計結果を認証不要で取得します。sent/closed のアンケートのみ対象。",
+  tags: ["Questionnaire"],
+  request: {
+    params: z.object({
+      id: z.string().min(1),
+    }),
+  },
+  responses: {
+    200: {
+      description: "取得成功",
+      content: {
+        "application/json": {
+          schema: pollResultSchema,
+        },
+      },
+    },
+    404: errorResponse(404),
+  },
+});
+
+questionnairePublicRoutes.openapi(pollRoute, async (c) => {
+  const { id } = c.req.valid("param");
+
+  const questionnaire = await questionnaireRepository.findById(c.env.DB, id);
+  if (!questionnaire) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+
+  if (questionnaire.status !== "sent" && questionnaire.status !== "closed") {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+
+  const results = await getQuestionnaireResults(c.env.DB, id);
+  if (!results) {
+    throw new HTTPException(404, {
+      message: "アンケートが見つかりません",
+    });
+  }
+
+  const choiceResults = results.questionResults.filter(
+    (
+      qr,
+    ): qr is typeof qr & {
+      choiceResults: { choice: string; count: number; percentage: number }[];
+    } =>
+      (qr.questionType === "single_choice" ||
+        qr.questionType === "multiple_choice") &&
+      "choiceResults" in qr,
+  );
+
+  return c.json(
+    {
+      questionnaireId: results.questionnaireId,
+      title: results.title,
+      totalSubmissions: results.totalSubmissions,
+      completedSubmissions: results.completedSubmissions,
+      questionResults: choiceResults.map((qr) => ({
+        questionId: qr.questionId,
+        questionText: qr.questionText,
+        questionType: qr.questionType as "single_choice" | "multiple_choice",
+        totalResponses: qr.totalResponses,
+        choiceResults: qr.choiceResults,
+      })),
+    },
+    200,
+  );
+});

--- a/server/src/services/questionnaire-delivery.ts
+++ b/server/src/services/questionnaire-delivery.ts
@@ -41,14 +41,23 @@ export const sendQuestionnaire = async (
     const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
     const retryKey = crypto.randomUUID();
     const firstQuestion = questions[0];
-    const message = buildQuestionFlexMessage(
+    const questionMessage = buildQuestionFlexMessage(
       questionnaire,
       firstQuestion,
       1,
       questions.length,
     );
 
-    await client.broadcast({ messages: [message] }, retryKey);
+    const hasChoiceQuestions = questions.some(
+      (q) => q.type === "single_choice" || q.type === "multiple_choice",
+    );
+
+    const messages: messagingApi.Message[] = [questionMessage];
+    if (hasChoiceQuestions) {
+      messages.push(buildPollResultsLinkMessage(questionnaire, env.WEB_URL));
+    }
+
+    await client.broadcast({ messages }, retryKey);
 
     await questionnaireRepository.update(env.DB, questionnaireId, {
       status: "sent",
@@ -199,6 +208,62 @@ export const buildQuestionFlexMessage = (
   return {
     type: "flex",
     altText: `アンケート: ${questionnaire.title} (Q${currentOrder}/${totalQuestions})`,
+    contents: bubble,
+  };
+};
+
+export const buildPollResultsLinkMessage = (
+  questionnaire: Questionnaire,
+  webUrl: string,
+): messagingApi.FlexMessage => {
+  const pollUrl = `${webUrl}/poll?id=${questionnaire.id}`;
+
+  const bubble: messagingApi.FlexBubble = {
+    type: "bubble",
+    size: "kilo",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "text",
+          text: "📊 投票結果",
+          weight: "bold",
+          size: "sm",
+          color: "#1DB446",
+        },
+        {
+          type: "text",
+          text: "投票状況を確認できます",
+          size: "xs",
+          color: "#888888",
+          margin: "md",
+          wrap: true,
+        },
+      ],
+    },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "button",
+          action: {
+            type: "uri",
+            label: "結果を見る",
+            uri: pollUrl,
+          },
+          style: "primary",
+          color: "#0f766e",
+          height: "sm",
+        },
+      ],
+    },
+  };
+
+  return {
+    type: "flex",
+    altText: `${questionnaire.title} - 投票結果を見る`,
     contents: bubble,
   };
 };

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -30,7 +30,8 @@ web/
 │   │   ├── index.astro        # / → チャット画面
 │   │   ├── dashboard.astro    # /dashboard → ダッシュボード
 │   │   ├── login.astro        # /login → ログイン
-│   │   └── register.astro     # /register → 登録
+│   │   ├── register.astro     # /register → 登録
+│   │   └── poll.astro         # /poll → 投票結果
 │   ├── app/                   # React ページコンポーネント
 │   │   ├── chat/              # チャット画面
 │   │   │   ├── App.tsx              # エントリー（RootLayout + QueryProvider）
@@ -40,6 +41,8 @@ web/
 │   │   ├── auth/              # 認証画面
 │   │   │   ├── LoginPage.tsx        # ログインページ
 │   │   │   └── RegisterPage.tsx     # 登録ページ
+│   │   ├── poll/              # 投票結果画面
+│   │   │   └── PollResultsPage.tsx  # 投票結果ページ
 │   │   └── dashboard/         # ダッシュボード画面
 │   │       ├── DashboardPage.tsx    # エントリー（RootLayout + Providers）
 │   │       ├── App.tsx              # ダッシュボード本体（認証ガード含む）
@@ -161,6 +164,7 @@ export const toolsByName = {
 | `/dashboard` | `pages/dashboard.astro`| `app/dashboard/DashboardPage` |
 | `/login`     | `pages/login.astro`    | `app/auth/LoginPage`    |
 | `/register`  | `pages/register.astro` | `app/auth/RegisterPage` |
+| `/poll`      | `pages/poll.astro`     | `app/poll/PollResultsPage` |
 
 ## コーディング規約
 

--- a/web/src/app/poll/PollResultsPage.tsx
+++ b/web/src/app/poll/PollResultsPage.tsx
@@ -1,0 +1,150 @@
+import { useQuery } from "@tanstack/react-query";
+import { RootLayout } from "~/components/RootLayout";
+import { QueryProvider } from "~/providers/QueryProvider";
+import { fetchPollResults } from "~/repository/questionnaire-repository";
+import type { PollChoiceResult, PollQuestionResult } from "~/types";
+
+const usePollResults = (id: string | null) =>
+  useQuery({
+    queryKey: ["poll-results", id],
+    queryFn: () => fetchPollResults(id as string),
+    enabled: !!id,
+  });
+
+const ChoiceBar = ({
+  choice,
+  count,
+  percentage,
+  isLeading,
+}: PollChoiceResult & { isLeading: boolean }) => (
+  <div className="space-y-1.5">
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-sm font-medium text-stone-700 truncate">
+        {choice}
+      </span>
+      <span className="text-sm tabular-nums shrink-0 text-stone-500">
+        {count}票
+      </span>
+    </div>
+    <div className="h-9 bg-stone-100 rounded-lg overflow-hidden relative">
+      <div
+        className={`h-full rounded-lg ${isLeading ? "bg-teal-500" : "bg-teal-300"}`}
+        style={{ width: `${Math.max(percentage, 2)}%` }}
+      />
+      <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-medium text-stone-600 tabular-nums">
+        {percentage}%
+      </span>
+    </div>
+  </div>
+);
+
+const QuestionCard = ({
+  result,
+  index,
+}: {
+  result: PollQuestionResult;
+  index: number;
+}) => {
+  const maxCount = Math.max(...result.choiceResults.map((cr) => cr.count), 0);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-stone-200/80 p-5 space-y-4">
+      <div className="space-y-1">
+        <p className="text-xs font-medium text-teal-600 tracking-wide">
+          Q{index + 1}
+          {result.questionType === "multiple_choice" && " (複数選択)"}
+        </p>
+        <h3 className="text-base font-semibold text-stone-800 leading-snug">
+          {result.questionText}
+        </h3>
+      </div>
+      <div className="space-y-3">
+        {result.choiceResults.map((cr) => (
+          <ChoiceBar
+            key={cr.choice}
+            {...cr}
+            isLeading={cr.count === maxCount && maxCount > 0}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-stone-400 text-right tabular-nums">
+        {result.totalResponses}票
+      </p>
+    </div>
+  );
+};
+
+const PollContent = ({ id }: { id: string }) => {
+  const { data, isLoading, isError } = usePollResults(id);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-dvh bg-stone-50">
+        <div className="animate-pulse text-center space-y-2">
+          <div className="h-4 w-32 bg-stone-200 rounded mx-auto" />
+          <div className="h-3 w-24 bg-stone-100 rounded mx-auto" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex items-center justify-center min-h-dvh bg-stone-50">
+        <div className="text-center space-y-2 p-6">
+          <p className="text-stone-600 font-medium">投票結果を表示できません</p>
+          <p className="text-sm text-stone-400">
+            アンケートが存在しないか、まだ配信されていません
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-dvh bg-stone-50">
+      <div className="max-w-lg mx-auto px-4 py-6 space-y-5">
+        <header className="space-y-1">
+          <h1 className="text-lg font-bold text-stone-800">{data.title}</h1>
+          <p className="text-sm text-stone-500 tabular-nums">
+            {data.totalSubmissions}人が参加
+          </p>
+        </header>
+
+        {data.questionResults.length === 0 && (
+          <div className="bg-white rounded-2xl border border-stone-200/80 p-8 text-center">
+            <p className="text-sm text-stone-400">まだ投票がありません</p>
+          </div>
+        )}
+
+        {data.questionResults.map((qr, i) => (
+          <QuestionCard key={qr.questionId} result={qr} index={i} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const PollResultsInner = () => {
+  const id = new URLSearchParams(window.location.search).get("id");
+
+  if (!id) {
+    return (
+      <div className="flex items-center justify-center min-h-dvh bg-stone-50">
+        <p className="text-stone-500 text-sm">
+          アンケートIDが指定されていません
+        </p>
+      </div>
+    );
+  }
+
+  return <PollContent id={id} />;
+};
+
+export const PollResultsPage = () => (
+  <RootLayout>
+    <QueryProvider>
+      <PollResultsInner />
+    </QueryProvider>
+  </RootLayout>
+);

--- a/web/src/pages/poll.astro
+++ b/web/src/pages/poll.astro
@@ -1,0 +1,19 @@
+---
+import "~/index.css";
+import { PollResultsPage } from "~/app/poll/PollResultsPage";
+---
+
+<html lang="ja">
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon-chat.svg" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content, viewport-fit=cover"
+		/>
+		<title>投票結果 | ねっぷちゃん</title>
+	</head>
+	<body>
+		<PollResultsPage client:only="react" />
+	</body>
+</html>

--- a/web/src/repository/questionnaire-repository.ts
+++ b/web/src/repository/questionnaire-repository.ts
@@ -88,3 +88,11 @@ export const fetchQuestionnaireResults = async (id: string) => {
   if (error) throw error;
   return data;
 };
+
+export const fetchPollResults = async (id: string) => {
+  const { data, error } = await client.GET("/questionnaires/{id}/poll", {
+    params: { path: { id } },
+  });
+  if (error) throw error;
+  return data;
+};

--- a/web/src/types/api.d.ts
+++ b/web/src/types/api.d.ts
@@ -45,65 +45,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/chat": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * ねっぷちゃんとおしゃべり
-         * @description ねっぷちゃん（音威子府村のAIキャラクター）にメッセージを送信し、ストリーミングレスポンスを受け取る
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        message: {
-                            id: string;
-                            /** @enum {string} */
-                            role: "user" | "assistant" | "system";
-                            parts: ({
-                                type: string;
-                            } & {
-                                [key: string]: unknown;
-                            })[];
-                            /** Format: date */
-                            createdAt?: string | null;
-                        };
-                        threadId: string;
-                        /** @enum {string} */
-                        intent?: "casual" | "thinking";
-                    };
-                };
-            };
-            responses: {
-                /** @description ストリーミングレスポンス */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "text/event-stream": string;
-                    };
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/feedback": {
         parameters: {
             query?: never;
@@ -442,6 +383,66 @@ export interface paths {
         };
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/threads/{threadId}/chat": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * ねっぷちゃんとおしゃべり
+         * @description ねっぷちゃん（音威子府村のAIキャラクター）にメッセージを送信し、ストリーミングレスポンスを受け取る
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    threadId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        message: {
+                            id: string;
+                            /** @enum {string} */
+                            role: "user" | "assistant" | "system";
+                            parts: ({
+                                type: string;
+                            } & {
+                                [key: string]: unknown;
+                            })[];
+                            /** Format: date-time */
+                            createdAt?: string | null;
+                        };
+                        /** @enum {string} */
+                        intent?: "casual" | "thinking";
+                    };
+                };
+            };
+            responses: {
+                /** @description ストリーミングレスポンス */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "text/event-stream": string;
+                    };
+                };
+            };
+        };
         delete?: never;
         options?: never;
         head?: never;
@@ -3646,6 +3647,78 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/questionnaires/{id}/poll": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * アンケート投票結果を公開取得
+         * @description 選択式設問の集計結果を認証不要で取得します。sent/closed のアンケートのみ対象。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 取得成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            questionnaireId: string;
+                            title: string;
+                            totalSubmissions: number;
+                            completedSubmissions: number;
+                            questionResults: {
+                                questionId: string;
+                                questionText: string;
+                                /** @enum {string} */
+                                questionType: "single_choice" | "multiple_choice";
+                                totalResponses: number;
+                                choiceResults: {
+                                    choice: string;
+                                    count: number;
+                                    percentage: number;
+                                }[];
+                            }[];
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/register": {
         parameters: {
             query?: never;
@@ -3873,7 +3946,7 @@ export interface paths {
         put?: never;
         /**
          * 匿名セッショントークン取得
-         * @description 一般ユーザー向けの匿名セッショントークンを発行する。resourceId を指定しない場合はサーバーで生成する。
+         * @description 一般ユーザー向けの匿名セッショントークンを発行する。resourceId はサーバーで生成する。
          */
         post: {
             parameters: {
@@ -3882,14 +3955,7 @@ export interface paths {
                 path?: never;
                 cookie?: never;
             };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** @description 既存の resourceId（UUID v4 形式） */
-                        resourceId?: string;
-                    };
-                };
-            };
+            requestBody?: never;
             responses: {
                 /** @description トークン発行成功 */
                 200: {
@@ -3900,34 +3966,6 @@ export interface paths {
                         "application/json": {
                             token: string;
                             resourceId: string;
-                        };
-                    };
-                };
-                /** @description リクエストエラー */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: {
-                                code: number;
-                                message: string;
-                            };
-                        };
-                    };
-                };
-                /** @description リソースが競合しています */
-                409: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: {
-                                code: number;
-                                message: string;
-                            };
                         };
                     };
                 };

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -133,3 +133,8 @@ export type QuestionnaireResultsResponse =
   GetOk<"/admin/questionnaires/{id}/results">;
 export type QuestionResult =
   QuestionnaireResultsResponse["questionResults"][number];
+
+// アンケート投票結果（公開）
+export type PollResultsResponse = GetOk<"/questionnaires/{id}/poll">;
+export type PollQuestionResult = PollResultsResponse["questionResults"][number];
+export type PollChoiceResult = PollQuestionResult["choiceResults"][number];

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -134,7 +134,7 @@ export type QuestionnaireResultsResponse =
 export type QuestionResult =
   QuestionnaireResultsResponse["questionResults"][number];
 
-// アンケート投票結果（公開）
+// アンケート投票結果
 export type PollResultsResponse = GetOk<"/questionnaires/{id}/poll">;
 export type PollQuestionResult = PollResultsResponse["questionResults"][number];
 export type PollChoiceResult = PollQuestionResult["choiceResults"][number];


### PR DESCRIPTION
## Summary
- 選択式アンケートの投票結果を閲覧できる公開ページ `/poll?id=xxx` を追加
- LINE Flex Message に「結果を見る」ボタンを同梱し、配信時にリンクを提供
- 認証不要の公開 API `GET /questionnaires/:id/poll` を新設

## 主な変更内容

### Server
- `GET /questionnaires/:id/poll` エンドポイント追加（認証不要、sent/closed のみ対象）
- 既存の `getQuestionnaireResults` を再利用し、選択式（single_choice / multiple_choice）のみフィルタして返す
- `sendQuestionnaire` で選択式設問を含む場合に「結果を見る」URI ボタン付き Flex Message をブロードキャストに同梱

### Web
- `pages/poll.astro` + `app/poll/PollResultsPage.tsx` で投票結果ページを追加
- OpenAPI 型を再生成し `client.GET` 経由で公開 API を呼び出す
- モバイルファースト（LINE In-App Browser 想定）の棒グラフ UI

## Test plan
- [ ] ダッシュボードから選択式アンケートを作成・配信
- [ ] `/poll?id={questionnaireId}` にアクセスして結果が表示されること
- [ ] 回答後に結果ページの数値が反映されること
- [ ] 存在しない ID やドラフト状態のアンケートで 404 が返ること
- [ ] LINE Flex Message に「結果を見る」ボタンが表示されること