### PR TITLE
feat(server): 解説ボタンに説明文を添えて意図を明確化

### DIFF
--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -31,12 +31,20 @@ const buildExplainButtonMessage = (
     body: {
       type: "box",
       layout: "vertical",
+      spacing: "md",
       contents: [
+        {
+          type: "text",
+          text: "このおしらせ、ねっぷちゃんが解説するよ！",
+          size: "sm",
+          color: "#57534e",
+          wrap: true,
+        },
         {
           type: "button",
           action: {
             type: "postback",
-            label: "おしらせを解説",
+            label: "解説してもらう",
             data: `broadcast=${broadcastId}`,
             displayText: "このおしらせ、ねっぷちゃんに解説してもらう！",
           },
@@ -50,7 +58,7 @@ const buildExplainButtonMessage = (
 
   return {
     type: "flex",
-    altText: "このおしらせ、ねっぷちゃんに解説してもらう？",
+    altText: "このおしらせ、ねっぷちゃんが解説するよ！",
     contents: bubble,
   };
 };


### PR DESCRIPTION
## Summary
- 解説ボタン単体では「何が起きるボタンか」が伝わりにくかったため、Flex Bubble の body に説明文を追加
- ボタンラベルも動作名のみに整理して可読性を向上

## 変更後の構成
- 説明文: 「このおしらせ、ねっぷちゃんが解説するよ！」
- ボタンラベル: 「解説してもらう」
- displayText（ユーザー発話として表示）: 「このおしらせ、ねっぷちゃんに解説してもらう！」

## 背景
#522 / #523 で追加・調整した配信末尾の解説ボタンについて、ラベルだけだと主語（ねっぷちゃんが解説する）や目的が伝わりにくいというフィードバックを受けての改善。

## Test plan
- [ ] 配信を実行し、LINE 側のボタン通が「説明文 + ボタン」の2段構成で表示されること
- [ ] 説明文「このおしらせ、ねっぷちゃんが解説するよ！」が改行なく収まって表示されること
- [ ] ボタンラベル「解説してもらう」が見切れず表示されること
- [ ] ボタン押下で displayText が表示され、ねっぷちゃんから解説テキストが返ってくること