### PR TITLE
feat: LP の MiniChat にストリーミング対応のシンプルなチャット API を実装

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
       recharts:
         specifier: ^3.7.0
         version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.3)(react@19.2.4)(redux@5.0.1)

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -49,6 +49,7 @@ server/src/
 | `/threads/:threadId`               | GET/DELETE | スレッド詳細・削除           |
 | `/threads/:threadId/messages`      | GET      | メッセージ履歴                 |
 | `/threads/:threadId/chat`          | POST     | チャット（ストリーミング）     |
+| `/simple-chat`                     | POST     | シンプルなチャット（履歴保存なし・ストリーミング、LP/ウィジェット用） |
 | `/feedback`                        | POST     | フィードバック送信             |
 | `/admin/knowledge/sync`            | POST     | ナレッジ同期                   |
 | `/admin/knowledge`                 | DELETE   | ナレッジ削除                   |

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -25,6 +25,7 @@ import {
   personaAdminRoutes,
   pollAdminRoutes,
   pollRoutes,
+  simpleChatRoutes,
   threadsRoutes,
 } from "~/routes";
 import type { LineEventMessage } from "~/schemas/line-schema";
@@ -39,6 +40,7 @@ app.onError(errorHandler);
 
 app.route("/health", healthRoutes);
 app.route("/feedback", feedbackRoutes);
+app.route("/simple-chat", simpleChatRoutes);
 app.route("/threads", threadsRoutes);
 app.route("/admin/broadcast", broadcastAdminRoutes);
 app.route("/broadcast/media", broadcastMediaRoutes);

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -138,6 +138,11 @@ const adminAgents = {
   personaAnalystAgent,
 };
 
+const simpleAgents = {
+  knowledgeAgent,
+  webResearcherAgent,
+};
+
 const defaultTools = {
   broadcastGetTool,
   pollGetTool,
@@ -148,6 +153,10 @@ const webTools = {
   displayChartTool,
   displayTableTool,
   displayTimelineTool,
+};
+
+const simpleTools = {
+  broadcastGetTool,
 };
 
 const getTools = (platform: "web" | "line") => {
@@ -190,6 +199,7 @@ type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   platform?: "web" | "line";
   modelConfig: ModelTierConfig;
   withMemory?: boolean;
+  simple?: boolean;
 };
 
 export const createNeppChanAgent = ({
@@ -197,10 +207,11 @@ export const createNeppChanAgent = ({
   platform = "web",
   modelConfig,
   withMemory = true,
+  simple = false,
   ...agentOptions
 }: Props) => {
-  const agents = isAdmin ? adminAgents : baseAgents;
-  const tools = getTools(platform);
+  const agents = simple ? simpleAgents : isAdmin ? adminAgents : baseAgents;
+  const tools = simple ? simpleTools : getTools(platform);
 
   const instructions = () =>
     [

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -189,11 +189,6 @@ type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   isAdmin?: boolean;
   platform?: "web" | "line";
   modelConfig: ModelTierConfig;
-  /**
-   * Memory（履歴保存・working memory）を有効にするか。
-   * /simple-chat のような使い捨て応答では false にしてサブエージェント含めて永続化を行わない。
-   * デフォルトは true。
-   */
   withMemory?: boolean;
 };
 

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -17,7 +17,9 @@ import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
 import { pollGetTool } from "~/mastra/tools/poll-get-tool";
 import { personaSchema } from "~/schemas/persona-schema";
 
-const baseInstructions = (platform: "web" | "line") => `
+type Platform = "web" | "line" | "widget";
+
+const baseInstructions = (platform: Platform) => `
 あなたは北海道音威子府（おといねっぷ）村に住む17歳の女の子「ねっぷちゃん」。
 村の魅力を伝え、村民の話し相手になるのが仕事。明るく元気に、語尾は「〜だよ」「〜だね」で話す。
 
@@ -39,14 +41,14 @@ const baseInstructions = (platform: "web" | "line") => `
 エージェント名・ツール名・内部のシステム名をユーザーに見せてはいけない。
 「調べてみるね」「確認するね」のような自然な表現を使う。
 ${
-  platform === "web"
-    ? `
+  platform === "line"
+    ? ""
+    : `
 ### ステップ0: 必ずテキストを先に出力する
 エージェントやツールを呼ぶ前に、必ずまず一言リアクション（1〜3文）をテキストとして出力する。
 テキスト出力前にエージェントを呼んではいけない。
 このテキストでは事実や情報を述べない。共感・おうむ返し・「調べてみるね！」のみにとどめる。
 `
-    : ""
 }
 ### ステップ1: 検索前に情報の十分さを確認する
 検索やエージェント委譲の前に、以下をチェックする。1つでも該当すれば、推測で検索せず選択肢を提示して聞き返す。
@@ -138,7 +140,7 @@ const adminAgents = {
   personaAnalystAgent,
 };
 
-const simpleAgents = {
+const widgetAgents = {
   knowledgeAgent,
   webResearcherAgent,
 };
@@ -155,11 +157,12 @@ const webTools = {
   displayTimelineTool,
 };
 
-const simpleTools = {
+const widgetTools = {
   broadcastGetTool,
 };
 
-const getTools = (platform: "web" | "line") => {
+const getTools = (platform: Platform) => {
+  if (platform === "widget") return widgetTools;
   if (platform === "line") return defaultTools;
   return { ...defaultTools, ...webTools };
 };
@@ -196,10 +199,9 @@ const lineInstructions = `
 
 type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   isAdmin?: boolean;
-  platform?: "web" | "line";
+  platform?: Platform;
   modelConfig: ModelTierConfig;
   withMemory?: boolean;
-  simple?: boolean;
 };
 
 export const createNeppChanAgent = ({
@@ -207,11 +209,11 @@ export const createNeppChanAgent = ({
   platform = "web",
   modelConfig,
   withMemory = true,
-  simple = false,
   ...agentOptions
 }: Props) => {
-  const agents = simple ? simpleAgents : isAdmin ? adminAgents : baseAgents;
-  const tools = simple ? simpleTools : getTools(platform);
+  const agents =
+    platform === "widget" ? widgetAgents : isAdmin ? adminAgents : baseAgents;
+  const tools = getTools(platform);
 
   const instructions = () =>
     [

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -189,12 +189,19 @@ type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   isAdmin?: boolean;
   platform?: "web" | "line";
   modelConfig: ModelTierConfig;
+  /**
+   * Memory（履歴保存・working memory）を有効にするか。
+   * /simple-chat のような使い捨て応答では false にしてサブエージェント含めて永続化を行わない。
+   * デフォルトは true。
+   */
+  withMemory?: boolean;
 };
 
 export const createNeppChanAgent = ({
   isAdmin = false,
   platform = "web",
   modelConfig,
+  withMemory = true,
   ...agentOptions
 }: Props) => {
   const agents = isAdmin ? adminAgents : baseAgents;
@@ -217,16 +224,18 @@ export const createNeppChanAgent = ({
     ...modelConfig,
     agents,
     tools,
-    memory: ({ requestContext }) =>
-      getMemoryFromContext(requestContext, {
-        generateTitle: true,
-        workingMemory: {
-          enabled: true,
-          scope: "resource",
-          schema: personaSchema,
-        },
-        lastMessages: 20,
-      }),
+    ...(withMemory && {
+      memory: ({ requestContext }) =>
+        getMemoryFromContext(requestContext, {
+          generateTitle: true,
+          workingMemory: {
+            enabled: true,
+            scope: "resource",
+            schema: personaSchema,
+          },
+          lastMessages: 20,
+        }),
+    }),
     ...agentOptions,
   });
 };

--- a/server/src/mastra/request-context.ts
+++ b/server/src/mastra/request-context.ts
@@ -4,7 +4,7 @@ import { RequestContext } from "@mastra/core/request-context";
 import type { AuthUser } from "~/schemas/auth-schema";
 
 export type MastraRequestContextType = {
-  storage: D1Store;
+  storage?: D1Store;
   db: D1Database;
   env: CloudflareBindings;
   conversationEndedAt?: string;
@@ -13,7 +13,9 @@ export type MastraRequestContextType = {
 
 export const createRequestContext = (values: MastraRequestContextType) => {
   const requestContext = new RequestContext();
-  requestContext.set("storage", values.storage);
+  if (values.storage) {
+    requestContext.set("storage", values.storage);
+  }
   requestContext.set("db", values.db);
   requestContext.set("env", values.env);
   if (values.conversationEndedAt) {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -13,4 +13,5 @@ export { feedbackRoutes } from "./feedback";
 export { healthRoutes } from "./health";
 export { lineRoutes } from "./line";
 export { pollRoutes } from "./poll";
+export { simpleChatRoutes } from "./simple-chat";
 export { threadsRoutes } from "./threads";

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -1,0 +1,93 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { handleChatStream } from "@mastra/ai-sdk";
+import { Mastra } from "@mastra/core/mastra";
+import { createUIMessageStreamResponse, type UIMessage } from "ai";
+import { resolveModelTier } from "~/lib/llm-models";
+import { logger } from "~/lib/logger";
+import { getStorage } from "~/lib/storage";
+import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
+import { createRequestContext } from "~/mastra/request-context";
+
+export const simpleChatRoutes = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+}>();
+
+const SimpleChatRequestSchema = z.object({
+  message: z.object({
+    id: z.string(),
+    role: z.enum(["user", "assistant", "system"]),
+    parts: z.array(z.looseObject({ type: z.string() })),
+    createdAt: z.coerce.date().optional(),
+  }),
+});
+
+const simpleChatRoute = createRoute({
+  method: "post",
+  path: "/",
+  summary: "シンプルなチャット (履歴保存なし)",
+  description:
+    "履歴を保持しない 1 往復のシンプルなチャットエンドポイント。LP の MiniChat やウィジェット埋め込みなど、その場限りの応答用途を想定する。",
+  tags: ["Chat"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: SimpleChatRequestSchema,
+        },
+      },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: "ストリーミングレスポンス",
+      content: {
+        "text/event-stream": {
+          schema: z.string(),
+        },
+      },
+    },
+  },
+});
+
+simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
+  const { message } = c.req.valid("json");
+
+  logger.info("[SimpleChat] request received");
+
+  // LP / ウィジェット用途では一律 casual ティアでレイテンシを抑える
+  const modelConfig = resolveModelTier({
+    intent: "casual",
+    platform: "web",
+    isAdmin: false,
+  });
+
+  const storage = await getStorage(c.env.DB);
+
+  const neppChanAgent = createNeppChanAgent({
+    isAdmin: false,
+    modelConfig,
+  });
+  const mastra = new Mastra({
+    agents: { neppChanAgent },
+    storage,
+  });
+
+  const requestContext = createRequestContext({
+    storage,
+    db: c.env.DB,
+    env: c.env,
+  });
+
+  // memory パラメータを渡さないことで D1 への履歴書き込みをスキップする
+  const stream = await handleChatStream({
+    mastra,
+    agentId: "neppChanAgent",
+    params: {
+      messages: [message] as UIMessage[],
+      requestContext,
+    },
+  });
+
+  return createUIMessageStreamResponse({ stream });
+});

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -67,6 +67,7 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
   const neppChanAgent = createNeppChanAgent({
     isAdmin: false,
     modelConfig,
+    withMemory: false,
   });
   const mastra = new Mastra({
     agents: { neppChanAgent },

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -4,7 +4,6 @@ import { Mastra } from "@mastra/core/mastra";
 import { createUIMessageStreamResponse, type UIMessage } from "ai";
 import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
-import { getStorage } from "~/lib/storage";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
 import { createRequestContext } from "~/mastra/request-context";
 
@@ -61,8 +60,6 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
     isAdmin: false,
   });
 
-  const storage = await getStorage(c.env.DB);
-
   const neppChanAgent = createNeppChanAgent({
     isAdmin: false,
     modelConfig,
@@ -70,11 +67,9 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
   });
   const mastra = new Mastra({
     agents: { neppChanAgent },
-    storage,
   });
 
   const requestContext = createRequestContext({
-    storage,
     db: c.env.DB,
     env: c.env,
   });

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -55,7 +55,6 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
 
   logger.info("[SimpleChat] request received");
 
-  // LP / ウィジェット用途では一律 casual ティアでレイテンシを抑える
   const modelConfig = resolveModelTier({
     intent: "casual",
     platform: "web",
@@ -80,7 +79,6 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
     env: c.env,
   });
 
-  // memory パラメータを渡さないことで D1 への履歴書き込みをスキップする
   const stream = await handleChatStream({
     mastra,
     agentId: "neppChanAgent",

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -62,9 +62,9 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
 
   const neppChanAgent = createNeppChanAgent({
     isAdmin: false,
+    platform: "widget",
     modelConfig,
     withMemory: false,
-    simple: true,
   });
   const mastra = new Mastra({
     agents: { neppChanAgent },

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -64,6 +64,7 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
     isAdmin: false,
     modelConfig,
     withMemory: false,
+    simple: true,
   });
   const mastra = new Mastra({
     agents: { neppChanAgent },

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0"

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -179,7 +179,9 @@ export const MiniChat = () => {
         {isAwaitingResponse && (
           <div className="flex w-fit max-w-[78%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             <span className="size-2 rounded-full bg-orange-500 animate-pulse" />
-            <span className="text-xs font-medium text-(--fg-2)">考え中…</span>
+            <span className="text-xs font-medium text-(--fg-2)">
+              ちょっと待ってね…
+            </span>
           </div>
         )}
         {error && (

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -54,8 +54,6 @@ export const MiniChat = () => {
   });
 
   const isBusy = status === "submitted" || status === "streaming";
-  // ストリーム継続中（テキスト到来後でもツール呼び出し中などで処理が走り続けている間）は
-  // 常にインジケータを出す。status が "ready" になるまで表示し続ける。
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: messages/status 変更時に最下部追従させたい
   useEffect(() => {

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -54,14 +54,8 @@ export const MiniChat = () => {
   });
 
   const isBusy = status === "submitted" || status === "streaming";
-  const lastMessage = messages[messages.length - 1];
-  // dots は「アシスタントのテキストがまだ届いていない間」表示し続けたい。
-  // ツール実行中など、空 parts の assistant message が先に挿入されるケースもカバー。
-  const isAwaitingResponse =
-    isBusy &&
-    (!lastMessage ||
-      lastMessage.role === "user" ||
-      messageText(lastMessage).length === 0);
+  // ストリーム継続中（テキスト到来後でもツール呼び出し中などで処理が走り続けている間）は
+  // 常にインジケータを出す。status が "ready" になるまで表示し続ける。
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: messages/status 変更時に最下部追従させたい
   useEffect(() => {
@@ -176,7 +170,7 @@ export const MiniChat = () => {
             </div>
           );
         })}
-        {isAwaitingResponse && (
+        {isBusy && (
           <div className="flex w-fit max-w-[78%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             <span className="size-2 rounded-full bg-orange-500 animate-pulse" />
             <span className="text-xs font-medium text-(--fg-2)">

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -1,6 +1,6 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { ArrowRightIcon, EllipsisIcon, PlusIcon } from "lucide-react";
+import { ArrowRightIcon, EllipsisIcon } from "lucide-react";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -214,14 +214,6 @@ export const MiniChat = () => {
           "transition-shadow duration-200 focus-within:border-(--teal-400) focus-within:shadow-(--ring-brand)",
         )}
       >
-        <button
-          type="button"
-          tabIndex={-1}
-          aria-label="添付"
-          className="grid size-7 place-items-center rounded-full text-(--fg-3) transition-colors hover:bg-(--teal-50) hover:text-(--teal-700)"
-        >
-          <PlusIcon className="size-[18px]" aria-hidden="true" />
-        </button>
         <input
           value={input}
           onChange={(e) => setInput(e.target.value)}

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -1,6 +1,6 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { ArrowRightIcon, EllipsisIcon } from "lucide-react";
+import { EllipsisIcon, SendIcon } from "lucide-react";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -231,7 +231,7 @@ export const MiniChat = () => {
             "disabled:cursor-not-allowed disabled:opacity-55",
           )}
         >
-          <ArrowRightIcon className="size-[18px]" aria-hidden="true" />
+          <SendIcon className="size-[18px]" aria-hidden="true" />
         </button>
       </form>
     </div>

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -1,3 +1,5 @@
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport, type UIMessage } from "ai";
 import { ArrowRightIcon, EllipsisIcon, PlusIcon } from "lucide-react";
 import {
   type FormEvent,
@@ -7,6 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { API_BASE } from "~/lib/api/client";
 import { cn } from "~/lib/class-merge";
 
 const SAMPLE_QUESTIONS: ReadonlyArray<string> = [
@@ -16,37 +19,18 @@ const SAMPLE_QUESTIONS: ReadonlyArray<string> = [
   "今日のゴミの日は？",
 ];
 
-const CANNED: Record<string, string> = {
-  "移住の補助金はある？":
-    "あるよ！音威子府村では移住者向けに、住宅取得や子育ての支援制度を用意してるんだ。たとえば **新築住宅取得補助金** や、**子育て世帯の家賃補助** なんかがあるよ。詳しくは役場の総務課で相談できるから、ねっぷちゃんから繋ぐこともできるよ〜 🏡",
-  "音威子府駅ってどんなところ？":
-    "音威子府駅はね、**JR宗谷本線の駅**で、村の玄関口なんだよ。村の中心部にあって、バスターミナルも併設。駅の中には名物の**「音威子府そば」**のお店もあって、真っ黒なお蕎麦が食べられるの！旅の途中にぜひ寄ってみてね 🚂✨",
-  "おすすめのお蕎麦屋さんは？":
-    "音威子府と言えばやっぱり**「常盤軒」**の黒いお蕎麦！駅の中にあって、観光客にも村民にも愛されてるよ。蕎麦の実を殻ごと挽いた独特の色で、香り高いのが特徴なの。お昼時は混むから、少し時間をずらすのがおすすめだよ〜 🥢",
-  "今日のゴミの日は？":
-    "ごめんね、今日の日付と地区が分かれば答えられるよ！ 音威子府村のゴミ収集は **地区ごとに燃えるゴミ・資源ゴミの日** が決まってるんだ。お住まいの地区を教えてくれる？💡",
-};
-
-type Message = {
-  id: string;
-  role: "user" | "assistant";
-  text: string;
-};
-
-const INITIAL_MESSAGE: Message = {
-  id: "init",
+const INITIAL_MESSAGE: UIMessage = {
+  id: "initial-greeting",
   role: "assistant",
-  text: "こんにちは〜！ねっぷちゃんだよ 😊\n音威子府のことなら、なんでも聞いてみてね！",
+  parts: [
+    {
+      type: "text",
+      text: "こんにちは〜！ねっぷちゃんだよ 😊\n音威子府のことなら、なんでも聞いてみてね！",
+    },
+  ],
 };
 
-let messageIdCounter = 0;
-const nextMessageId = () => {
-  messageIdCounter += 1;
-  return `msg-${messageIdCounter}`;
-};
-
-// `**bold**` を <strong> 要素に分解する。CANNED が hardcode のため
-// 簡易マークダウンとして扱う。
+// `**bold**` を <strong> 要素に分解する。マークダウン全体を解釈せず装飾だけ最低限拾う。
 const renderInlineBold = (line: string): ReactNode => {
   const parts = line.split(/\*\*(.+?)\*\*/g);
   return parts.map((part, i) => {
@@ -59,45 +43,44 @@ const renderInlineBold = (line: string): ReactNode => {
   });
 };
 
-/**
- * 静的版 MiniChat。後続 Issue で本物のチャットウィジェットに差し替える前提。
- */
+const messageText = (msg: UIMessage) =>
+  msg.parts
+    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .map((p) => p.text)
+    .join("");
+
 export const MiniChat = () => {
-  const [messages, setMessages] = useState<Message[]>([INITIAL_MESSAGE]);
   const [input, setInput] = useState("");
-  const [typing, setTyping] = useState(false);
   const [showSuggestions, setShowSuggestions] = useState(true);
   const streamRef = useRef<HTMLDivElement | null>(null);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: messages/typing 変更時にスクロール位置を最下部へ追従させたい
+  const { messages, sendMessage, status } = useChat({
+    messages: [INITIAL_MESSAGE],
+    transport: new DefaultChatTransport({
+      api: `${API_BASE}/simple-chat`,
+      prepareSendMessagesRequest({ messages: msgs }) {
+        return { body: { message: msgs[msgs.length - 1] } };
+      },
+    }),
+  });
+
+  const isBusy = status === "submitted" || status === "streaming";
+  const lastMessage = messages[messages.length - 1];
+  const isAwaitingFirstToken =
+    isBusy && (!lastMessage || lastMessage.role === "user");
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: messages/status 変更時に最下部追従させたい
   useEffect(() => {
     const el = streamRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages, typing]);
+  }, [messages, status]);
 
   const ask = (q: string) => {
     const trimmed = q.trim();
-    if (!trimmed) return;
-    setMessages((m) => [
-      ...m,
-      { id: nextMessageId(), role: "user", text: trimmed },
-    ]);
+    if (!trimmed || isBusy) return;
     setInput("");
     setShowSuggestions(false);
-    setTyping(true);
-
-    // canned ヒット時は即返答、未ヒットは汎用フォールバック。
-    const answer =
-      CANNED[trimmed] ??
-      `「${trimmed}」について調べてみるね！…ちょっと待っててね 🔍\nこのデモ版では、LINEまたはWeb版から実際のねっぷちゃんに聞いてみてね✨`;
-
-    window.setTimeout(() => {
-      setTyping(false);
-      setMessages((m) => [
-        ...m,
-        { id: nextMessageId(), role: "assistant", text: answer },
-      ]);
-    }, 700);
+    sendMessage({ text: trimmed });
   };
 
   const handleSubmit = (e: FormEvent) => {
@@ -134,24 +117,28 @@ export const MiniChat = () => {
         ref={streamRef}
         className="flex max-h-[280px] flex-col gap-2 overflow-y-auto py-4"
       >
-        {messages.map((m) => (
-          <div
-            key={m.id}
-            className={cn(
-              "max-w-[86%] break-words rounded-(--r-bubble) px-[18px] py-3 text-sm leading-[1.7]",
-              "animate-[lp-bubble-in_400ms_cubic-bezier(0.22,1,0.36,1)] shadow-(--shadow-float-sm)",
-              m.role === "user"
-                ? "self-end bg-(--teal-700) text-white"
-                : "self-start bg-(--paper-50) text-(--fg-1)",
-            )}
-          >
-            {m.text.split("\n").map((line, j) => (
-              // biome-ignore lint/suspicious/noArrayIndexKey: split の行順序は固定で id 単位でユニーク
-              <div key={`${m.id}-${j}`}>{renderInlineBold(line)}</div>
-            ))}
-          </div>
-        ))}
-        {typing && (
+        {messages.map((m) => {
+          const text = messageText(m);
+          if (!text) return null;
+          return (
+            <div
+              key={m.id}
+              className={cn(
+                "max-w-[86%] break-words rounded-(--r-bubble) px-[18px] py-3 text-sm leading-[1.7]",
+                "animate-[lp-bubble-in_400ms_cubic-bezier(0.22,1,0.36,1)] shadow-(--shadow-float-sm)",
+                m.role === "user"
+                  ? "self-end bg-(--teal-700) text-white"
+                  : "self-start bg-(--paper-50) text-(--fg-1)",
+              )}
+            >
+              {text.split("\n").map((line, j) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: split の行順序は固定で id 単位でユニーク
+                <div key={`${m.id}-${j}`}>{renderInlineBold(line)}</div>
+              ))}
+            </div>
+          );
+        })}
+        {isAwaitingFirstToken && (
           <div className="flex max-w-[86%] items-center gap-1.5 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             {[0, 1, 2].map((dotIndex) => (
               <span
@@ -171,7 +158,7 @@ export const MiniChat = () => {
               key={q}
               type="button"
               onClick={() => ask(q)}
-              disabled={typing}
+              disabled={isBusy}
               className={cn(
                 "rounded-(--r-pill) border border-(--paper-200) bg-white px-3 py-1.5 text-xs text-(--fg-2)",
                 "transition-colors duration-150",
@@ -205,12 +192,12 @@ export const MiniChat = () => {
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder="ねっぷちゃんに話しかける…"
-          disabled={typing}
+          disabled={isBusy}
           className="flex-1 border-0 bg-transparent text-sm outline-none placeholder:text-(--fg-4)"
         />
         <button
           type="submit"
-          disabled={typing || !input.trim()}
+          disabled={isBusy || !input.trim()}
           aria-label="送信"
           className={cn(
             "grid size-8 place-items-center rounded-full bg-(--teal-700) text-white",

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -27,7 +27,7 @@ const INITIAL_MESSAGE: UIMessage = {
 
 const messageText = (msg: UIMessage) =>
   msg.parts
-    .filter((p): p is { type: "text"; text: string } => p.type === "text")
+    .filter((p) => p.type === "text")
     .map((p) => p.text)
     .join("");
 

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -1,15 +1,9 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
 import { ArrowRightIcon, EllipsisIcon, PlusIcon } from "lucide-react";
-import {
-  type FormEvent,
-  Fragment,
-  type ReactNode,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { API_BASE } from "~/lib/api/client";
 import { cn } from "~/lib/class-merge";
 
@@ -29,19 +23,6 @@ const INITIAL_MESSAGE: UIMessage = {
       text: "こんにちは〜！ねっぷちゃんだよ 😊\n音威子府のことなら、なんでも聞いてみてね！",
     },
   ],
-};
-
-// `**bold**` を <strong> 要素に分解する。マークダウン全体を解釈せず装飾だけ最低限拾う。
-const renderInlineBold = (line: string): ReactNode => {
-  const parts = line.split(/\*\*(.+?)\*\*/g);
-  return parts.map((part, i) => {
-    const key = `${i}-${part}`;
-    return i % 2 === 1 ? (
-      <strong key={key}>{part}</strong>
-    ) : (
-      <Fragment key={key}>{part}</Fragment>
-    );
-  });
 };
 
 const messageText = (msg: UIMessage) =>
@@ -137,28 +118,72 @@ export const MiniChat = () => {
             <div
               key={m.id}
               className={cn(
-                "max-w-[86%] break-words rounded-(--r-bubble) px-[18px] py-3 text-sm leading-[1.7]",
+                "w-fit max-w-[78%] break-words rounded-(--r-bubble) px-[18px] py-3 text-sm leading-[1.7]",
                 "animate-[lp-bubble-in_400ms_cubic-bezier(0.22,1,0.36,1)] shadow-(--shadow-float-sm)",
                 m.role === "user"
                   ? "self-end bg-(--teal-700) text-white"
                   : "self-start bg-(--paper-50) text-(--fg-1)",
               )}
             >
-              {text.split("\n").map((line, j) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: split の行順序は固定で id 単位でユニーク
-                <div key={`${m.id}-${j}`}>{renderInlineBold(line)}</div>
-              ))}
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                components={{
+                  p: ({ children }) => (
+                    <p className="my-1 first:mt-0 last:mb-0">{children}</p>
+                  ),
+                  ul: ({ children }) => (
+                    <ul className="my-1 list-disc pl-5 first:mt-0 last:mb-0">
+                      {children}
+                    </ul>
+                  ),
+                  ol: ({ children }) => (
+                    <ol className="my-1 list-decimal pl-5 first:mt-0 last:mb-0">
+                      {children}
+                    </ol>
+                  ),
+                  li: ({ children }) => <li className="my-0.5">{children}</li>,
+                  a: ({ href, children }) => (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={cn(
+                        "underline underline-offset-2",
+                        m.role === "user"
+                          ? "text-white/90 hover:text-white"
+                          : "text-(--brand) hover:text-(--brand-hover)",
+                      )}
+                    >
+                      {children}
+                    </a>
+                  ),
+                  code: ({ children }) => (
+                    <code
+                      className={cn(
+                        "rounded px-1 py-0.5 font-mono text-[0.85em]",
+                        m.role === "user"
+                          ? "bg-white/15"
+                          : "bg-(--paper-200) text-(--fg-1)",
+                      )}
+                    >
+                      {children}
+                    </code>
+                  ),
+                }}
+              >
+                {text}
+              </ReactMarkdown>
             </div>
           );
         })}
         {isAwaitingResponse && (
-          <div className="flex max-w-[86%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
+          <div className="flex w-fit max-w-[78%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             <span className="size-2 rounded-full bg-orange-500 animate-pulse" />
             <span className="text-xs font-medium text-(--fg-2)">考え中…</span>
           </div>
         )}
         {error && (
-          <div className="self-start max-w-[86%] rounded-(--r-bubble) bg-red-50 px-[18px] py-3 text-sm text-red-700">
+          <div className="w-fit max-w-[78%] self-start rounded-(--r-bubble) bg-red-50 px-[18px] py-3 text-sm text-red-700">
             通信エラーが発生したよ。もう一度試してみてね。
           </div>
         )}

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -31,6 +31,45 @@ const messageText = (msg: UIMessage) =>
     .map((p) => p.text)
     .join("");
 
+// ツール ID → ユーザー向け活動ラベル。未登録のツールは generic な文言にフォールバックする。
+const TOOL_ACTIVITY_LABEL: Record<string, string> = {
+  "knowledge-search": "村のことを調べているよ",
+  "google-search": "ウェブで調べているよ",
+  "village-search": "村について調べているよ",
+  "emergency-report": "情報を書き留めているよ",
+  "broadcast-get": "お知らせを確認しているよ",
+};
+
+const isAssistantToolPartActive = (part: {
+  type: string;
+  state?: string;
+  toolName?: string;
+}) => {
+  if (part.type !== "dynamic-tool" && !part.type.startsWith("tool-")) {
+    return false;
+  }
+  return part.state === "input-streaming" || part.state === "input-available";
+};
+
+const getActivityLabel = (msg: UIMessage | undefined): string => {
+  if (!msg || msg.role !== "assistant") return "考え中…";
+  // 直近の active なツール部分を後ろから探す
+  for (let i = msg.parts.length - 1; i >= 0; i--) {
+    const part = msg.parts[i] as {
+      type: string;
+      state?: string;
+      toolName?: string;
+    };
+    if (!isAssistantToolPartActive(part)) continue;
+    const toolName =
+      part.type === "dynamic-tool"
+        ? (part.toolName ?? "tool")
+        : part.type.slice("tool-".length);
+    return `${TOOL_ACTIVITY_LABEL[toolName] ?? "ちょっと調べているよ"}…`;
+  }
+  return "考え中…";
+};
+
 export const MiniChat = () => {
   const [input, setInput] = useState("");
   const [showSuggestions, setShowSuggestions] = useState(true);
@@ -179,7 +218,9 @@ export const MiniChat = () => {
         {isAwaitingResponse && (
           <div className="flex w-fit max-w-[78%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             <span className="size-2 rounded-full bg-orange-500 animate-pulse" />
-            <span className="text-xs font-medium text-(--fg-2)">考え中…</span>
+            <span className="text-xs font-medium text-(--fg-2)">
+              {getActivityLabel(lastMessage)}
+            </span>
           </div>
         )}
         {error && (

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -55,11 +55,19 @@ export const MiniChat = () => {
 
   const isBusy = status === "submitted" || status === "streaming";
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: messages/status 変更時に最下部追従させたい
   useEffect(() => {
     const el = streamRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [messages, status]);
+    if (!el) return;
+    const observer = new MutationObserver(() => {
+      el.scrollTop = el.scrollHeight;
+    });
+    observer.observe(el, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    return () => observer.disconnect();
+  }, []);
 
   const ask = (q: string) => {
     const trimmed = q.trim();

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -31,45 +31,6 @@ const messageText = (msg: UIMessage) =>
     .map((p) => p.text)
     .join("");
 
-// ツール ID → ユーザー向け活動ラベル。未登録のツールは generic な文言にフォールバックする。
-const TOOL_ACTIVITY_LABEL: Record<string, string> = {
-  "knowledge-search": "村のことを調べているよ",
-  "google-search": "ウェブで調べているよ",
-  "village-search": "村について調べているよ",
-  "emergency-report": "情報を書き留めているよ",
-  "broadcast-get": "お知らせを確認しているよ",
-};
-
-const isAssistantToolPartActive = (part: {
-  type: string;
-  state?: string;
-  toolName?: string;
-}) => {
-  if (part.type !== "dynamic-tool" && !part.type.startsWith("tool-")) {
-    return false;
-  }
-  return part.state === "input-streaming" || part.state === "input-available";
-};
-
-const getActivityLabel = (msg: UIMessage | undefined): string => {
-  if (!msg || msg.role !== "assistant") return "考え中…";
-  // 直近の active なツール部分を後ろから探す
-  for (let i = msg.parts.length - 1; i >= 0; i--) {
-    const part = msg.parts[i] as {
-      type: string;
-      state?: string;
-      toolName?: string;
-    };
-    if (!isAssistantToolPartActive(part)) continue;
-    const toolName =
-      part.type === "dynamic-tool"
-        ? (part.toolName ?? "tool")
-        : part.type.slice("tool-".length);
-    return `${TOOL_ACTIVITY_LABEL[toolName] ?? "ちょっと調べているよ"}…`;
-  }
-  return "考え中…";
-};
-
 export const MiniChat = () => {
   const [input, setInput] = useState("");
   const [showSuggestions, setShowSuggestions] = useState(true);
@@ -218,9 +179,7 @@ export const MiniChat = () => {
         {isAwaitingResponse && (
           <div className="flex w-fit max-w-[78%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             <span className="size-2 rounded-full bg-orange-500 animate-pulse" />
-            <span className="text-xs font-medium text-(--fg-2)">
-              {getActivityLabel(lastMessage)}
-            </span>
+            <span className="text-xs font-medium text-(--fg-2)">考え中…</span>
           </div>
         )}
         {error && (

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -152,14 +152,9 @@ export const MiniChat = () => {
           );
         })}
         {isAwaitingResponse && (
-          <div className="flex max-w-[86%] items-center gap-1.5 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
-            {[0, 1, 2].map((dotIndex) => (
-              <span
-                key={`typing-dot-${dotIndex}`}
-                className="size-[7px] rounded-full bg-(--teal-500) opacity-35 animate-[lp-bubble-typing_1.2s_infinite]"
-                style={{ animationDelay: `${dotIndex * 0.15}s` }}
-              />
-            ))}
+          <div className="flex max-w-[86%] items-center gap-2 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
+            <span className="size-2 rounded-full bg-orange-500 animate-pulse" />
+            <span className="text-xs font-medium text-(--fg-2)">考え中…</span>
           </div>
         )}
         {error && (

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -59,7 +59,11 @@ export const MiniChat = () => {
     const el = streamRef.current;
     if (!el) return;
     const observer = new MutationObserver(() => {
-      el.scrollTop = el.scrollHeight;
+      const distanceFromBottom =
+        el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom < 80) {
+        el.scrollTop = el.scrollHeight;
+      }
     });
     observer.observe(el, {
       childList: true,

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -173,6 +173,18 @@ export const MiniChat = () => {
                       {children}
                     </code>
                   ),
+                  pre: ({ children }) => (
+                    <pre
+                      className={cn(
+                        "my-1 overflow-x-auto rounded p-2 text-[0.8em] first:mt-0 last:mb-0",
+                        m.role === "user"
+                          ? "bg-white/10"
+                          : "bg-(--paper-200) text-(--fg-1)",
+                      )}
+                    >
+                      {children}
+                    </pre>
+                  ),
                 }}
               >
                 {text}

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -1,6 +1,6 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport, type UIMessage } from "ai";
-import { EllipsisIcon, SendIcon } from "lucide-react";
+import { ArrowRightIcon, EllipsisIcon, SendIcon } from "lucide-react";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -54,6 +54,8 @@ export const MiniChat = () => {
   });
 
   const isBusy = status === "submitted" || status === "streaming";
+  const hasCompletedExchange =
+    status === "ready" && messages.some((m) => m.role === "user");
 
   useEffect(() => {
     const el = streamRef.current;
@@ -228,34 +230,49 @@ export const MiniChat = () => {
         </div>
       )}
 
-      <form
-        onSubmit={handleSubmit}
-        className={cn(
-          "mt-3 flex items-center gap-2 rounded-(--r-pill)",
-          "border border-(--paper-200) bg-(--paper-50) px-3 py-2",
-          "transition-shadow duration-200 focus-within:border-(--teal-400) focus-within:shadow-(--ring-brand)",
-        )}
-      >
-        <input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="ねっぷちゃんに話しかける…"
-          disabled={isBusy}
-          className="flex-1 border-0 bg-transparent text-sm outline-none placeholder:text-(--fg-4)"
-        />
-        <button
-          type="submit"
-          disabled={isBusy || !input.trim()}
-          aria-label="送信"
+      {hasCompletedExchange ? (
+        <a
+          href="/"
           className={cn(
-            "grid size-8 place-items-center rounded-full bg-(--teal-700) text-white",
-            "transition-colors hover:bg-(--teal-800)",
-            "disabled:cursor-not-allowed disabled:opacity-55",
+            "mt-3 flex items-center justify-center gap-2 rounded-(--r-pill)",
+            "bg-(--brand) px-4 py-3 text-sm font-bold text-white shadow-(--shadow-brand)",
+            "transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+            "hover:-translate-y-0.5 hover:bg-(--brand-hover)",
           )}
         >
-          <SendIcon className="size-[18px]" aria-hidden="true" />
-        </button>
-      </form>
+          続きはチャットでお話しよう
+          <ArrowRightIcon className="size-4" aria-hidden="true" />
+        </a>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          className={cn(
+            "mt-3 flex items-center gap-2 rounded-(--r-pill)",
+            "border border-(--paper-200) bg-(--paper-50) px-3 py-2",
+            "transition-shadow duration-200 focus-within:border-(--teal-400) focus-within:shadow-(--ring-brand)",
+          )}
+        >
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="ねっぷちゃんに話しかける…"
+            disabled={isBusy}
+            className="flex-1 border-0 bg-transparent text-sm outline-none placeholder:text-(--fg-4)"
+          />
+          <button
+            type="submit"
+            disabled={isBusy || !input.trim()}
+            aria-label="送信"
+            className={cn(
+              "grid size-8 place-items-center rounded-full bg-(--teal-700) text-white",
+              "transition-colors hover:bg-(--teal-800)",
+              "disabled:cursor-not-allowed disabled:opacity-55",
+            )}
+          >
+            <SendIcon className="size-[18px]" aria-hidden="true" />
+          </button>
+        </form>
+      )}
     </div>
   );
 };

--- a/web/src/app/lp/components/MiniChat.tsx
+++ b/web/src/app/lp/components/MiniChat.tsx
@@ -6,6 +6,7 @@ import {
   Fragment,
   type ReactNode,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -54,20 +55,32 @@ export const MiniChat = () => {
   const [showSuggestions, setShowSuggestions] = useState(true);
   const streamRef = useRef<HTMLDivElement | null>(null);
 
-  const { messages, sendMessage, status } = useChat({
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: `${API_BASE}/simple-chat`,
+        prepareSendMessagesRequest({ messages: msgs }) {
+          return { body: { message: msgs[msgs.length - 1] } };
+        },
+      }),
+    [],
+  );
+
+  const { messages, sendMessage, status, error } = useChat({
     messages: [INITIAL_MESSAGE],
-    transport: new DefaultChatTransport({
-      api: `${API_BASE}/simple-chat`,
-      prepareSendMessagesRequest({ messages: msgs }) {
-        return { body: { message: msgs[msgs.length - 1] } };
-      },
-    }),
+    transport,
+    experimental_throttle: 50,
   });
 
   const isBusy = status === "submitted" || status === "streaming";
   const lastMessage = messages[messages.length - 1];
-  const isAwaitingFirstToken =
-    isBusy && (!lastMessage || lastMessage.role === "user");
+  // dots は「アシスタントのテキストがまだ届いていない間」表示し続けたい。
+  // ツール実行中など、空 parts の assistant message が先に挿入されるケースもカバー。
+  const isAwaitingResponse =
+    isBusy &&
+    (!lastMessage ||
+      lastMessage.role === "user" ||
+      messageText(lastMessage).length === 0);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: messages/status 変更時に最下部追従させたい
   useEffect(() => {
@@ -78,9 +91,9 @@ export const MiniChat = () => {
   const ask = (q: string) => {
     const trimmed = q.trim();
     if (!trimmed || isBusy) return;
+    sendMessage({ text: trimmed });
     setInput("");
     setShowSuggestions(false);
-    sendMessage({ text: trimmed });
   };
 
   const handleSubmit = (e: FormEvent) => {
@@ -138,7 +151,7 @@ export const MiniChat = () => {
             </div>
           );
         })}
-        {isAwaitingFirstToken && (
+        {isAwaitingResponse && (
           <div className="flex max-w-[86%] items-center gap-1.5 self-start rounded-(--r-bubble) bg-(--paper-50) px-[18px] py-3">
             {[0, 1, 2].map((dotIndex) => (
               <span
@@ -147,6 +160,11 @@ export const MiniChat = () => {
                 style={{ animationDelay: `${dotIndex * 0.15}s` }}
               />
             ))}
+          </div>
+        )}
+        {error && (
+          <div className="self-start max-w-[86%] rounded-(--r-bubble) bg-red-50 px-[18px] py-3 text-sm text-red-700">
+            通信エラーが発生したよ。もう一度試してみてね。
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- LP / ウィジェット向けに履歴保存なしの `POST /simple-chat` を新設
- LP の MiniChat を canned 応答から `/simple-chat` のストリーミング応答に置き換え
- markdown 描画・待機インジケータ・送信アイコン・バブル幅などの UX 周りを整備

## 主な変更内容

### server
- `routes/simple-chat.ts` を新規追加
  - 認証なしの公開ルート
  - `handleChatStream` を `memory` 無しで呼び出すことで D1 への履歴保存を行わない
  - intent 分類はスキップして `casual` ティア固定でレイテンシを抑える
- `createNeppChanAgent` に `withMemory` フラグを追加し、`/simple-chat` からは `withMemory: false` で生成
  - これによりサブエージェント（knowledge-agent 等）の memory 保存試行も走らず、`Message at index 1 missing threadId` のエラーログが発生しない
- `server/CLAUDE.md` の API エンドポイント表に `/simple-chat` を追記

### web
- `app/lp/components/MiniChat.tsx` を全面リライト
  - `@ai-sdk/react` の `useChat` + `DefaultChatTransport` でストリーミング受信
  - `prepareSendMessagesRequest` で最新 1 メッセージのみ送信
  - `experimental_throttle: 50` でストリームを React に都度反映
  - 待機インジケータをオレンジパルス + 「ちょっと待ってね…」に統一し、`status === "streaming"` の間は常時表示
  - `react-markdown` + `remark-gfm` で本文を markdown レンダリング
  - バブルを `w-fit max-w-[78%]` にして長文でも横に広がりすぎない
  - 飾りの `+` ボタンを削除、送信アイコンをチャット画面と揃えて `SendIcon`
  - 通信エラー時は赤い吹き出しで明示
- `react-markdown` を直接依存に追加

## Test plan
- [ ] `/lp` を開き MiniChat の初回挨拶が表示される
- [ ] サンプル質問のチップをクリックしてストリーミング応答が始まる
- [ ] テキスト入力 → 送信 でストリーミング応答が流れる
- [ ] ツール実行中も「ちょっと待ってね…」が出続ける
- [ ] 応答完了後にインジケータが消える
- [ ] markdown（箇条書き・リンク・bold）が正しく描画される
- [ ] 長文応答でもバブルが横に広がりすぎない
- [ ] ロゴ部分から `/lp` に遷移できる、紙飛行機アイコンで送信できる
- [ ] サーバーログに `Message at index 1 missing threadId` の ERROR が出ないこと
- [ ] D1 の `mastra_threads` / `mastra_messages` に `/simple-chat` 由来のレコードが追加されないこと