### PR TITLE
feat(server): LINE配信におしらせ解説ボタンを追加

### DIFF
--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -5,6 +5,10 @@ import { logger } from "~/lib/logger";
 import { lineSignatureVerify } from "~/middleware";
 import type { LineEventMessage } from "~/schemas/line-schema";
 import {
+  generateBroadcastExplanation,
+  handleBroadcastPostback,
+} from "~/services/broadcast-response";
+import {
   generatePollFollowUp,
   handlePollPostback,
 } from "~/services/poll-response";
@@ -38,30 +42,58 @@ const enqueueLineEvents = async (
   for (const event of events) {
     if (event.type === "postback") {
       if (!event.source.userId || !event.replyToken) continue;
-      if (!event.postback.data.startsWith("poll=")) continue;
+      const userId = event.source.userId;
+      const postbackData = event.postback.data;
 
-      try {
-        const result = await handlePollPostback(
-          env,
-          event.source.userId,
-          event.postback.data,
-          event.replyToken,
-        );
-
-        if (result.status === "answered") {
-          const userId = event.source.userId;
-          executionCtx.waitUntil(
-            generatePollFollowUp(
-              env,
-              userId,
-              result.poll,
-              result.selectedChoice,
-            ),
+      if (postbackData.startsWith("poll=")) {
+        try {
+          const result = await handlePollPostback(
+            env,
+            userId,
+            postbackData,
+            event.replyToken,
           );
+
+          if (result.status === "answered") {
+            executionCtx.waitUntil(
+              generatePollFollowUp(
+                env,
+                userId,
+                result.poll,
+                result.selectedChoice,
+              ),
+            );
+          }
+        } catch (error) {
+          logger.error("[LINE] Poll postback error", error);
         }
-      } catch (error) {
-        logger.error("[LINE] Poll postback error", error);
+        continue;
       }
+
+      if (postbackData.startsWith("broadcast=")) {
+        try {
+          const result = await handleBroadcastPostback(
+            env,
+            postbackData,
+            event.replyToken,
+          );
+
+          if (result.status === "accepted") {
+            executionCtx.waitUntil(
+              generateBroadcastExplanation(
+                env,
+                userId,
+                result.broadcast,
+                result.replyToken,
+              ),
+            );
+          }
+        } catch (error) {
+          logger.error("[LINE] Broadcast postback error", error);
+        }
+        continue;
+      }
+
       continue;
     }
 

--- a/server/src/services/broadcast-response.ts
+++ b/server/src/services/broadcast-response.ts
@@ -1,0 +1,87 @@
+import { logger } from "~/lib/logger";
+import { toResourceId } from "~/lib/principal";
+import {
+  type BroadcastMessage,
+  broadcastRepository,
+} from "~/repository/broadcast-repository";
+import type { BroadcastPart } from "~/schemas/broadcast-schema";
+import {
+  createLineClient,
+  generateReply,
+  sendLineMessages,
+} from "~/services/line-messaging";
+
+const decodeBroadcastPostback = (data: string) => {
+  const params = new URLSearchParams(data);
+  return { broadcastId: params.get("broadcast") };
+};
+
+const extractBodyText = (broadcast: BroadcastMessage): string => {
+  if (!broadcast.parts) return broadcast.body;
+  try {
+    const parts = JSON.parse(broadcast.parts) as BroadcastPart[];
+    const texts = parts
+      .filter(
+        (p): p is Extract<BroadcastPart, { type: "text" }> => p.type === "text",
+      )
+      .map((p) => p.text);
+    return texts.join("\n\n") || broadcast.body;
+  } catch {
+    return broadcast.body;
+  }
+};
+
+export type BroadcastExplainResult =
+  | { status: "accepted"; broadcast: BroadcastMessage; replyToken: string }
+  | { status: "invalid" };
+
+export const handleBroadcastPostback = async (
+  env: CloudflareBindings,
+  data: string,
+  replyToken: string,
+): Promise<BroadcastExplainResult> => {
+  const { broadcastId } = decodeBroadcastPostback(data);
+  if (!broadcastId) return { status: "invalid" };
+
+  const broadcast = await broadcastRepository.findById(env.DB, broadcastId);
+  if (!broadcast) return { status: "invalid" };
+
+  return { status: "accepted", broadcast, replyToken };
+};
+
+export const generateBroadcastExplanation = async (
+  env: CloudflareBindings,
+  userId: string,
+  broadcast: BroadcastMessage,
+  replyToken: string,
+) => {
+  try {
+    const threadId = `line-thread:${userId}`;
+    const resourceId = toResourceId({ type: "line", id: userId });
+
+    const bodyText = extractBodyText(broadcast);
+    const userMessage = `（おしらせ解説リクエスト）「${broadcast.title}」のおしらせについて、ねっぷちゃんの視点でやさしく解説して！
+
+【おしらせ本文】
+${bodyText}`;
+
+    const replyTexts = await generateReply({
+      userMessage,
+      resourceId,
+      threadId,
+      env,
+    });
+
+    if (replyTexts.length === 0) return;
+
+    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+    await sendLineMessages({
+      client,
+      replyToken,
+      userId,
+      texts: replyTexts,
+    });
+  } catch (error) {
+    logger.error("[Broadcast] Explanation failed", error);
+  }
+};

--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -22,11 +22,45 @@ const getPublicImageUrl = (env: CloudflareBindings, r2Key: string): string => {
   return `${apiBaseUrl}/broadcast/media/${r2Key}`;
 };
 
+const buildExplainButtonMessage = (
+  broadcastId: string,
+): messagingApi.FlexMessage => {
+  const bubble: messagingApi.FlexBubble = {
+    type: "bubble",
+    size: "kilo",
+    body: {
+      type: "box",
+      layout: "vertical",
+      contents: [
+        {
+          type: "button",
+          action: {
+            type: "postback",
+            label: "ねっぷちゃんに解説してもらう",
+            data: `broadcast=${broadcastId}`,
+            displayText: "このおしらせ、ねっぷちゃんに解説してもらう！",
+          },
+          style: "primary",
+          color: "#0f766e",
+          height: "sm",
+        },
+      ],
+    },
+  };
+
+  return {
+    type: "flex",
+    altText: "このおしらせ、ねっぷちゃんに解説してもらう？",
+    contents: bubble,
+  };
+};
+
 const buildLineMessages = (
   parts: BroadcastPart[],
   env: CloudflareBindings,
-): messagingApi.Message[] =>
-  parts.map((part) => {
+  broadcastId?: string,
+): messagingApi.Message[] => {
+  const contentMessages: messagingApi.Message[] = parts.map((part) => {
     if (part.type === "text") {
       return { type: "text" as const, text: part.text };
     }
@@ -37,6 +71,10 @@ const buildLineMessages = (
       previewImageUrl: imageUrl,
     };
   });
+
+  if (!broadcastId) return contentMessages;
+  return [...contentMessages, buildExplainButtonMessage(broadcastId)];
+};
 
 const parseParts = (broadcast: BroadcastMessage): BroadcastPart[] =>
   broadcast.parts
@@ -139,7 +177,7 @@ export const sendBroadcast = async (
     const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
     const retryKey = crypto.randomUUID();
     const parts = parseParts(broadcast);
-    const messages = buildLineMessages(parts, env);
+    const messages = buildLineMessages(parts, env, broadcast.id);
 
     await client.broadcast({ messages }, retryKey);
 


### PR DESCRIPTION
## Summary
- LINE 配信メッセージの末尾に「ねっぷちゃんに解説してもらう」Postback ボタン（Flex Message）を付与
- ボタン押下で配信本文をねっぷちゃん Agent に渡し、要約・解説を `replyMessage` で返す
- 画像は通常の image message のまま残すので LINE ネイティブビューアでの拡大・保存が可能

## 主な変更内容

### 送信側（`server/src/services/broadcast-service.ts`）
- `buildExplainButtonMessage()` を追加し、ボタン1個のみのシンプルな Flex Bubble を生成
- `buildLineMessages()` に `broadcastId` を渡すと末尾にボタン通を付与する形に変更
- `sendBroadcast()` で `broadcast.id` を渡して解説ボタンを配信メッセージに付与

### 受信側（新規 `server/src/services/broadcast-response.ts` + `server/src/routes/line.ts`）
- `broadcast=` Postback を解釈し、非同期で `generateBroadcastExplanation()` を起動
- `generateReply()`（既存）経由で Agent に本文を渡し、`sendLineMessages()` で **reply 優先 → 失敗時のみ push にフォールバック**
- `line.ts` では `poll=` と `broadcast=` の分岐を並列化

### push API の節約
- 解説は通常時に `replyMessage` で完結するため push は 0 回
- `replyToken` 失効などの異常時のみ 1 回の push にフォールバック

## Test plan
- [ ] 管理画面から配信を実行し、LINE 側で本文＋画像＋ボタンの3通が届くこと
- [ ] 画像を LINE 上でタップし、ネイティブビューアで拡大・保存できること
- [ ] 「ねっぷちゃんに解説してもらう」ボタン押下で displayText が表示されること
- [ ] その後、ねっぷちゃんから配信内容に即した解説テキストが返ってくること
- [ ] 複数ニュースを配信した場合、押したニュースの解説が返ること（`broadcastId` が正しくルーティングされる）
- [ ] 投票（`poll=`）の既存動線がこれまで通り動作すること（リグレッションなし）