### PR TITLE
fix(server): Workers Logs に LINE 生 userId を出さないようにする

### DIFF
--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -17,13 +17,15 @@ export const handleLineEvent = async (
 
   for (const message of batch.messages) {
     const { userId, userMessage, replyToken } = message.body;
+    let threadId: string | undefined;
 
     try {
       const principal: LinePrincipal = { type: "line", id: userId };
-      const [resourceId, threadId] = await Promise.all([
+      const [resourceId, hashedThreadId] = await Promise.all([
         toLineResourceId(principal, secret),
         toLineThreadId(principal, secret),
       ]);
+      threadId = hashedThreadId;
       const replyTexts = await generateReply({
         userMessage,
         userId,
@@ -37,13 +39,18 @@ export const handleLineEvent = async (
           client,
           replyToken,
           userId,
+          threadId,
           texts: replyTexts,
         });
       }
 
       message.ack();
     } catch (error) {
-      logger.error(`LINE reply failed for user ${userId}`, error);
+      logger.error(
+        "LINE reply failed",
+        error,
+        threadId ? { threadId } : undefined,
+      );
       message.retry();
     }
   }

--- a/server/src/services/broadcast-response.ts
+++ b/server/src/services/broadcast-response.ts
@@ -83,6 +83,7 @@ ${bodyText}`;
       client,
       replyToken,
       userId,
+      threadId,
       texts: replyTexts,
     });
   } catch (error) {

--- a/server/src/services/line-messaging.test.ts
+++ b/server/src/services/line-messaging.test.ts
@@ -15,6 +15,7 @@ describe("sendLineMessages", () => {
     client,
     replyToken: "token-123",
     userId: "user-456",
+    threadId: "line-thread-hash-abc",
     texts: ["こんにちは", "元気？"],
   };
 

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -99,6 +99,7 @@ export const sendLineMessages = async (params: {
   client: messagingApi.MessagingApiClient;
   replyToken: string;
   userId: string;
+  threadId: string;
   texts: string[];
 }) => {
   const messages = params.texts.map((text) => ({
@@ -111,12 +112,12 @@ export const sendLineMessages = async (params: {
       replyToken: params.replyToken,
       messages,
     });
-    logger.info(`LINE replyMessage sent to ${params.userId}`);
+    logger.info("[LINE] replyMessage sent", { threadId: params.threadId });
   } catch {
-    logger.warn(
-      `LINE replyMessage failed for ${params.userId}, falling back to pushMessage`,
-    );
+    logger.warn("[LINE] replyMessage failed, falling back to pushMessage", {
+      threadId: params.threadId,
+    });
     await params.client.pushMessage({ to: params.userId, messages });
-    logger.info(`LINE pushMessage sent to ${params.userId}`);
+    logger.info("[LINE] pushMessage sent", { threadId: params.threadId });
   }
 };


### PR DESCRIPTION
## Summary
- Workers Logs に流れていた生 LINE userId を取り除き、ハッシュ化済み threadId に置き換え

### 変更点
- `server/src/services/line-messaging.ts`
  - `sendLineMessages` 関数の引数に `threadId: string` を追加
  - 3 箇所のログ出力 (`replyMessage sent` / `replyMessage failed` / `pushMessage sent`) を `\${params.userId}` → `{ threadId }` attrs に置換
  - `userId` は LINE API (`pushMessage`) への引数として保持
- `server/src/handlers/line-event-handler.ts`
  - `sendLineMessages` 呼び出しに `threadId` を渡す
  - catch のログから生 userId を削除、ハッシュ化済み `threadId` を attrs に格納
- `server/src/services/broadcast-response.ts`
  - `sendLineMessages` 呼び出しに `threadId` を渡す
- `server/src/services/line-messaging.test.ts`
  - テスト fixture に `threadId` を追加

### 残課題
\`logger.error(..., error)\` の第2引数 (`error`) が PII を巻き込む可能性は別途レビュー予定

## Test plan
- [x] \`pnpm test --run\` で server の全テスト 661/661 passed
- [x] \`pnpm lint\` でエラー 0
- [x] \`codex review --uncommitted\` で指摘なし
- [ ] dev デプロイ後、LINE webhook を 1 回踏んで Workers Logs の出力を目視確認（生 userId が出ないこと / threadId が hash 値であること）