### PR TITLE
feat(server): 管理者モード向けに投票結果取得ツール pollGetTool を追加

### DIFF
--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -14,6 +14,7 @@ import { devTool } from "~/mastra/tools/dev-tool";
 import { displayChartTool } from "~/mastra/tools/display-chart-tool";
 import { displayTableTool } from "~/mastra/tools/display-table-tool";
 import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
+import { pollGetTool } from "~/mastra/tools/poll-get-tool";
 import { personaSchema } from "~/schemas/persona-schema";
 
 const baseInstructions = (platform: "web" | "line") => `
@@ -118,6 +119,10 @@ const adminInstructions = `
 - 村民の声・住民レポート → まず personaAnalystAgent に委譲する
   村の状況把握や住民の声に関する質問はpersonaAnalystAgentを優先する。結果が不十分な場合はwebResearcherAgentで補完する。
   例: 「住民の声を教えて」「困ってる人はいる？」「村の調子はどう？」「最近どんな話題が多い？」「年代別の傾向は？」「交通の不満をもっと教えて」
+
+### 投票の結果・傾向分析
+- 投票結果を踏まえた分析（例: 「最近の投票結果は？」「どの選択肢が人気だった？」「投票の傾向を教えて」）→ pollGetTool
+- 選択肢別の割合や参加人数は display-chart で可視化、複数投票の比較は display-table で一覧化する
 `;
 
 const baseAgents = {
@@ -135,6 +140,7 @@ const adminAgents = {
 
 const defaultTools = {
   broadcastGetTool,
+  pollGetTool,
 };
 
 const webTools = {

--- a/server/src/mastra/tools/poll-get-tool.ts
+++ b/server/src/mastra/tools/poll-get-tool.ts
@@ -1,0 +1,127 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { logger } from "~/lib/logger";
+import { type Poll, pollRepository } from "~/repository/poll-repository";
+import { getPollResults } from "~/services/poll-response";
+import { requireDb } from "./helpers";
+
+const pollWithResultsSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  choices: z.array(z.string()),
+  status: z.enum(["draft", "scheduled", "sent", "closed"]),
+  sentAt: z.string().nullable(),
+  closedAt: z.string().nullable(),
+  totalSubmissions: z.number(),
+  choiceResults: z.array(
+    z.object({
+      choice: z.string(),
+      count: z.number(),
+      percentage: z.number(),
+    }),
+  ),
+});
+
+type PollWithResults = z.infer<typeof pollWithResultsSchema>;
+
+export const pollGetTool = createTool({
+  id: "poll-get",
+  description:
+    "過去の投票とその集計結果を取得します。IDで特定の投票を指定するか、件数を指定して最新の配信済み（sent/closed）投票一覧を取得できます。結果の分析や傾向把握に利用します。",
+  inputSchema: z.object({
+    id: z
+      .string()
+      .optional()
+      .describe("投票のID。特定の投票を取得する場合に指定"),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(20)
+      .default(10)
+      .describe("取得する最大件数（一覧取得時）。デフォルトは10件"),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    polls: z.array(pollWithResultsSchema),
+    count: z.number(),
+    message: z.string(),
+    error: z.string().optional(),
+  }),
+  execute: async (inputData, context) => {
+    const result = requireDb(context);
+    if ("error" in result) {
+      return {
+        success: false,
+        polls: [],
+        count: 0,
+        message: result.error.message,
+        error: result.error.error,
+      };
+    }
+    const { db } = result;
+    const { id, limit } = inputData;
+
+    try {
+      if (id) {
+        const poll = await pollRepository.findById(db, id);
+        if (!poll || (poll.status !== "sent" && poll.status !== "closed")) {
+          return {
+            success: true,
+            polls: [],
+            count: 0,
+            message: "指定されたIDの投票が見つかりません",
+          };
+        }
+        return {
+          success: true,
+          polls: [await buildPollWithResults(db, poll)],
+          count: 1,
+          message: "投票を取得しました",
+        };
+      }
+
+      const listResult = await pollRepository.findAll(db, {
+        limit,
+        status: ["sent", "closed"],
+      });
+
+      const polls = await Promise.all(
+        listResult.polls.map((p) => buildPollWithResults(db, p)),
+      );
+
+      return {
+        success: true,
+        polls,
+        count: polls.length,
+        message: `配信済みの投票を${polls.length}件取得しました`,
+      };
+    } catch (error) {
+      logger.error("Poll fetch failed", error);
+      return {
+        success: false,
+        polls: [],
+        count: 0,
+        message: "投票の取得に失敗しました",
+        error: error instanceof Error ? error.message : "Unknown error",
+      };
+    }
+  },
+});
+
+const buildPollWithResults = async (
+  db: D1Database,
+  poll: Poll,
+): Promise<PollWithResults> => {
+  const results = await getPollResults(db, poll.id);
+  return {
+    id: poll.id,
+    title: poll.title,
+    choices: JSON.parse(poll.choices) as string[],
+    status: poll.status,
+    sentAt: poll.sentAt,
+    closedAt: poll.closedAt,
+    totalSubmissions: results?.totalSubmissions ?? 0,
+    choiceResults: results?.choiceResults ?? [],
+  };
+};

--- a/server/src/repository/poll-repository.ts
+++ b/server/src/repository/poll-repository.ts
@@ -24,7 +24,7 @@ type CreatePollInput = {
 type ListOptions = {
   limit?: number;
   cursor?: string;
-  status?: PollStatus;
+  status?: PollStatus | PollStatus[];
 };
 
 export const pollRepository = {
@@ -78,7 +78,11 @@ export const pollRepository = {
 
     const conditions = [];
     if (options.status) {
-      conditions.push(eq(polls.status, options.status));
+      conditions.push(
+        Array.isArray(options.status)
+          ? inArray(polls.status, options.status)
+          : eq(polls.status, options.status),
+      );
     }
     if (options.cursor) {
       conditions.push(sql`${polls.createdAt} < ${options.cursor}`);


### PR DESCRIPTION
## Summary
- 管理画面のねっぷちゃんが投票結果を参照して分析・可視化できるように、`pollGetTool` を追加
- ID 指定 or 一覧で、投票情報と集計結果（参加人数・選択肢別の票数/割合）をまとめて取得可能

## 主な変更内容
- `server/src/mastra/tools/poll-get-tool.ts` を新規追加
  - 入力: `id?` / `limit` (最大 20、デフォルト 10)
  - 出力: `polls[]`（id, title, choices, status, sentAt, closedAt, totalSubmissions, choiceResults）
  - ID 指定時は sent/closed の投票のみ返却、未指定時は sent + closed の最新 N 件を返却
- `nepp-chan-agent`
  - `defaultTools` に `pollGetTool` を追加（LINE/Web 両プラットフォームで利用可能）
  - `adminInstructions` に「投票の結果・傾向分析 → pollGetTool」「display-chart / display-table で可視化」の指示を追記
- `pollRepository.findAll` の status フィルタを `PollStatus | PollStatus[]` に拡張し、sent + closed を 1 クエリで取得できるように

## Test plan
- [ ] 管理画面のチャットで「最近の投票どう？」と聞くと、一覧と集計が取得できること
- [ ] 「〇〇の投票結果は？」のように特定投票を指し示すと、該当投票の集計が返ること
- [ ] 選択肢別の割合が display-chart で可視化されること
- [ ] 複数投票の比較が display-table で一覧化されること
- [ ] draft / scheduled の投票は pollGetTool の結果に含まれないこと
- [ ] LINE 側でも投票結果についての質問に答えられること