### PR TITLE
fix(server): admin_sessions マイグレーションを冪等に修正

### DIFF
--- a/server/src/db/migrations/0013_admin_sessions.sql
+++ b/server/src/db/migrations/0013_admin_sessions.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `admin_sessions` (
+CREATE TABLE IF NOT EXISTS `admin_sessions` (
 	`token` text PRIMARY KEY NOT NULL,
 	`user_id` text NOT NULL,
 	`expires_at` text NOT NULL,


### PR DESCRIPTION
## Summary
- dev 環境で `admin_sessions` テーブルが既存のためマイグレーション (`0013_admin_sessions.sql`) が失敗していた
- `CREATE TABLE` を `CREATE TABLE IF NOT EXISTS` に変更して冪等化

## Test plan
- [ ] dev 環境にデプロイしてマイグレーションが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)