### PR TITLE
fix(server): 解説ボタンのラベルを短縮して見切れを防止

### DIFF
--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -36,7 +36,7 @@ const buildExplainButtonMessage = (
           type: "button",
           action: {
             type: "postback",
-            label: "ねっぷちゃんに解説してもらう",
+            label: "おしらせを解説",
             data: `broadcast=${broadcastId}`,
             displayText: "このおしらせ、ねっぷちゃんに解説してもらう！",
           },


### PR DESCRIPTION
## Summary
- LINE の Flex ボタン幅で「ねっぷちゃんに解説してもらう」が見切れていたため、ラベルを「おしらせを解説」（7文字）に短縮
- displayText（発話として表示される文言）は自然さを維持するため従来のまま

## 背景
#522 で追加した配信末尾の解説ボタンについて、端末によってボタンラベルが途中で切れて表示される問題が発覚したための fix。

## Test plan
- [ ] 配信を実行し、LINE 側でボタンラベル「おしらせを解説」が見切れず収まって表示されること
- [ ] ボタン押下時の displayText「このおしらせ、ねっぷちゃんに解説してもらう！」が従来通り表示されること
- [ ] ボタン押下後、ねっぷちゃんから解説テキストが返ってくること