### PR TITLE
feat(server): LINE userId 由来の resourceId / threadId を HMAC-SHA256 でハッシュ化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,13 +103,15 @@ cp web/.env.example web/.env
 
 ### server 環境変数
 
-| 変数名                         | 用途              |
-| ------------------------------ | ----------------- |
-| `GOOGLE_GENERATIVE_AI_API_KEY` | Gemini API        |
-| `GOOGLE_SEARCH_ENGINE_ID`      | Custom Search     |
-| `WEB_URL`                      | Web URL           |
-| `LINE_CHANNEL_SECRET`          | LINE 署名検証     |
-| `LINE_CHANNEL_ACCESS_TOKEN`    | LINE API 認証     |
+| 変数名                         | 用途                                  |
+| ------------------------------ | ------------------------------------- |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Gemini API                            |
+| `GOOGLE_SEARCH_ENGINE_ID`      | Custom Search                         |
+| `WEB_URL`                      | Web URL                               |
+| `LINE_CHANNEL_SECRET`          | LINE 署名検証                         |
+| `LINE_CHANNEL_ACCESS_TOKEN`    | LINE API 認証                         |
+| `JWT_SECRET`                   | anonymous セッション JWT 署名         |
+| `RESOURCE_ID_HASH_SECRET`      | LINE userId のハッシュ化（HMAC-SHA256）|
 
 ### web 環境変数
 

--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -4,6 +4,9 @@ GOOGLE_SEARCH_ENGINE_ID=your-engine-id-here
 # JWT
 JWT_SECRET=local-dev-jwt-secret-must-be-at-least-32-chars-long
 
+# LINE userId のハッシュ化用シークレット（HMAC-SHA256 のキー）
+RESOURCE_ID_HASH_SECRET=local-dev-resource-id-hash-secret-change-me
+
 # Eval専用（省略時は GOOGLE_GENERATIVE_AI_API_KEY を使用）
 EVAL_GOOGLE_API_KEY=
 

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -5,4 +5,5 @@
  */
 interface CloudflareBindings {
   JWT_SECRET: string;
+  RESOURCE_ID_HASH_SECRET: string;
 }

--- a/server/src/handlers/line-event-handler.test.ts
+++ b/server/src/handlers/line-event-handler.test.ts
@@ -15,6 +15,7 @@ const { handleLineEvent } = await import("./line-event-handler");
 
 const env = {
   LINE_CHANNEL_ACCESS_TOKEN: "token",
+  RESOURCE_ID_HASH_SECRET: "test-secret",
 } as unknown as CloudflareBindings;
 
 const buildMessage = (body: {
@@ -59,9 +60,14 @@ describe("handleLineEvent", () => {
     expect(mockGenerateReply).toHaveBeenCalledWith(
       expect.objectContaining({
         userMessage: "こんにちは",
-        threadId: "line-thread:U1",
+        userId: "U1",
+        threadId: expect.stringMatching(/^line-thread:[A-Za-z0-9_-]+$/),
+        resourceId: expect.stringMatching(/^line:[A-Za-z0-9_-]+$/),
       }),
     );
+    const callArg = mockGenerateReply.mock.calls[0]?.[0];
+    expect(callArg.threadId).not.toContain("U1");
+    expect(callArg.resourceId).not.toContain("U1");
     expect(mockSendLineMessages).toHaveBeenCalled();
     expect(msg.ack).toHaveBeenCalled();
     expect(msg.retry).not.toHaveBeenCalled();

--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -1,6 +1,6 @@
 import { logger } from "~/lib/logger";
 import type { LinePrincipal } from "~/lib/principal";
-import { toResourceId } from "~/lib/principal";
+import { toLineResourceId, toLineThreadId } from "~/lib/principal";
 import type { LineEventMessage } from "~/schemas/line-schema";
 import {
   createLineClient,
@@ -13,16 +13,22 @@ export const handleLineEvent = async (
   env: CloudflareBindings,
 ) => {
   const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+  const secret = env.RESOURCE_ID_HASH_SECRET;
 
   for (const message of batch.messages) {
     const { userId, userMessage, replyToken } = message.body;
 
     try {
       const principal: LinePrincipal = { type: "line", id: userId };
+      const [resourceId, threadId] = await Promise.all([
+        toLineResourceId(principal, secret),
+        toLineThreadId(principal, secret),
+      ]);
       const replyTexts = await generateReply({
         userMessage,
-        resourceId: toResourceId(principal),
-        threadId: `line-thread:${userId}`,
+        userId,
+        resourceId,
+        threadId,
         env,
       });
 

--- a/server/src/lib/crypto.test.ts
+++ b/server/src/lib/crypto.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { hmacSha256 } from "./crypto";
+
+describe("hmacSha256", () => {
+  it("同じ value と secret から決定的に同じ値を返す", async () => {
+    const a = await hmacSha256("U1234567890", "secret");
+    const b = await hmacSha256("U1234567890", "secret");
+    expect(a).toBe(b);
+  });
+
+  it("value が異なれば異なる値を返す", async () => {
+    const a = await hmacSha256("U1234567890", "secret");
+    const b = await hmacSha256("U0987654321", "secret");
+    expect(a).not.toBe(b);
+  });
+
+  it("secret が異なれば異なる値を返す", async () => {
+    const a = await hmacSha256("U1234567890", "secret-a");
+    const b = await hmacSha256("U1234567890", "secret-b");
+    expect(a).not.toBe(b);
+  });
+
+  it("base64url 形式（+ / = を含まない）で返す", async () => {
+    const out = await hmacSha256("U1234567890", "secret");
+    expect(out).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("SHA-256 由来の固定長（base64url で 43 文字）を返す", async () => {
+    const out = await hmacSha256("any-value", "any-secret");
+    expect(out).toHaveLength(43);
+  });
+
+  it("空文字 value でも HMAC を計算できる", async () => {
+    const out = await hmacSha256("", "secret");
+    expect(out).toHaveLength(43);
+  });
+
+  it("空 secret は許容しない", async () => {
+    await expect(hmacSha256("value", "")).rejects.toThrow();
+  });
+});

--- a/server/src/lib/crypto.ts
+++ b/server/src/lib/crypto.ts
@@ -2,6 +2,38 @@
  * 暗号化関連のユーティリティ関数
  */
 
+const toBase64Url = (bytes: ArrayBuffer): string => {
+  const u8 = new Uint8Array(bytes);
+  let binary = "";
+  for (const byte of u8) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+};
+
+export const hmacSha256 = async (
+  value: string,
+  secret: string,
+): Promise<string> => {
+  if (!secret) {
+    throw new Error("hmacSha256: secret は空にできません");
+  }
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(value),
+  );
+  return toBase64Url(signature);
+};
+
 export const generateId = () => {
   const array = new Uint8Array(16);
   crypto.getRandomValues(array);

--- a/server/src/lib/crypto.ts
+++ b/server/src/lib/crypto.ts
@@ -2,7 +2,7 @@
  * 暗号化関連のユーティリティ関数
  */
 
-const toBase64Url = (bytes: ArrayBuffer): string => {
+const toBase64Url = (bytes: ArrayBuffer) => {
   const u8 = new Uint8Array(bytes);
   let binary = "";
   for (const byte of u8) binary += String.fromCharCode(byte);
@@ -12,10 +12,7 @@ const toBase64Url = (bytes: ArrayBuffer): string => {
     .replace(/=+$/, "");
 };
 
-export const hmacSha256 = async (
-  value: string,
-  secret: string,
-): Promise<string> => {
+export const hmacSha256 = async (value: string, secret: string) => {
   if (!secret) {
     throw new Error("hmacSha256: secret は空にできません");
   }

--- a/server/src/lib/principal.test.ts
+++ b/server/src/lib/principal.test.ts
@@ -5,8 +5,12 @@ import {
   type AnonymousPrincipal,
   type LinePrincipal,
   requireAdminUser,
+  toLineResourceId,
+  toLineThreadId,
   toResourceId,
 } from "./principal";
+
+const SECRET = "test-secret-key";
 
 describe("toResourceId", () => {
   it("anonymous: id をそのまま返す", () => {
@@ -28,9 +32,65 @@ describe("toResourceId", () => {
     expect(toResourceId(p)).toBe("admin:admin-1");
   });
 
-  it("line: line: プレフィックス付きで返す", () => {
+  it("line: 平文ハッシュ化忘れ防止のため必ず throw する", () => {
     const p: LinePrincipal = { type: "line", id: "U1234567890" };
-    expect(toResourceId(p)).toBe("line:U1234567890");
+    expect(() => toResourceId(p)).toThrow(/toLineResourceId/);
+  });
+});
+
+describe("toLineResourceId", () => {
+  it("line: プレフィックス付きの base64url ハッシュを返す", async () => {
+    const p: LinePrincipal = { type: "line", id: "U1234567890" };
+    const out = await toLineResourceId(p, SECRET);
+    expect(out).toMatch(/^line:[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("同じ userId / secret から同じ resourceId が再現される（会話継続性）", async () => {
+    const p: LinePrincipal = { type: "line", id: "U1234567890" };
+    const a = await toLineResourceId(p, SECRET);
+    const b = await toLineResourceId(p, SECRET);
+    expect(a).toBe(b);
+  });
+
+  it("異なる userId は異なる resourceId になる", async () => {
+    const a = await toLineResourceId({ type: "line", id: "Uaaa" }, SECRET);
+    const b = await toLineResourceId({ type: "line", id: "Ubbb" }, SECRET);
+    expect(a).not.toBe(b);
+  });
+
+  it("出力に平文 userId を含まない", async () => {
+    const out = await toLineResourceId(
+      { type: "line", id: "U1234567890" },
+      SECRET,
+    );
+    expect(out).not.toContain("U1234567890");
+  });
+});
+
+describe("toLineThreadId", () => {
+  it("line-thread: プレフィックス付きの base64url ハッシュを返す", async () => {
+    const out = await toLineThreadId(
+      { type: "line", id: "U1234567890" },
+      SECRET,
+    );
+    expect(out).toMatch(/^line-thread:[A-Za-z0-9_-]{43}$/);
+  });
+
+  it("toLineResourceId と toLineThreadId は同じハッシュを共有する", async () => {
+    const p: LinePrincipal = { type: "line", id: "U1234567890" };
+    const resourceId = await toLineResourceId(p, SECRET);
+    const threadId = await toLineThreadId(p, SECRET);
+    expect(resourceId.replace("line:", "")).toBe(
+      threadId.replace("line-thread:", ""),
+    );
+  });
+
+  it("出力に平文 userId を含まない", async () => {
+    const out = await toLineThreadId(
+      { type: "line", id: "U1234567890" },
+      SECRET,
+    );
+    expect(out).not.toContain("U1234567890");
   });
 });
 

--- a/server/src/lib/principal.ts
+++ b/server/src/lib/principal.ts
@@ -1,4 +1,5 @@
 import { HTTPException } from "hono/http-exception";
+import { hmacSha256 } from "~/lib/crypto";
 import type { AuthUser } from "~/schemas/auth-schema";
 
 export type AnonymousPrincipal = { type: "anonymous"; id: string };
@@ -18,9 +19,23 @@ export const toResourceId = (p: Principal): string => {
     case "admin":
       return `admin:${p.id}`;
     case "line":
-      return `line:${p.id}`;
+      // LINE ケースはハッシュ化が必須。誤って平文 resourceId が永続化されないよう、
+      // 平文を返さず toLineResourceId() の利用を強制する。
+      throw new Error(
+        "toResourceId: LINE principal は toLineResourceId(p, secret) を使ってください",
+      );
   }
 };
+
+export const toLineResourceId = async (
+  p: LinePrincipal,
+  secret: string,
+): Promise<string> => `line:${await hmacSha256(p.id, secret)}`;
+
+export const toLineThreadId = async (
+  p: LinePrincipal,
+  secret: string,
+): Promise<string> => `line-thread:${await hmacSha256(p.id, secret)}`;
 
 export const requireAdminUser = (
   principal: Principal | undefined,

--- a/server/src/lib/principal.ts
+++ b/server/src/lib/principal.ts
@@ -27,15 +27,11 @@ export const toResourceId = (p: Principal): string => {
   }
 };
 
-export const toLineResourceId = async (
-  p: LinePrincipal,
-  secret: string,
-): Promise<string> => `line:${await hmacSha256(p.id, secret)}`;
+export const toLineResourceId = async (p: LinePrincipal, secret: string) =>
+  `line:${await hmacSha256(p.id, secret)}`;
 
-export const toLineThreadId = async (
-  p: LinePrincipal,
-  secret: string,
-): Promise<string> => `line-thread:${await hmacSha256(p.id, secret)}`;
+export const toLineThreadId = async (p: LinePrincipal, secret: string) =>
+  `line-thread:${await hmacSha256(p.id, secret)}`;
 
 export const requireAdminUser = (
   principal: Principal | undefined,

--- a/server/src/middleware/require-thread-access.test.ts
+++ b/server/src/middleware/require-thread-access.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { hmacSha256 } from "~/lib/crypto";
 import type { Principal } from "~/lib/principal";
 
 const mockGetThreadById = vi.fn();
@@ -28,6 +29,7 @@ const mockThread = {
 
 const mockEnv = {
   DB: {} as D1Database,
+  RESOURCE_ID_HASH_SECRET: "test-secret",
 } as unknown as CloudflareBindings;
 
 const createApp = () => {
@@ -116,8 +118,9 @@ describe("requireThreadAccess", () => {
     expect(res.status).toBe(404);
   });
 
-  it("line principal + 所有スレッド → 通過", async () => {
-    const lineThread = { ...mockThread, resourceId: "line:U123" };
+  it("line principal + 所有スレッド（ハッシュ化された resourceId）→ 通過", async () => {
+    const hashed = await hmacSha256("U123", "test-secret");
+    const lineThread = { ...mockThread, resourceId: `line:${hashed}` };
     mockGetThreadById.mockResolvedValue(lineThread);
     const principal: Principal = { type: "line", id: "U123" };
 
@@ -128,6 +131,20 @@ describe("requireThreadAccess", () => {
     );
 
     expect(res.status).toBe(200);
+  });
+
+  it("line principal + 平文 resourceId のスレッド → 404（ハッシュ化前提のため）", async () => {
+    const lineThread = { ...mockThread, resourceId: "line:U123" };
+    mockGetThreadById.mockResolvedValue(lineThread);
+    const principal: Principal = { type: "line", id: "U123" };
+
+    const res = await createApp().request(
+      makeRequest("thread-123", principal),
+      {},
+      mockEnv,
+    );
+
+    expect(res.status).toBe(404);
   });
 
   it("存在しない threadId → 404", async () => {

--- a/server/src/middleware/require-thread-access.ts
+++ b/server/src/middleware/require-thread-access.ts
@@ -2,7 +2,7 @@ import { Memory } from "@mastra/memory";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import type { PrincipalVariables } from "~/lib/principal";
-import { toResourceId } from "~/lib/principal";
+import { toLineResourceId, toResourceId } from "~/lib/principal";
 import { getStorage } from "~/lib/storage";
 
 export type ThreadVariables = {
@@ -38,7 +38,11 @@ export const requireThreadAccess = createMiddleware<{
     throw new HTTPException(404, { message: "スレッドが見つかりません" });
   }
 
-  if (thread.resourceId !== toResourceId(principal)) {
+  const expectedResourceId =
+    principal.type === "line"
+      ? await toLineResourceId(principal, c.env.RESOURCE_ID_HASH_SECRET)
+      : toResourceId(principal);
+  if (thread.resourceId !== expectedResourceId) {
     throw new HTTPException(404, { message: "スレッドが見つかりません" });
   }
 

--- a/server/src/services/broadcast-response.ts
+++ b/server/src/services/broadcast-response.ts
@@ -1,5 +1,5 @@
 import { logger } from "~/lib/logger";
-import { toResourceId } from "~/lib/principal";
+import { toLineResourceId, toLineThreadId } from "~/lib/principal";
 import {
   type BroadcastMessage,
   broadcastRepository,
@@ -56,8 +56,11 @@ export const generateBroadcastExplanation = async (
   replyToken: string,
 ) => {
   try {
-    const threadId = `line-thread:${userId}`;
-    const resourceId = toResourceId({ type: "line", id: userId });
+    const principal = { type: "line", id: userId } as const;
+    const [resourceId, threadId] = await Promise.all([
+      toLineResourceId(principal, env.RESOURCE_ID_HASH_SECRET),
+      toLineThreadId(principal, env.RESOURCE_ID_HASH_SECRET),
+    ]);
 
     const bodyText = extractBodyText(broadcast);
     const userMessage = `（おしらせ解説リクエスト）「${broadcast.title}」のおしらせについて、ねっぷちゃんの視点でやさしく解説して！
@@ -67,6 +70,7 @@ ${bodyText}`;
 
     const replyTexts = await generateReply({
       userMessage,
+      userId,
       resourceId,
       threadId,
       env,

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -16,6 +16,7 @@ export const createLineClient = (token: string) =>
 
 export const generateReply = async (params: {
   userMessage: string;
+  userId: string;
   resourceId: string;
   threadId: string;
   env: CloudflareBindings;
@@ -28,22 +29,20 @@ export const generateReply = async (params: {
     env: params.env,
   });
 
-  // 未注入の配信メッセージ／投票お知らせをスレッドに system として追加
-  const lineUserId = params.threadId.replace("line-thread:", "");
   await Promise.all([
     injectBroadcastsToThread({
       d1: params.env.DB,
       storage,
       threadId: params.threadId,
       resourceId: params.resourceId,
-      userId: lineUserId,
+      userId: params.userId,
     }),
     injectPollsToThread({
       d1: params.env.DB,
       storage,
       threadId: params.threadId,
       resourceId: params.resourceId,
-      userId: lineUserId,
+      userId: params.userId,
     }),
   ]);
 

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -1,6 +1,7 @@
 import { messagingApi } from "@line/bot-sdk";
 import { Mastra } from "@mastra/core/mastra";
 import { classifyIntent } from "~/lib/classify-intent";
+import { hmacSha256 } from "~/lib/crypto";
 import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { splitMessagesForLine } from "~/lib/split-message";
@@ -20,7 +21,7 @@ export const generateReply = async (params: {
   resourceId: string;
   threadId: string;
   env: CloudflareBindings;
-}): Promise<string[]> => {
+}) => {
   const storage = await getStorage(params.env.DB);
 
   const requestContext = createRequestContext({
@@ -29,20 +30,25 @@ export const generateReply = async (params: {
     env: params.env,
   });
 
+  const hashedUserId = await hmacSha256(
+    params.userId,
+    params.env.RESOURCE_ID_HASH_SECRET,
+  );
+
   await Promise.all([
     injectBroadcastsToThread({
       d1: params.env.DB,
       storage,
       threadId: params.threadId,
       resourceId: params.resourceId,
-      userId: params.userId,
+      userId: hashedUserId,
     }),
     injectPollsToThread({
       d1: params.env.DB,
       storage,
       threadId: params.threadId,
       resourceId: params.resourceId,
-      userId: params.userId,
+      userId: hashedUserId,
     }),
   ]);
 

--- a/server/src/services/poll-response.test.ts
+++ b/server/src/services/poll-response.test.ts
@@ -33,6 +33,7 @@ const env = {
   DB: {} as D1Database,
   LINE_CHANNEL_ACCESS_TOKEN: "token",
   WEB_URL: "https://web.example.com",
+  RESOURCE_ID_HASH_SECRET: "test-secret",
 } as unknown as CloudflareBindings;
 
 const dbRow = {

--- a/server/src/services/poll-response.test.ts
+++ b/server/src/services/poll-response.test.ts
@@ -128,12 +128,27 @@ describe("handlePollPostback", () => {
       env.DB,
       expect.objectContaining({
         pollId: "p-1",
-        userId: "U1",
+        userId: expect.stringMatching(/^[A-Za-z0-9_-]{43}$/),
         selectedChoice: "春",
       }),
     );
+    const savedUserId = vi.mocked(pollRepository.createSubmission).mock
+      .calls[0]?.[1].userId;
+    expect(savedUserId).not.toBe("U1");
     const reply = mockReplyMessage.mock.calls[0]?.[0];
     expect(reply.messages[0].type).toBe("flex");
+  });
+
+  it("findSubmission にはハッシュ化済み userId が渡される", async () => {
+    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
+    vi.mocked(pollRepository.findSubmission).mockResolvedValue(null);
+
+    await handlePollPostback(env, "U1", "poll=p-1&c=春", "rt");
+
+    const [, , passedUserId] = vi.mocked(pollRepository.findSubmission).mock
+      .calls[0]!;
+    expect(passedUserId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(passedUserId).not.toBe("U1");
   });
 
   it("URL エンコードされた選択肢もデコードして処理", async () => {

--- a/server/src/services/poll-response.ts
+++ b/server/src/services/poll-response.ts
@@ -1,5 +1,6 @@
 import type { messagingApi } from "@line/bot-sdk";
 
+import { hmacSha256 } from "~/lib/crypto";
 import { logger } from "~/lib/logger";
 import { toLineResourceId, toLineThreadId } from "~/lib/principal";
 import { type Poll, pollRepository } from "~/repository/poll-repository";
@@ -31,9 +32,11 @@ export const handlePollPostback = async (
   const { pollId, selectedChoice } = decodePollPostback(data);
   if (!pollId || !selectedChoice) return { status: "invalid" };
 
+  const hashedUserId = await hmacSha256(userId, env.RESOURCE_ID_HASH_SECRET);
+
   const [poll, existing] = await Promise.all([
     pollRepository.findById(env.DB, pollId),
-    pollRepository.findSubmission(env.DB, pollId, userId),
+    pollRepository.findSubmission(env.DB, pollId, hashedUserId),
   ]);
 
   if (!poll) return { status: "invalid" };
@@ -63,7 +66,7 @@ export const handlePollPostback = async (
   await pollRepository.createSubmission(env.DB, {
     id: crypto.randomUUID(),
     pollId,
-    userId,
+    userId: hashedUserId,
     selectedChoice,
     createdAt: now,
   });

--- a/server/src/services/poll-response.ts
+++ b/server/src/services/poll-response.ts
@@ -1,7 +1,7 @@
 import type { messagingApi } from "@line/bot-sdk";
 
 import { logger } from "~/lib/logger";
-import { toResourceId } from "~/lib/principal";
+import { toLineResourceId, toLineThreadId } from "~/lib/principal";
 import { type Poll, pollRepository } from "~/repository/poll-repository";
 import { createLineClient, generateReply } from "~/services/line-messaging";
 
@@ -139,13 +139,17 @@ export const generatePollFollowUp = async (
   selectedChoice: string,
 ) => {
   try {
-    const threadId = `line-thread:${userId}`;
-    const resourceId = toResourceId({ type: "line", id: userId });
+    const principal = { type: "line", id: userId } as const;
+    const [resourceId, threadId] = await Promise.all([
+      toLineResourceId(principal, env.RESOURCE_ID_HASH_SECRET),
+      toLineThreadId(principal, env.RESOURCE_ID_HASH_SECRET),
+    ]);
 
     const userMessage = `（投票）「${poll.title}」で「${selectedChoice}」を選んだよ。`;
 
     const replyTexts = await generateReply({
       userMessage,
+      userId,
       resourceId,
       threadId,
       env,


### PR DESCRIPTION
## Summary

- LINE 経由ユーザーの `resourceId` / `threadId` 生成を HMAC-SHA256 ベースに変更する
- 同一入力からは常に同じハッシュが得られるため、会話継続性は維持される
- メモリ上の `Principal.id` は LINE reply API 送信用に元の値を保持する（DB と分離）

Refs: #16

## 変更内容

### HMAC ユーティリティ追加
- `server/src/lib/crypto.ts` に `hmacSha256(value, secret): Promise<string>`（base64url 出力）を Web Crypto API ベースで追加

### Principal ハッシュ化 API
- `toLineResourceId(p, secret)` / `toLineThreadId(p, secret)` を新設（同じ HMAC を共有し `line:` / `line-thread:` プレフィックスを付ける）
- `toResourceId()` の `case \"line\"` は throw に変更（呼び出し側で新ヘルパの利用を強制）

### 呼び出し側修正
- `services/line-messaging.ts`: `generateReply()` に `userId` 引数を追加。旧実装の `threadId.replace(\"line-thread:\", \"\")` による逆抽出を廃止
- `handlers/line-event-handler.ts` / `services/poll-response.ts` / `services/broadcast-response.ts`: LINE 経由 3 箇所で `toLineResourceId` / `toLineThreadId` を使うように差し替え
- `middleware/require-thread-access.ts`: LINE principal の場合はハッシュ化値で比較する分岐を追加

### 環境変数
- `RESOURCE_ID_HASH_SECRET` を `env.d.ts` / `.dev.vars.example` に追加
- dev / prd の Cloudflare Secret は登録済み

## デプロイ前の確認事項

- [x] dev / prd の `wrangler secret put RESOURCE_ID_HASH_SECRET` は登録済み
- [ ] ローカル `.dev.vars` に `RESOURCE_ID_HASH_SECRET` を追記（各開発者で実施）

## Test plan

- [x] `pnpm --filter @nepp-chan/server test`: 660/660 通過
- [x] `pnpm lint`: error 0（biome + tsc + web/lp check）
- [x] codex review: 修正必須の指摘なし
- [ ] dev デプロイ後の動作確認（LINE webhook → 応答 → DB の `mastra_threads.id` / `resourceId` がハッシュ化されている）
- [ ] dev で同じ LINE ユーザーが連続して話したとき、会話継続性が機能している
- [ ] dev で投票・配信解説の Postback フローもハッシュ化されたスレッドに正しく書き込まれる