### PR TITLE
refactor(server): LINE userId の HMAC 計算を 1 回にまとめる toLineIds を新設する

### DIFF
--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -1,6 +1,6 @@
 import { logger } from "~/lib/logger";
 import type { LinePrincipal } from "~/lib/principal";
-import { toLineResourceId, toLineThreadId } from "~/lib/principal";
+import { toLineIds } from "~/lib/principal";
 import type { LineEventMessage } from "~/schemas/line-schema";
 import {
   createLineClient,
@@ -34,14 +34,16 @@ export const handleLineEvent = async (
     try {
       const { userId, userMessage, replyToken } = body;
       const principal: LinePrincipal = { type: "line", id: userId };
-      const [resourceId, hashedThreadId] = await Promise.all([
-        toLineResourceId(principal, secret),
-        toLineThreadId(principal, secret),
-      ]);
-      threadId = hashedThreadId;
+      const {
+        hashedUserId,
+        resourceId,
+        threadId: t,
+      } = await toLineIds(principal, secret);
+      threadId = t;
       const replyTexts = await generateReply({
         userMessage,
         userId,
+        hashedUserId,
         resourceId,
         threadId,
         env,

--- a/server/src/lib/principal.test.ts
+++ b/server/src/lib/principal.test.ts
@@ -5,6 +5,7 @@ import {
   type AnonymousPrincipal,
   type LinePrincipal,
   requireAdminUser,
+  toLineIds,
   toLineResourceId,
   toLineThreadId,
   toResourceId,
@@ -91,6 +92,34 @@ describe("toLineThreadId", () => {
       SECRET,
     );
     expect(out).not.toContain("U1234567890");
+  });
+});
+
+describe("toLineIds", () => {
+  it("resourceId / threadId / hashedUserId をまとめて返す", async () => {
+    const p: LinePrincipal = { type: "line", id: "U1234567890" };
+    const ids = await toLineIds(p, SECRET);
+    expect(ids.hashedUserId).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(ids.resourceId).toBe(`line:${ids.hashedUserId}`);
+    expect(ids.threadId).toBe(`line-thread:${ids.hashedUserId}`);
+  });
+
+  it("toLineResourceId / toLineThreadId と同じ値を返す（互換性）", async () => {
+    const p: LinePrincipal = { type: "line", id: "U1234567890" };
+    const [ids, resourceId, threadId] = await Promise.all([
+      toLineIds(p, SECRET),
+      toLineResourceId(p, SECRET),
+      toLineThreadId(p, SECRET),
+    ]);
+    expect(ids.resourceId).toBe(resourceId);
+    expect(ids.threadId).toBe(threadId);
+  });
+
+  it("出力に平文 userId を含まない", async () => {
+    const ids = await toLineIds({ type: "line", id: "U1234567890" }, SECRET);
+    expect(ids.hashedUserId).not.toContain("U1234567890");
+    expect(ids.resourceId).not.toContain("U1234567890");
+    expect(ids.threadId).not.toContain("U1234567890");
   });
 });
 

--- a/server/src/lib/principal.ts
+++ b/server/src/lib/principal.ts
@@ -33,6 +33,17 @@ export const toLineResourceId = async (p: LinePrincipal, secret: string) =>
 export const toLineThreadId = async (p: LinePrincipal, secret: string) =>
   `line-thread:${await hmacSha256(p.id, secret)}`;
 
+// 1 回の HMAC 計算で resourceId / threadId / hashedUserId をまとめて生成する。
+// 同じ LINE userId から複数の派生 ID が必要な呼び出し側で利用する。
+export const toLineIds = async (p: LinePrincipal, secret: string) => {
+  const hashedUserId = await hmacSha256(p.id, secret);
+  return {
+    hashedUserId,
+    resourceId: `line:${hashedUserId}`,
+    threadId: `line-thread:${hashedUserId}`,
+  };
+};
+
 export const requireAdminUser = (
   principal: Principal | undefined,
 ): AuthUser => {

--- a/server/src/services/broadcast-response.ts
+++ b/server/src/services/broadcast-response.ts
@@ -1,5 +1,5 @@
 import { logger } from "~/lib/logger";
-import { toLineResourceId, toLineThreadId } from "~/lib/principal";
+import { toLineIds } from "~/lib/principal";
 import {
   type BroadcastMessage,
   broadcastRepository,
@@ -57,10 +57,10 @@ export const generateBroadcastExplanation = async (
 ) => {
   try {
     const principal = { type: "line", id: userId } as const;
-    const [resourceId, threadId] = await Promise.all([
-      toLineResourceId(principal, env.RESOURCE_ID_HASH_SECRET),
-      toLineThreadId(principal, env.RESOURCE_ID_HASH_SECRET),
-    ]);
+    const { hashedUserId, resourceId, threadId } = await toLineIds(
+      principal,
+      env.RESOURCE_ID_HASH_SECRET,
+    );
 
     const bodyText = extractBodyText(broadcast);
     const userMessage = `（おしらせ解説リクエスト）「${broadcast.title}」のおしらせについて、ねっぷちゃんの視点でやさしく解説して！
@@ -71,6 +71,7 @@ ${bodyText}`;
     const replyTexts = await generateReply({
       userMessage,
       userId,
+      hashedUserId,
       resourceId,
       threadId,
       env,

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -1,7 +1,6 @@
 import { messagingApi } from "@line/bot-sdk";
 import { Mastra } from "@mastra/core/mastra";
 import { classifyIntent } from "~/lib/classify-intent";
-import { hmacSha256 } from "~/lib/crypto";
 import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { splitMessagesForLine } from "~/lib/split-message";
@@ -18,6 +17,7 @@ export const createLineClient = (token: string) =>
 export const generateReply = async (params: {
   userMessage: string;
   userId: string;
+  hashedUserId: string;
   resourceId: string;
   threadId: string;
   env: CloudflareBindings;
@@ -30,25 +30,20 @@ export const generateReply = async (params: {
     env: params.env,
   });
 
-  const hashedUserId = await hmacSha256(
-    params.userId,
-    params.env.RESOURCE_ID_HASH_SECRET,
-  );
-
   await Promise.all([
     injectBroadcastsToThread({
       d1: params.env.DB,
       storage,
       threadId: params.threadId,
       resourceId: params.resourceId,
-      userId: hashedUserId,
+      userId: params.hashedUserId,
     }),
     injectPollsToThread({
       d1: params.env.DB,
       storage,
       threadId: params.threadId,
       resourceId: params.resourceId,
-      userId: hashedUserId,
+      userId: params.hashedUserId,
     }),
   ]);
 

--- a/server/src/services/poll-response.ts
+++ b/server/src/services/poll-response.ts
@@ -1,8 +1,7 @@
 import type { messagingApi } from "@line/bot-sdk";
 
-import { hmacSha256 } from "~/lib/crypto";
 import { logger } from "~/lib/logger";
-import { toLineResourceId, toLineThreadId } from "~/lib/principal";
+import { toLineIds } from "~/lib/principal";
 import { type Poll, pollRepository } from "~/repository/poll-repository";
 import { createLineClient, generateReply } from "~/services/line-messaging";
 
@@ -32,7 +31,11 @@ export const handlePollPostback = async (
   const { pollId, selectedChoice } = decodePollPostback(data);
   if (!pollId || !selectedChoice) return { status: "invalid" };
 
-  const hashedUserId = await hmacSha256(userId, env.RESOURCE_ID_HASH_SECRET);
+  const principal = { type: "line", id: userId } as const;
+  const { hashedUserId } = await toLineIds(
+    principal,
+    env.RESOURCE_ID_HASH_SECRET,
+  );
 
   const [poll, existing] = await Promise.all([
     pollRepository.findById(env.DB, pollId),
@@ -143,16 +146,17 @@ export const generatePollFollowUp = async (
 ) => {
   try {
     const principal = { type: "line", id: userId } as const;
-    const [resourceId, threadId] = await Promise.all([
-      toLineResourceId(principal, env.RESOURCE_ID_HASH_SECRET),
-      toLineThreadId(principal, env.RESOURCE_ID_HASH_SECRET),
-    ]);
+    const { hashedUserId, resourceId, threadId } = await toLineIds(
+      principal,
+      env.RESOURCE_ID_HASH_SECRET,
+    );
 
     const userMessage = `（投票）「${poll.title}」で「${selectedChoice}」を選んだよ。`;
 
     const replyTexts = await generateReply({
       userMessage,
       userId,
+      hashedUserId,
       resourceId,
       threadId,
       env,


### PR DESCRIPTION
## Summary
- PR #559 の Copilot レビューで指摘された HMAC の二重計算を解消する
- `toLineIds(p, secret)` を新設し、resourceId / threadId / hashedUserId を 1 回の HMAC でまとめて返す
- `generateReply` の引数に `hashedUserId` を追加し、内部の `hmacSha256` 呼び出しを削除

## 背景
PR #559 で LINE userId の resourceId / threadId を HMAC-SHA256 でハッシュ化したが、Copilot レビューにて以下が指摘された：

> toLineResourceId() と toLineThreadId() がそれぞれ独立に HMAC を計算しているため、両方が必要な呼び出し箇所では同一入力に対して HMAC が二重に実行されます（さらに generateReply 内でも別途 hmacSha256 を実行）。

実際に LINE webhook 1 リクエストで `hmacSha256(userId)` が 3 回呼ばれていた（resourceId / threadId / generateReply 内）。

## 主な変更内容
- `server/src/lib/principal.ts`: `toLineIds(p, secret): Promise<{ hashedUserId, resourceId, threadId }>` を追加。1 回の HMAC 計算で 3 値をまとめて返す
- `server/src/services/line-messaging.ts`: `generateReply` の引数に `hashedUserId` を追加し、内部 `hmacSha256` を削除
- `server/src/handlers/line-event-handler.ts` / `server/src/services/broadcast-response.ts` / `server/src/services/poll-response.ts`: `toLineIds` に統一し、`hashedUserId` を `generateReply` へ渡す
- `server/src/lib/principal.test.ts`: `toLineIds` のテストを追加（`toLineResourceId` / `toLineThreadId` と同じ値を返すことを含む）

既存の `toLineResourceId` / `toLineThreadId` は `require-thread-access.ts` 等の単独利用箇所のため残置。

## Test plan
- [ ] `pnpm --filter server test` がパスする（673 件すべて green を確認済み）
- [ ] `pnpm lint` がパスする（確認済み）
- [ ] dev デプロイ後、LINE webhook 経由のチャット返信が動作する
- [ ] LINE 経由の投票 postback 回答が動作する
- [ ] LINE 経由のおしらせ解説 postback が動作する