### PR TITLE
fix(web): ログアウト見え状態でのチャット 401 永続ローディングを解消する

### DIFF
--- a/web/src/app/dashboard/contexts/AuthContext.tsx
+++ b/web/src/app/dashboard/contexts/AuthContext.tsx
@@ -1,8 +1,9 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { createContext, type ReactNode, useCallback, useContext } from "react";
 
-import { adminUserKeys, useAdminUser } from "~/hooks/useAdminUser";
+import { useAdminUser } from "~/hooks/useAdminUser";
 import { type AdminUser, postLogout } from "~/lib/api/auth";
+import { adminUserKeys } from "~/lib/api/keys";
 import { removeAuthToken } from "~/lib/auth-token";
 
 type AuthContextType = {

--- a/web/src/app/dashboard/contexts/AuthContext.tsx
+++ b/web/src/app/dashboard/contexts/AuthContext.tsx
@@ -1,77 +1,41 @@
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-} from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { createContext, type ReactNode, useCallback, useContext } from "react";
 
-import { type AdminUser, fetchCurrentUser, postLogout } from "~/lib/api/auth";
+import { adminUserKeys, useAdminUser } from "~/hooks/useAdminUser";
+import { type AdminUser, postLogout } from "~/lib/api/auth";
 import { removeAuthToken } from "~/lib/auth-token";
 
-type AuthState = {
+type AuthContextType = {
   user: AdminUser | null;
   isLoading: boolean;
   isAuthenticated: boolean;
-};
-
-type AuthContextType = AuthState & {
-  checkAuth: () => Promise<void>;
   logout: () => Promise<void>;
-  setUser: (user: AdminUser | null) => void;
 };
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
-  const [state, setState] = useState<AuthState>({
-    user: null,
-    isLoading: true,
-    isAuthenticated: false,
-  });
-
-  const checkAuth = useCallback(async () => {
-    try {
-      const user = await fetchCurrentUser();
-      if (user) {
-        setState({ user, isLoading: false, isAuthenticated: true });
-      } else {
-        setState({ user: null, isLoading: false, isAuthenticated: false });
-      }
-    } catch (error) {
-      console.error("認証チェック失敗:", error);
-      setState({ user: null, isLoading: false, isAuthenticated: false });
-    }
-  }, []);
+  const queryClient = useQueryClient();
+  const { data, isLoading } = useAdminUser();
+  const user = data ?? null;
 
   const logout = useCallback(async () => {
     try {
       await postLogout();
     } finally {
       removeAuthToken();
-      setState({ user: null, isLoading: false, isAuthenticated: false });
+      queryClient.setQueryData(adminUserKeys.current, null);
     }
-  }, []);
+  }, [queryClient]);
 
-  const setUser = useCallback((user: AdminUser | null) => {
-    setState({
-      user,
-      isLoading: false,
-      isAuthenticated: user !== null,
-    });
-  }, []);
-
-  useEffect(() => {
-    checkAuth();
-  }, [checkAuth]);
-
-  if (state.isLoading) {
+  if (isLoading) {
     return null;
   }
 
   return (
-    <AuthContext.Provider value={{ ...state, checkAuth, logout, setUser }}>
+    <AuthContext.Provider
+      value={{ user, isLoading, isAuthenticated: !!user, logout }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/web/src/hooks/useAdminUser.ts
+++ b/web/src/hooks/useAdminUser.ts
@@ -1,10 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { type AdminUser, fetchCurrentUser } from "~/lib/api/auth";
-
-export const adminUserKeys = {
-  current: ["adminUser", "current"] as const,
-};
+import { adminUserKeys } from "~/lib/api/keys";
 
 export const useAdminUser = () =>
   useQuery<AdminUser | null>({

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -1,4 +1,4 @@
-import { getAuthToken } from "~/lib/auth-token";
+import { getAuthToken, removeAuthToken } from "~/lib/auth-token";
 import type { paths } from "~/types/api";
 import { API_BASE, parseErrorResponse } from "./client";
 
@@ -60,7 +60,12 @@ export const fetchCurrentUser = async (): Promise<AdminUser | null> => {
     },
   });
 
-  if (!res.ok) return null;
+  if (!res.ok) {
+    if (res.status === 401) {
+      removeAuthToken();
+    }
+    return null;
+  }
 
   const data: AuthMeResponse = await res.json();
   return data.user;

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -18,55 +18,44 @@ class ApiError extends Error {
 
 const API_BASE = import.meta.env.PUBLIC_API_URL || "";
 
-export const client = createClient<paths>({ baseUrl: API_BASE });
+// 401 が返って admin token が原因と判定できれば、token を破棄してフォールバックで再試行する。
+const fetchWithAuthRetry = async (request: Request): Promise<Response> => {
+  const retryRequest = request.clone();
+  const response = await fetch(request);
+  if (response.status !== 401) return response;
 
-const adminTokenRequests = new Map<string, Request>();
+  const adminToken = getAuthToken();
+  const sentAuth = retryRequest.headers.get("Authorization");
+  if (!adminToken || sentAuth !== `Bearer ${adminToken}`) return response;
+
+  removeAuthToken();
+  const headers = new Headers(retryRequest.headers);
+  const fallbackToken = getBearerToken();
+  if (fallbackToken) {
+    headers.set("Authorization", `Bearer ${fallbackToken}`);
+  } else {
+    headers.delete("Authorization");
+  }
+  return fetch(new Request(retryRequest, { headers }));
+};
+
+export const client = createClient<paths>({
+  baseUrl: API_BASE,
+  fetch: fetchWithAuthRetry,
+});
 
 client.use({
-  async onRequest({ request, id }) {
-    const adminToken = getAuthToken();
+  async onRequest({ request }) {
     const token = getBearerToken();
     if (token) {
       request.headers.set("Authorization", `Bearer ${token}`);
-    }
-    if (adminToken && token === adminToken) {
-      adminTokenRequests.set(id, request.clone());
     }
     return request;
   },
 });
 
 client.use({
-  async onResponse({ response, id }) {
-    const adminTokenRequest = adminTokenRequests.get(id);
-    adminTokenRequests.delete(id);
-
-    if (response.status === 401 && adminTokenRequest) {
-      removeAuthToken();
-      const retryHeaders = new Headers(adminTokenRequest.headers);
-      retryHeaders.delete("Authorization");
-      const fallbackToken = getBearerToken();
-      if (fallbackToken) {
-        retryHeaders.set("Authorization", `Bearer ${fallbackToken}`);
-      }
-      const retryResponse = await fetch(adminTokenRequest.url, {
-        method: adminTokenRequest.method,
-        headers: retryHeaders,
-        body: adminTokenRequest.body,
-        credentials: adminTokenRequest.credentials,
-        // @ts-expect-error duplex is required when streaming a body
-        duplex: adminTokenRequest.body ? "half" : undefined,
-      });
-      if (!retryResponse.ok) {
-        const message = await parseErrorResponse(retryResponse);
-        if (retryResponse.status >= 500) {
-          Sentry.captureException(new ApiError(message, retryResponse.status));
-        }
-        throw new ApiError(message, retryResponse.status);
-      }
-      return retryResponse;
-    }
-
+  async onResponse({ response }) {
     if (!response.ok) {
       const message = await parseErrorResponse(response);
       if (response.status >= 500) {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1,10 +1,12 @@
 import * as Sentry from "@sentry/react";
 import createClient from "openapi-fetch";
+import { adminUserKeys } from "~/hooks/useAdminUser";
 import {
-  getAuthToken,
   getBearerToken,
+  getSessionToken,
   removeAuthToken,
 } from "~/lib/auth-token";
+import { queryClient } from "~/providers/QueryProvider";
 import type { paths } from "~/types/api";
 
 class ApiError extends Error {
@@ -19,16 +21,20 @@ class ApiError extends Error {
 const API_BASE = import.meta.env.PUBLIC_API_URL || "";
 
 // 401 が返って admin token が原因と判定できれば、token を破棄してフォールバックで再試行する。
+// 並行リクエストで判定がぶれないよう、送信時の Authorization ヘッダーを起点に判定する。
 const fetchWithAuthRetry = async (request: Request): Promise<Response> => {
   const retryRequest = request.clone();
   const response = await fetch(request);
   if (response.status !== 401) return response;
 
-  const adminToken = getAuthToken();
   const sentAuth = retryRequest.headers.get("Authorization");
-  if (!adminToken || sentAuth !== `Bearer ${adminToken}`) return response;
+  if (!sentAuth) return response;
+  const sessionToken = getSessionToken();
+  const wasAdminAuth = !sessionToken || sentAuth !== `Bearer ${sessionToken}`;
+  if (!wasAdminAuth) return response;
 
   removeAuthToken();
+  queryClient.invalidateQueries({ queryKey: adminUserKeys.current });
   const headers = new Headers(retryRequest.headers);
   const fallbackToken = getBearerToken();
   if (fallbackToken) {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1,13 +1,13 @@
 import * as Sentry from "@sentry/react";
 import createClient from "openapi-fetch";
-import { adminUserKeys } from "~/hooks/useAdminUser";
 import {
   getBearerToken,
   getSessionToken,
   removeAuthToken,
 } from "~/lib/auth-token";
-import { queryClient } from "~/providers/QueryProvider";
+import { queryClient } from "~/lib/query-client";
 import type { paths } from "~/types/api";
+import { adminUserKeys } from "./keys";
 
 class ApiError extends Error {
   status: number;
@@ -21,7 +21,8 @@ class ApiError extends Error {
 const API_BASE = import.meta.env.PUBLIC_API_URL || "";
 
 // 401 が返って admin token が原因と判定できれば、token を破棄してフォールバックで再試行する。
-// 並行リクエストで判定がぶれないよう、送信時の Authorization ヘッダーを起点に判定する。
+// session token は不変なので、「送ったヘッダが session token と一致しない」を起点に判定する。
+// admin token は破棄後も並行リクエストで判定がぶれないよう、現在値ではなく送信ヘッダ側を見る。
 const fetchWithAuthRetry = async (request: Request): Promise<Response> => {
   const retryRequest = request.clone();
   const response = await fetch(request);
@@ -30,8 +31,7 @@ const fetchWithAuthRetry = async (request: Request): Promise<Response> => {
   const sentAuth = retryRequest.headers.get("Authorization");
   if (!sentAuth) return response;
   const sessionToken = getSessionToken();
-  const wasAdminAuth = !sessionToken || sentAuth !== `Bearer ${sessionToken}`;
-  if (!wasAdminAuth) return response;
+  if (sessionToken && sentAuth === `Bearer ${sessionToken}`) return response;
 
   removeAuthToken();
   queryClient.invalidateQueries({ queryKey: adminUserKeys.current });

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1,6 +1,10 @@
 import * as Sentry from "@sentry/react";
 import createClient from "openapi-fetch";
-import { getBearerToken } from "~/lib/auth-token";
+import {
+  getAuthToken,
+  getBearerToken,
+  removeAuthToken,
+} from "~/lib/auth-token";
 import type { paths } from "~/types/api";
 
 class ApiError extends Error {
@@ -16,18 +20,53 @@ const API_BASE = import.meta.env.PUBLIC_API_URL || "";
 
 export const client = createClient<paths>({ baseUrl: API_BASE });
 
+const adminTokenRequests = new Map<string, Request>();
+
 client.use({
-  async onRequest({ request }) {
+  async onRequest({ request, id }) {
+    const adminToken = getAuthToken();
     const token = getBearerToken();
     if (token) {
       request.headers.set("Authorization", `Bearer ${token}`);
+    }
+    if (adminToken && token === adminToken) {
+      adminTokenRequests.set(id, request.clone());
     }
     return request;
   },
 });
 
 client.use({
-  async onResponse({ response }) {
+  async onResponse({ response, id }) {
+    const adminTokenRequest = adminTokenRequests.get(id);
+    adminTokenRequests.delete(id);
+
+    if (response.status === 401 && adminTokenRequest) {
+      removeAuthToken();
+      const retryHeaders = new Headers(adminTokenRequest.headers);
+      retryHeaders.delete("Authorization");
+      const fallbackToken = getBearerToken();
+      if (fallbackToken) {
+        retryHeaders.set("Authorization", `Bearer ${fallbackToken}`);
+      }
+      const retryResponse = await fetch(adminTokenRequest.url, {
+        method: adminTokenRequest.method,
+        headers: retryHeaders,
+        body: adminTokenRequest.body,
+        credentials: adminTokenRequest.credentials,
+        // @ts-expect-error duplex is required when streaming a body
+        duplex: adminTokenRequest.body ? "half" : undefined,
+      });
+      if (!retryResponse.ok) {
+        const message = await parseErrorResponse(retryResponse);
+        if (retryResponse.status >= 500) {
+          Sentry.captureException(new ApiError(message, retryResponse.status));
+        }
+        throw new ApiError(message, retryResponse.status);
+      }
+      return retryResponse;
+    }
+
     if (!response.ok) {
       const message = await parseErrorResponse(response);
       if (response.status >= 500) {

--- a/web/src/lib/api/keys.ts
+++ b/web/src/lib/api/keys.ts
@@ -1,0 +1,3 @@
+export const adminUserKeys = {
+  current: ["adminUser", "current"] as const,
+};

--- a/web/src/lib/query-client.ts
+++ b/web/src/lib/query-client.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/web/src/providers/QueryProvider.tsx
+++ b/web/src/providers/QueryProvider.tsx
@@ -1,15 +1,6 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 1000 * 60,
-      retry: 1,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
+import { queryClient } from "~/lib/query-client";
 
 type Props = {
   children: ReactNode;

--- a/web/src/providers/QueryProvider.tsx
+++ b/web/src/providers/QueryProvider.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60,


### PR DESCRIPTION
## Summary
- 古い admin token 残存時に `/threads` 等が 401 で永続ローディングになる問題を解消
- 401 検知後は admin token を破棄して匿名 token で 1 回だけリトライ
- 認証状態の真実の源を react-query (`useAdminUser`) に集約し、 UI とリトライ後の同期を担保

## 主な変更内容

### 401 リトライ
- `web/src/lib/api/client.ts` の `fetchWithAuthRetry`
  - 401 受信時、 送信した Authorization ヘッダが session token と一致しない（= admin 由来）と判定したら `removeAuthToken()` → 匿名 token で再試行
  - admin token 削除後でも並行リクエストの判定がぶれないよう、 現在の admin token ではなく送信ヘッダ側を起点にする

### 認証状態の集約
- `useAdminUser` (react-query) を auth state の真実の源にする
- `AuthContext` を `useAdminUser` ベースに書き換え（`fetchCurrentUser` の重複呼び出しを排除）
- `client.ts` の 401 処理から `queryClient.invalidateQueries` を呼ぶことで、 token 破棄後に `useAdminUser` が再評価される
- `fetchCurrentUser` は 401 時に明示的に `removeAuthToken()` を呼ぶ

### 依存方向の整理
- `lib/api/client.ts` が `providers/QueryProvider`・`hooks/useAdminUser` を参照していた逆向き依存を解消
- `queryClient` を `lib/query-client.ts`、 `adminUserKeys` を `lib/api/keys.ts` に切り出し、 client.ts は `lib/` 内のみを参照

## Test plan
- [ ] admin としてログイン → ログアウト → 通常状態でチャットを開いてスレッド一覧が読み込めること
- [ ] admin token を localStorage に手動で残した状態でチャットを開き、 401 → 匿名 token でリトライ → スレッド一覧が読み込めること
- [ ] ログイン直後 / ログアウト直後の管理者バナー表示が瞬時に切り替わること
- [ ] 管理画面 (`/dashboard`) で認証ガードが従来通り動作すること