### PR TITLE
feat(server): LINE unfollow → 全関連データ削除パイプラインを実装する (#20)

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -45,6 +45,10 @@ export const mastraMessages = sqliteTable("mastra_messages", {
   threadId: text("thread_id").notNull(),
 });
 
+export const mastraResources = sqliteTable("mastra_resources", {
+  id: text("id").primaryKey(),
+});
+
 // 型エクスポート
 export type EmergencyReport = typeof emergencyReports.$inferSelect;
 export type NewEmergencyReport = typeof emergencyReports.$inferInsert;

--- a/server/src/handlers/line-event-handler.test.ts
+++ b/server/src/handlers/line-event-handler.test.ts
@@ -11,6 +11,14 @@ vi.mock("~/services/line-messaging", () => ({
   sendLineMessages: mockSendLineMessages,
 }));
 
+const { mockDeleteAllByLineUserId } = vi.hoisted(() => ({
+  mockDeleteAllByLineUserId: vi.fn(),
+}));
+
+vi.mock("~/services/user-deletion", () => ({
+  deleteAllByLineUserId: mockDeleteAllByLineUserId,
+}));
+
 const { handleLineEvent } = await import("./line-event-handler");
 
 const env = {
@@ -20,10 +28,18 @@ const env = {
 
 const buildMessage = (body: {
   userId: string;
-  userMessage: string;
-  replyToken: string;
+  userMessage?: string;
+  replyToken?: string;
+  type?: "message" | "unfollow";
 }) => ({
-  body,
+  body: {
+    type: body.type ?? "message",
+    userId: body.userId,
+    ...(body.userMessage !== undefined
+      ? { userMessage: body.userMessage }
+      : {}),
+    ...(body.replyToken !== undefined ? { replyToken: body.replyToken } : {}),
+  },
   ack: vi.fn(),
   retry: vi.fn(),
   id: "m-1",
@@ -96,6 +112,31 @@ describe("handleLineEvent", () => {
       userMessage: "x",
       replyToken: "rt",
     });
+
+    await handleLineEvent(buildBatch([msg]), env);
+
+    expect(msg.ack).not.toHaveBeenCalled();
+    expect(msg.retry).toHaveBeenCalled();
+  });
+
+  it("unfollow は deleteAllByLineUserId を呼んで ack（generateReply は呼ばない）", async () => {
+    mockDeleteAllByLineUserId.mockResolvedValue(undefined);
+
+    const msg = buildMessage({ userId: "U-bye", type: "unfollow" });
+
+    await handleLineEvent(buildBatch([msg]), env);
+
+    expect(mockDeleteAllByLineUserId).toHaveBeenCalledWith(env, "U-bye");
+    expect(mockGenerateReply).not.toHaveBeenCalled();
+    expect(mockSendLineMessages).not.toHaveBeenCalled();
+    expect(msg.ack).toHaveBeenCalled();
+    expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  it("unfollow の削除が失敗したら retry", async () => {
+    mockDeleteAllByLineUserId.mockRejectedValue(new Error("DB down"));
+
+    const msg = buildMessage({ userId: "U-bye", type: "unfollow" });
 
     await handleLineEvent(buildBatch([msg]), env);
 

--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -7,6 +7,7 @@ import {
   generateReply,
   sendLineMessages,
 } from "~/services/line-messaging";
+import { deleteAllByLineUserId } from "~/services/user-deletion";
 
 export const handleLineEvent = async (
   batch: MessageBatch<LineEventMessage>,
@@ -16,10 +17,22 @@ export const handleLineEvent = async (
   const secret = env.RESOURCE_ID_HASH_SECRET;
 
   for (const message of batch.messages) {
-    const { userId, userMessage, replyToken } = message.body;
-    let threadId: string | undefined;
+    const body = message.body;
 
+    if (body.type === "unfollow") {
+      try {
+        await deleteAllByLineUserId(env, body.userId);
+        message.ack();
+      } catch (error) {
+        logger.error("LINE unfollow deletion failed", error);
+        message.retry();
+      }
+      continue;
+    }
+
+    let threadId: string | undefined;
     try {
+      const { userId, userMessage, replyToken } = body;
       const principal: LinePrincipal = { type: "line", id: userId };
       const [resourceId, hashedThreadId] = await Promise.all([
         toLineResourceId(principal, secret),

--- a/server/src/routes/line.test.ts
+++ b/server/src/routes/line.test.ts
@@ -121,10 +121,35 @@ describe("lineRoutes: POST /webhook", () => {
 
       expect(res.status).toBe(200);
       expect(queueSend).toHaveBeenCalledWith({
+        type: "message",
         userId: "U123",
         userMessage: "こんにちは",
         replyToken: "reply-1",
       });
+    });
+
+    it("unfollow event は { type: 'unfollow', userId } を LINE_QUEUE に送る", async () => {
+      const unfollowEvent = {
+        type: "unfollow",
+        timestamp: 0,
+        source: { userId: "U999", type: "user" },
+      };
+
+      const res = await sendWebhook([unfollowEvent]);
+
+      expect(res.status).toBe(200);
+      expect(queueSend).toHaveBeenCalledWith({
+        type: "unfollow",
+        userId: "U999",
+      });
+    });
+
+    it("unfollow event に userId が無ければスキップ", async () => {
+      await sendWebhook([
+        { type: "unfollow", timestamp: 0, source: { type: "user" } },
+      ]);
+
+      expect(queueSend).not.toHaveBeenCalled();
     });
 
     it("非テキスト message はキューに送らない", async () => {

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -97,11 +97,22 @@ const enqueueLineEvents = async (
       continue;
     }
 
+    if (event.type === "unfollow") {
+      if (!event.source.userId) continue;
+      const unfollow: LineEventMessage = {
+        type: "unfollow",
+        userId: event.source.userId,
+      };
+      await env.LINE_QUEUE.send(unfollow);
+      continue;
+    }
+
     if (event.type !== "message" || event.message.type !== "text") continue;
     if (!("replyToken" in event) || !event.replyToken) continue;
     if (!event.source.userId) continue;
 
     const message: LineEventMessage = {
+      type: "message",
       userId: event.source.userId,
       userMessage: event.message.text,
       replyToken: event.replyToken,

--- a/server/src/schemas/line-schema.ts
+++ b/server/src/schemas/line-schema.ts
@@ -1,12 +1,14 @@
+import type { MessageEvent, UnfollowEvent } from "@line/bot-sdk";
+
 export type LineMessageEvent = {
-  type: "message";
+  type: MessageEvent["type"];
   userId: string;
   userMessage: string;
   replyToken: string;
 };
 
 export type LineUnfollowEvent = {
-  type: "unfollow";
+  type: UnfollowEvent["type"];
   userId: string;
 };
 

--- a/server/src/schemas/line-schema.ts
+++ b/server/src/schemas/line-schema.ts
@@ -1,5 +1,13 @@
-export type LineEventMessage = {
+export type LineMessageEvent = {
+  type: "message";
   userId: string;
   userMessage: string;
   replyToken: string;
 };
+
+export type LineUnfollowEvent = {
+  type: "unfollow";
+  userId: string;
+};
+
+export type LineEventMessage = LineMessageEvent | LineUnfollowEvent;

--- a/server/src/services/user-deletion.test.ts
+++ b/server/src/services/user-deletion.test.ts
@@ -1,0 +1,332 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  mastraMessages,
+  mastraResources,
+  mastraThreads,
+  messageFeedback,
+  persona,
+  pollSubmissions,
+  polls,
+  threadPersonaStatus,
+  userBroadcastState,
+  userPollState,
+} from "~/db";
+import { hmacSha256 } from "~/lib/crypto";
+import { createTestDb, type TestDb } from "../test-helpers/test-db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+vi.mock("~/lib/logger", () => ({
+  logger: loggerMock,
+}));
+
+vi.mock("~/lib/storage", () => ({
+  getStorage: vi.fn().mockResolvedValue({}),
+}));
+
+const { deleteAllByLineUserId } = await import("./user-deletion");
+
+const SECRET = "test-secret";
+const TARGET_USER_ID = "U-target";
+const OTHER_USER_ID = "U-other";
+
+const env = {
+  DB: {} as D1Database,
+  RESOURCE_ID_HASH_SECRET: SECRET,
+} as unknown as CloudflareBindings;
+
+const insertFixtures = async (
+  db: TestDb,
+  hashedTarget: string,
+  hashedOther: string,
+) => {
+  const targetThreadId = `line-thread:${hashedTarget}`;
+  const otherThreadId = `line-thread:${hashedOther}`;
+  const targetResourceId = `line:${hashedTarget}`;
+  const otherResourceId = `line:${hashedOther}`;
+
+  await db.insert(mastraThreads).values([
+    { id: targetThreadId, resourceId: targetResourceId },
+    { id: otherThreadId, resourceId: otherResourceId },
+  ]);
+  await db.insert(mastraMessages).values([
+    { id: "m1", threadId: targetThreadId },
+    { id: "m2", threadId: targetThreadId },
+    { id: "m3", threadId: otherThreadId },
+  ]);
+  await db
+    .insert(mastraResources)
+    .values([{ id: targetResourceId }, { id: otherResourceId }]);
+  await db.insert(threadPersonaStatus).values([
+    {
+      threadId: targetThreadId,
+      lastExtractedAt: "2025-01-01T00:00:00Z",
+      lastMessageCount: 2,
+    },
+    {
+      threadId: otherThreadId,
+      lastExtractedAt: "2025-01-01T00:00:00Z",
+      lastMessageCount: 5,
+    },
+  ]);
+  await db.insert(messageFeedback).values([
+    {
+      id: "f1",
+      threadId: targetThreadId,
+      messageId: "m1",
+      rating: "good",
+      conversationContext: "[]",
+      createdAt: "2025-01-01T00:00:00Z",
+    },
+    {
+      id: "f2",
+      threadId: otherThreadId,
+      messageId: "m3",
+      rating: "bad",
+      conversationContext: "[]",
+      createdAt: "2025-01-01T00:00:00Z",
+    },
+  ]);
+  await db.insert(polls).values({
+    id: "p1",
+    title: "t",
+    choices: '["a","b"]',
+    createdBy: "admin",
+    createdAt: "2025-01-01T00:00:00Z",
+  });
+  await db.insert(pollSubmissions).values([
+    {
+      id: "ps1",
+      pollId: "p1",
+      userId: hashedTarget,
+      selectedChoice: "a",
+      createdAt: "2025-01-01T00:00:00Z",
+    },
+    {
+      id: "ps2",
+      pollId: "p1",
+      userId: hashedOther,
+      selectedChoice: "b",
+      createdAt: "2025-01-01T00:00:00Z",
+    },
+  ]);
+  await db.insert(userBroadcastState).values([
+    { userId: hashedTarget, lastInjectedAt: "2025-01-01T00:00:00Z" },
+    { userId: hashedOther, lastInjectedAt: "2025-01-01T00:00:00Z" },
+  ]);
+  await db.insert(userPollState).values([
+    { userId: hashedTarget, lastInjectedAt: "2025-01-01T00:00:00Z" },
+    { userId: hashedOther, lastInjectedAt: "2025-01-01T00:00:00Z" },
+  ]);
+  // persona は削除対象外（個人データ非該当）
+  await db.insert(persona).values({
+    id: "pe1",
+    resourceId: targetResourceId,
+    category: "cat",
+    content: "c",
+    createdAt: "2025-01-01T00:00:00Z",
+  });
+};
+
+describe("deleteAllByLineUserId", () => {
+  let hashedTarget: string;
+  let hashedOther: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    testDbHolder.db = await createTestDb();
+    hashedTarget = await hmacSha256(TARGET_USER_ID, SECRET);
+    hashedOther = await hmacSha256(OTHER_USER_ID, SECRET);
+    await insertFixtures(testDbHolder.db, hashedTarget, hashedOther);
+  });
+
+  it("対象ユーザーの全関連レコードを削除する（thread / message / resource / persona_status / feedback / poll_submission / state 系）", async () => {
+    await deleteAllByLineUserId(env, TARGET_USER_ID);
+
+    const db = testDbHolder.db as TestDb;
+    const targetThreadId = `line-thread:${hashedTarget}`;
+    const targetResourceId = `line:${hashedTarget}`;
+
+    expect(
+      await db
+        .select()
+        .from(mastraThreads)
+        .where(eq(mastraThreads.id, targetThreadId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(mastraMessages)
+        .where(eq(mastraMessages.threadId, targetThreadId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(mastraResources)
+        .where(eq(mastraResources.id, targetResourceId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(threadPersonaStatus)
+        .where(eq(threadPersonaStatus.threadId, targetThreadId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(messageFeedback)
+        .where(eq(messageFeedback.threadId, targetThreadId)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(pollSubmissions)
+        .where(eq(pollSubmissions.userId, hashedTarget)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(userBroadcastState)
+        .where(eq(userBroadcastState.userId, hashedTarget)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(userPollState)
+        .where(eq(userPollState.userId, hashedTarget)),
+    ).toHaveLength(0);
+  });
+
+  it("他ユーザーのレコードは残る", async () => {
+    await deleteAllByLineUserId(env, TARGET_USER_ID);
+
+    const db = testDbHolder.db as TestDb;
+    const otherThreadId = `line-thread:${hashedOther}`;
+    const otherResourceId = `line:${hashedOther}`;
+
+    expect(await db.select().from(mastraThreads)).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(mastraThreads)
+        .where(eq(mastraThreads.id, otherThreadId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(mastraMessages)
+        .where(eq(mastraMessages.threadId, otherThreadId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(mastraResources)
+        .where(eq(mastraResources.id, otherResourceId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(threadPersonaStatus)
+        .where(eq(threadPersonaStatus.threadId, otherThreadId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(messageFeedback)
+        .where(eq(messageFeedback.threadId, otherThreadId)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(pollSubmissions)
+        .where(eq(pollSubmissions.userId, hashedOther)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(userBroadcastState)
+        .where(eq(userBroadcastState.userId, hashedOther)),
+    ).toHaveLength(1);
+    expect(
+      await db
+        .select()
+        .from(userPollState)
+        .where(eq(userPollState.userId, hashedOther)),
+    ).toHaveLength(1);
+  });
+
+  it("persona テーブルは削除されない（個人データ非該当）", async () => {
+    await deleteAllByLineUserId(env, TARGET_USER_ID);
+
+    const db = testDbHolder.db as TestDb;
+    expect(await db.select().from(persona)).toHaveLength(1);
+  });
+
+  it("成功時に user_data_deleted イベントを件数つきでログ出力し、userId 平文を含まない", async () => {
+    await deleteAllByLineUserId(env, TARGET_USER_ID);
+
+    const infoCalls = loggerMock.info.mock.calls;
+    const deletedCall = infoCalls.find((c) =>
+      JSON.stringify(c).includes("user_data_deleted"),
+    );
+    expect(
+      deletedCall,
+      "user_data_deleted ログが出力されていない",
+    ).toBeDefined();
+
+    expect(JSON.stringify(deletedCall)).not.toContain(TARGET_USER_ID);
+
+    const payload = deletedCall?.[1] as Record<string, unknown> | undefined;
+    expect(payload).toEqual(
+      expect.objectContaining({
+        event: "user_data_deleted",
+        mastra_threads_deleted: 1,
+        mastra_messages_deleted: 2,
+        mastra_resources_deleted: 1,
+        thread_persona_status_deleted: 1,
+        message_feedback_deleted: 1,
+        poll_submissions_deleted: 1,
+        user_broadcast_state_deleted: 1,
+        user_poll_state_deleted: 1,
+      }),
+    );
+  });
+
+  it("DB エラー時は logger.error を呼んで throw する", async () => {
+    const brokenDb = {
+      select: () => {
+        throw new Error("DB down");
+      },
+    };
+    testDbHolder.db = brokenDb as unknown as TestDb;
+
+    await expect(deleteAllByLineUserId(env, TARGET_USER_ID)).rejects.toThrow(
+      "DB down",
+    );
+    expect(loggerMock.error).toHaveBeenCalled();
+    expect(JSON.stringify(loggerMock.error.mock.calls)).not.toContain(
+      TARGET_USER_ID,
+    );
+  });
+});

--- a/server/src/services/user-deletion.ts
+++ b/server/src/services/user-deletion.ts
@@ -1,0 +1,105 @@
+import type { SQL } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+
+import {
+  createDb,
+  type DbClient,
+  mastraMessages,
+  mastraResources,
+  mastraThreads,
+  messageFeedback,
+  pollSubmissions,
+  threadPersonaStatus,
+  userBroadcastState,
+  userPollState,
+} from "~/db";
+import { hmacSha256 } from "~/lib/crypto";
+import { logger } from "~/lib/logger";
+import { getStorage } from "~/lib/storage";
+
+const countAndDelete = async (db: DbClient, table: SQLiteTable, where: SQL) => {
+  const row = await db
+    .select({ c: sql<number>`COUNT(*)` })
+    .from(table)
+    .where(where)
+    .get();
+  await db.delete(table).where(where);
+  return Number(row?.c ?? 0);
+};
+
+export const deleteAllByLineUserId = async (
+  env: CloudflareBindings,
+  userId: string,
+) => {
+  const hashedUserId = await hmacSha256(userId, env.RESOURCE_ID_HASH_SECRET);
+  const lineThreadId = `line-thread:${hashedUserId}`;
+  const lineResourceId = `line:${hashedUserId}`;
+
+  const db = createDb(env.DB);
+
+  try {
+    // Mastra テーブルは drizzle の migration 対象外（tablesFilter で除外）。
+    // 未初期化の D1 に対して unfollow が最初に届くと "no such table" になるため、
+    // D1Store.init() を経由してテーブルの存在を保証する。
+    await getStorage(env.DB);
+
+    const mastraMessagesDeleted = await countAndDelete(
+      db,
+      mastraMessages,
+      eq(mastraMessages.threadId, lineThreadId),
+    );
+    const messageFeedbackDeleted = await countAndDelete(
+      db,
+      messageFeedback,
+      eq(messageFeedback.threadId, lineThreadId),
+    );
+    const threadPersonaStatusDeleted = await countAndDelete(
+      db,
+      threadPersonaStatus,
+      eq(threadPersonaStatus.threadId, lineThreadId),
+    );
+    const mastraThreadsDeleted = await countAndDelete(
+      db,
+      mastraThreads,
+      eq(mastraThreads.id, lineThreadId),
+    );
+    const mastraResourcesDeleted = await countAndDelete(
+      db,
+      mastraResources,
+      eq(mastraResources.id, lineResourceId),
+    );
+    const pollSubmissionsDeleted = await countAndDelete(
+      db,
+      pollSubmissions,
+      eq(pollSubmissions.userId, hashedUserId),
+    );
+    const userBroadcastStateDeleted = await countAndDelete(
+      db,
+      userBroadcastState,
+      eq(userBroadcastState.userId, hashedUserId),
+    );
+    const userPollStateDeleted = await countAndDelete(
+      db,
+      userPollState,
+      eq(userPollState.userId, hashedUserId),
+    );
+
+    logger.info("user_data_deleted", {
+      event: "user_data_deleted",
+      mastra_threads_deleted: mastraThreadsDeleted,
+      mastra_messages_deleted: mastraMessagesDeleted,
+      mastra_resources_deleted: mastraResourcesDeleted,
+      thread_persona_status_deleted: threadPersonaStatusDeleted,
+      message_feedback_deleted: messageFeedbackDeleted,
+      poll_submissions_deleted: pollSubmissionsDeleted,
+      user_broadcast_state_deleted: userBroadcastStateDeleted,
+      user_poll_state_deleted: userPollStateDeleted,
+    });
+  } catch (error) {
+    logger.error("user_data_deletion_failed", error, {
+      event: "user_data_deletion_failed",
+    });
+    throw error;
+  }
+};

--- a/server/src/test-helpers/test-db.ts
+++ b/server/src/test-helpers/test-db.ts
@@ -138,6 +138,21 @@ export const createTestDb = async () => {
       user_id TEXT PRIMARY KEY,
       last_injected_at TEXT NOT NULL
     );
+
+    -- Mastra 管理テーブル（read-only スキーマ。テストのフィクスチャ生成用に最低限のカラムを定義）
+    CREATE TABLE IF NOT EXISTS mastra_threads (
+      id TEXT PRIMARY KEY,
+      resourceId TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS mastra_messages (
+      id TEXT PRIMARY KEY,
+      thread_id TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS mastra_resources (
+      id TEXT PRIMARY KEY
+    );
   `);
 
   return drizzle(client, { schema });


### PR DESCRIPTION
## Summary
- LINE Webhook の `unfollow` イベントを `LINE_QUEUE` 経由で非同期処理する
- `services/user-deletion.ts` を新設し、当該 LINE ユーザーの全関連データを 8 テーブルから削除する
- 削除実行ログには件数のみを記録し、生 userId は出力しない

## 主な変更内容

### `services/user-deletion.ts`（新規）

`deleteAllByLineUserId(env, userId)` を実装。HMAC-SHA256 でハッシュ化した threadId / resourceId をキーに以下 8 テーブルからレコードを削除する：

- `mastra_threads` / `mastra_messages` / `mastra_resources`（working memory）
- `thread_persona_status` / `message_feedback`
- `poll_submissions` / `user_broadcast_state` / `user_poll_state`

`persona` テーブルは個人データ非該当のため対象外（#23 確定方針）。Mastra テーブルは migration 対象外で未初期化 D1 では `no such table` になるため、削除前に `getStorage(env.DB)` で `D1Store.init()` を経由させる。

### `LineEventMessage` の判別ユニオン化

`{ type: "message" } | { type: "unfollow" }` のユニオンに変更。`type` リテラルは `@line/bot-sdk` の `MessageEvent["type"]` / `UnfollowEvent["type"]` から derive することで、SDK 側の型変更に追従可能にした。

### `routes/line.ts` + `handlers/line-event-handler.ts`

- `enqueueLineEvents` に `unfollow` 分岐を追加し、`{ type: "unfollow", userId }` を `LINE_QUEUE` に投入
- `handleLineEvent` で type 分岐し、`unfollow` 時は `deleteAllByLineUserId` を呼んで ack、失敗時は retry

### スキーマ整備

- `db/schema.ts` に `mastraResources` を read-only スキーマで追加
- `test-helpers/test-db.ts` に `mastra_threads` / `mastra_messages` / `mastra_resources` の DDL を追加

## 受入基準の対応

| 受入基準 | 対応 |
|---|---|
| unfollow 受信から数分以内に削除 | Queue + 同期削除（Queue の遅延は通常秒オーダー） |
| `persona` 非削除 | 削除対象から除外、テストで明示検証 |
| `mastra_resources`（working memory）削除 | `id = line:<hashed>` で DELETE、テストで検証 |
| 失敗時 Workers Logs 検知 | `logger.error` + `message.retry()` |
| 監査ログに userId 平文なし | counts のみ出力、テストで検証 |

## 設計判断：取り込まなかった指摘

`codex review --uncommitted` で P1 指摘あり：

> unfollow 削除メッセージに発生時刻情報がないため、Queue retry 中に同ユーザーが再フォローして会話再開すると、遅れて実行された削除処理が新規 thread/state まで消す可能性

以下の理由で本 PR では取り込まず、継続検討としました：

1. **現実的リスクが低い**: Cloudflare Queue の retry は通常数分以内に完結。その間に再フォロー＋会話再開する確率は極めて低い
2. **対策コストが大きい**: 完全対応には Mastra 内部テーブルの timestamp 構造に依存した条件付き削除が必要で PR スコープを大きく超える
3. **issue #20 が Queue+retry 前提**: 「24h SLA のため Queue を推奨」と明示されている

再フォロー時は「履歴クリア状態で新規会話を開始」となり、削除義務観点では問題なし。

## Test plan

- [x] `pnpm test` で全 670 件 + 新規 5 件 = 675 件パス
- [x] `pnpm exec tsc --noEmit` クリーン
- [x] `pnpm biome check` 変更ファイル全てクリーン
- [ ] dev 環境にデプロイ後、テスト用 LINE アカウントで unfollow → 関連テーブルが消えることを確認
- [ ] 削除実行時に Workers Logs に件数のみが出力され、生 userId が出ないことを確認