### PR TITLE
feat(server): 投票結果リンクを回答完了時に送信

### DIFF
--- a/server/src/services/questionnaire-delivery.ts
+++ b/server/src/services/questionnaire-delivery.ts
@@ -48,16 +48,7 @@ export const sendQuestionnaire = async (
       questions.length,
     );
 
-    const hasChoiceQuestions = questions.some(
-      (q) => q.type === "single_choice" || q.type === "multiple_choice",
-    );
-
-    const messages: messagingApi.Message[] = [questionMessage];
-    if (hasChoiceQuestions) {
-      messages.push(buildPollResultsLinkMessage(questionnaire, env.WEB_URL));
-    }
-
-    await client.broadcast({ messages }, retryKey);
+    await client.broadcast({ messages: [questionMessage] }, retryKey);
 
     await questionnaireRepository.update(env.DB, questionnaireId, {
       status: "sent",
@@ -212,58 +203,3 @@ export const buildQuestionFlexMessage = (
   };
 };
 
-export const buildPollResultsLinkMessage = (
-  questionnaire: Questionnaire,
-  webUrl: string,
-): messagingApi.FlexMessage => {
-  const pollUrl = `${webUrl}/poll?id=${questionnaire.id}`;
-
-  const bubble: messagingApi.FlexBubble = {
-    type: "bubble",
-    size: "kilo",
-    body: {
-      type: "box",
-      layout: "vertical",
-      contents: [
-        {
-          type: "text",
-          text: "📊 投票結果",
-          weight: "bold",
-          size: "sm",
-          color: "#1DB446",
-        },
-        {
-          type: "text",
-          text: "投票状況を確認できます",
-          size: "xs",
-          color: "#888888",
-          margin: "md",
-          wrap: true,
-        },
-      ],
-    },
-    footer: {
-      type: "box",
-      layout: "vertical",
-      contents: [
-        {
-          type: "button",
-          action: {
-            type: "uri",
-            label: "結果を見る",
-            uri: pollUrl,
-          },
-          style: "primary",
-          color: "#0f766e",
-          height: "sm",
-        },
-      ],
-    },
-  };
-
-  return {
-    type: "flex",
-    altText: `${questionnaire.title} - 投票結果を見る`,
-    contents: bubble,
-  };
-};

--- a/server/src/services/questionnaire-delivery.ts
+++ b/server/src/services/questionnaire-delivery.ts
@@ -202,4 +202,3 @@ export const buildQuestionFlexMessage = (
     contents: bubble,
   };
 };
-

--- a/server/src/services/questionnaire-response.ts
+++ b/server/src/services/questionnaire-response.ts
@@ -1,4 +1,7 @@
+import type { messagingApi } from "@line/bot-sdk";
+
 import {
+  type Questionnaire,
   type QuestionnaireQuestion,
   questionnaireRepository,
 } from "~/repository/questionnaire-repository";
@@ -116,25 +119,20 @@ export const handleQuestionnairePostback = async (
       completedAt: now,
     });
 
+    const completionMessage = buildCompletionFlexMessage(
+      questionnaire,
+      env.WEB_URL,
+    );
+
     try {
       await client.replyMessage({
         replyToken,
-        messages: [
-          {
-            type: "text",
-            text: `「${questionnaire.title}」へのご回答ありがとうございました！`,
-          },
-        ],
+        messages: [completionMessage],
       });
     } catch {
       await client.pushMessage({
         to: userId,
-        messages: [
-          {
-            type: "text",
-            text: `「${questionnaire.title}」へのご回答ありがとうございました！`,
-          },
-        ],
+        messages: [completionMessage],
       });
     }
   }
@@ -160,6 +158,62 @@ const buildAnswerData = (
     default:
       return { answerText: answer };
   }
+};
+
+const buildCompletionFlexMessage = (
+  questionnaire: Questionnaire,
+  webUrl: string,
+): messagingApi.FlexMessage => {
+  const pollUrl = `${webUrl}/poll?id=${questionnaire.id}`;
+
+  const bubble: messagingApi.FlexBubble = {
+    type: "bubble",
+    size: "kilo",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "text",
+          text: "✅ 回答完了",
+          weight: "bold",
+          size: "sm",
+          color: "#1DB446",
+        },
+        {
+          type: "text",
+          text: `「${questionnaire.title}」へのご回答ありがとうございました！`,
+          size: "xs",
+          color: "#888888",
+          margin: "md",
+          wrap: true,
+        },
+      ],
+    },
+    footer: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "button",
+          action: {
+            type: "uri",
+            label: "投票結果を見る",
+            uri: pollUrl,
+          },
+          style: "primary",
+          color: "#0f766e",
+          height: "sm",
+        },
+      ],
+    },
+  };
+
+  return {
+    type: "flex",
+    altText: `「${questionnaire.title}」へのご回答ありがとうございました！`,
+    contents: bubble,
+  };
 };
 
 // --- 集計 ---


### PR DESCRIPTION
## Summary
- 配信時の Flex Message から投票結果リンクを削除
- アンケート全問回答完了時のお礼メッセージを Flex Message に変更し、投票結果リンクを付与

## 主な変更内容
- `questionnaire-delivery.ts`: `buildPollResultsLinkMessage` を削除し、配信時は設問のみ送信
- `questionnaire-response.ts`: 回答完了時に `buildCompletionFlexMessage` で「✅ 回答完了」+お礼+「投票結果を見る」ボタンを送信

## Test plan
- [ ] アンケート配信時に投票結果リンクが含まれないことを確認
- [ ] 全問回答完了時に投票結果リンク付き Flex Message が表示されることを確認
- [ ] 投票結果リンクから `/poll?id=xxx` に正しく遷移できることを確認