### PR TITLE
feat(server): 雑談ボタンの Postback ハンドラを実装

### DIFF
--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -8,6 +8,7 @@ import {
   generateBroadcastExplanation,
   handleBroadcastPostback,
 } from "~/services/broadcast-response";
+import { handleChitchatTrigger } from "~/services/line/chitchat";
 import {
   generatePollFollowUp,
   handlePollPostback,
@@ -67,6 +68,13 @@ const enqueueLineEvents = async (
         } catch (error) {
           logger.error("[LINE] Poll postback error", error);
         }
+        continue;
+      }
+
+      if (postbackData.startsWith("chitchat=")) {
+        executionCtx.waitUntil(
+          handleChitchatTrigger(env, userId, event.replyToken),
+        );
         continue;
       }
 

--- a/server/src/services/line/chitchat.ts
+++ b/server/src/services/line/chitchat.ts
@@ -1,0 +1,50 @@
+import { logger } from "~/lib/logger";
+import { toResourceId } from "~/lib/principal";
+import {
+  createLineClient,
+  generateReply,
+  sendLineMessages,
+} from "~/services/line-messaging";
+
+const TOPICS = [
+  "暮らしの何気ない話（天気・季節・近況）",
+  "村のお知らせや行事の話題",
+  "村の歴史・地名・豆知識",
+  "村民への気軽な問いかけ",
+  "ねっぷちゃんの最近の出来事",
+] as const;
+
+const pickRandomTopic = () => TOPICS[Math.floor(Math.random() * TOPICS.length)];
+
+export const handleChitchatTrigger = async (
+  env: CloudflareBindings,
+  userId: string,
+  replyToken: string,
+) => {
+  try {
+    const topic = pickRandomTopic();
+    const userMessage = `（雑談ボタン）村民の話し相手として、「${topic}」をテーマに、観光案内ではなく村に住んでいる人との何気ない雑談として気軽に話題を振って。`;
+
+    const threadId = `line-thread:${userId}`;
+    const resourceId = toResourceId({ type: "line", id: userId });
+
+    const replyTexts = await generateReply({
+      userMessage,
+      resourceId,
+      threadId,
+      env,
+    });
+
+    if (replyTexts.length === 0) return;
+
+    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+    await sendLineMessages({
+      client,
+      replyToken,
+      userId,
+      texts: replyTexts,
+    });
+  } catch (error) {
+    logger.error("[LINE] Chitchat trigger failed", error);
+  }
+};


### PR DESCRIPTION
## Summary

- LINE の「雑談」ボタン（Postback `chitchat=...`）を受けて、ねっぷちゃんがランダムなトピックで気軽に話題を振る処理を `server/src/services/line/chitchat.ts` に追加。
- `server/src/routes/line.ts` の Postback ディスパッチに `chitchat=` 分岐を追加し、`executionCtx.waitUntil` で非同期実行する。
- トピックは「暮らしの何気ない話」「村のお知らせ」「歴史・地名豆知識」「問いかけ」「近況」の 5 種からランダム選択。

## Test plan

- [ ] LINE テスト環境で雑談 Postback を送り、話題が返ってくることを確認
- [ ] `replyToken` が失効した場合に `sendLineMessages` の pushMessage フォールバックが効くことを確認
- [ ] Mastra メモリに thread/resource が紐付き、以降の会話が文脈として保持されることを確認
- [ ] エラー発生時に `logger.error` のみが出て、後続 Postback 処理に影響しないことを確認

## TODO

- [ ] `handleChitchatTrigger` の単体テスト追加（`generateReply`・`sendLineMessages` をモックして、トピック注入・エラー握り潰し・空 reply スキップを検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)