### PR TITLE
feat(server): 保管期間自動削除 Cron を実装する

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -371,6 +371,18 @@ UNIQUE INDEX: `(poll_id, user_id)` で重複回答を防止
 | user_id          | TEXT | PRIMARY KEY（LINE userId）    |
 | last_injected_at | TEXT | 最終投票注入日時（NOT NULL）  |
 
+### data_retention_logs
+
+保管期間ポリシーによる自動削除の実行ログ。3年（1095日）経過した行は自身も削除対象。
+
+| カラム        | 型      | 説明                                          |
+| ------------- | ------- | --------------------------------------------- |
+| id            | TEXT    | PRIMARY KEY                                   |
+| executed_at   | TEXT    | 実行時刻（NOT NULL）                          |
+| target_table  | TEXT    | 削除対象テーブル名（NOT NULL）                |
+| deleted_count | INTEGER | 削除件数（NOT NULL）                          |
+| created_at    | TEXT    | 作成時刻（NOT NULL）                          |
+
 ## Drizzle ORM
 
 ### スキーマ定義
@@ -477,11 +489,27 @@ thread_persona_status 更新
 
 ### Cron Trigger
 
-| スケジュール   | ハンドラー           | 説明                          |
-| -------------- | -------------------- | ----------------------------- |
-| `*/5 * * * *`  | handleBroadcastCheck | 配信予約チェック（5分ごと）        |
-| `*/5 * * * *`  | handlePollCheck          | 投票予約配信チェック（5分ごと） |
-| `0 18 * * *`   | handlePersonaExtract | ペルソナ抽出（毎日03:00 JST）      |
+| スケジュール   | ハンドラー                              | 説明                                                              |
+| -------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| `*/5 * * * *`  | handleBroadcastCheck                    | 配信予約チェック（5分ごと）                                        |
+| `*/5 * * * *`  | handlePollCheck                         | 投票予約配信チェック（5分ごと）                                    |
+| `0 18 * * *`   | handlePersonaExtract → handleDataRetention | ペルソナ抽出 + 保管期間自動削除（毎日03:00 JST、順次実行）        |
+
+### 保管期間自動削除
+
+`handleDataRetention` は以下のテーブルを期限超過行で削除する。実行結果は `data_retention_logs` に記録される。
+
+| 対象テーブル              | 保管期間 | 判定キー                                                                  |
+| ------------------------- | -------- | ------------------------------------------------------------------------- |
+| `mastra_messages`         | 30日     | `createdAt`                                                               |
+| `mastra_threads`          | 30日     | 紐づくメッセージが無い AND `createdAt` 経過（空スレッドへの猶予）         |
+| `thread_persona_status`   | -        | 紐づく `mastra_threads` が無くなった孤立分                                |
+| `mastra_resources`        | 180日    | `updatedAt`（working memory の最終更新）                                  |
+| `message_feedback`        | 180日    | `created_at`                                                              |
+| `poll_submissions`        | 365日    | `created_at`                                                              |
+| `data_retention_logs`     | 1095日   | `executed_at`                                                             |
+
+`mastra_messages` 削除後は `thread_persona_status.last_message_count` を残メッセージ数に再計算する（persona-extractor が新規メッセージを取りこぼさないように）。
 
 ## デプロイ環境
 

--- a/server/src/db/migrations/0018_data_retention_logs.sql
+++ b/server/src/db/migrations/0018_data_retention_logs.sql
@@ -1,0 +1,7 @@
+CREATE TABLE data_retention_logs (
+  id TEXT PRIMARY KEY NOT NULL,
+  executed_at TEXT NOT NULL,
+  target_table TEXT NOT NULL,
+  deleted_count INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -38,15 +38,18 @@ export const threadPersonaStatus = sqliteTable("thread_persona_status", {
 export const mastraThreads = sqliteTable("mastra_threads", {
   id: text("id").primaryKey(),
   resourceId: text("resourceId"),
+  createdAt: text("createdAt"),
 });
 
 export const mastraMessages = sqliteTable("mastra_messages", {
   id: text("id").primaryKey(),
   threadId: text("thread_id").notNull(),
+  createdAt: text("createdAt"),
 });
 
 export const mastraResources = sqliteTable("mastra_resources", {
   id: text("id").primaryKey(),
+  updatedAt: text("updatedAt"),
 });
 
 // 型エクスポート
@@ -184,3 +187,15 @@ export const userPollState = sqliteTable("user_poll_state", {
 });
 
 export type UserPollState = typeof userPollState.$inferSelect;
+
+// 保管期間ポリシーによる削除実行ログ
+export const dataRetentionLogs = sqliteTable("data_retention_logs", {
+  id: text("id").primaryKey(),
+  executedAt: text("executed_at").notNull(),
+  targetTable: text("target_table").notNull(),
+  deletedCount: integer("deleted_count").notNull(),
+  createdAt: text("created_at").notNull(),
+});
+
+export type DataRetentionLog = typeof dataRetentionLogs.$inferSelect;
+export type NewDataRetentionLog = typeof dataRetentionLogs.$inferInsert;

--- a/server/src/handlers/data-retention-handler.test.ts
+++ b/server/src/handlers/data-retention-handler.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/services/data-retention", () => ({
+  runDataRetention: vi.fn(),
+}));
+
+const { runDataRetention } = await import("~/services/data-retention");
+const { handleDataRetention } = await import("./data-retention-handler");
+
+const env = {} as CloudflareBindings;
+const ctx = {} as ExecutionContext;
+
+const buildEvent = () =>
+  ({
+    cron: "0 18 * * *",
+    type: "scheduled",
+    scheduledTime: Date.now(),
+    // biome-ignore lint/suspicious/noExplicitAny: テスト用
+  }) as any;
+
+describe("handleDataRetention", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常系: runDataRetention を env つきで呼ぶ", async () => {
+    vi.mocked(runDataRetention).mockResolvedValue([]);
+
+    await handleDataRetention(buildEvent(), env, ctx);
+
+    expect(runDataRetention).toHaveBeenCalledWith(env);
+  });
+
+  it("結果をログに残して完了する", async () => {
+    vi.mocked(runDataRetention).mockResolvedValue([
+      { table: "mastra_messages", deletedCount: 3 },
+      { table: "mastra_threads", deletedCount: 1 },
+    ]);
+
+    await expect(
+      handleDataRetention(buildEvent(), env, ctx),
+    ).resolves.toBeUndefined();
+  });
+
+  it("失敗時は throw して Cron Trigger に再試行させる", async () => {
+    vi.mocked(runDataRetention).mockRejectedValue(new Error("db"));
+
+    await expect(handleDataRetention(buildEvent(), env, ctx)).rejects.toThrow(
+      "db",
+    );
+  });
+});

--- a/server/src/handlers/data-retention-handler.ts
+++ b/server/src/handlers/data-retention-handler.ts
@@ -1,0 +1,20 @@
+import { logger } from "~/lib/logger";
+import { runDataRetention } from "~/services/data-retention";
+
+export const handleDataRetention: ExportedHandlerScheduledHandler<
+  CloudflareBindings
+> = async (_event, env, _ctx) => {
+  logger.info(`[DataRetention] Cron triggered at ${new Date().toISOString()}`);
+
+  try {
+    const results = await runDataRetention(env);
+    const total = results.reduce((sum, r) => sum + r.deletedCount, 0);
+
+    logger.info(
+      `[DataRetention] Completed: ${total} total rows deleted across ${results.length} tables`,
+    );
+  } catch (error) {
+    logger.error("[DataRetention] Error", error);
+    throw error;
+  }
+};

--- a/server/src/handlers/scheduled-handler.test.ts
+++ b/server/src/handlers/scheduled-handler.test.ts
@@ -12,10 +12,17 @@ vi.mock("~/handlers/persona-extract-handler", () => ({
   handlePersonaExtract: vi.fn(),
 }));
 
+vi.mock("~/handlers/data-retention-handler", () => ({
+  handleDataRetention: vi.fn(),
+}));
+
 const { handleBroadcastCheck } = await import("~/handlers/broadcast-handler");
 const { handlePollCheck } = await import("~/handlers/poll-handler");
 const { handlePersonaExtract } = await import(
   "~/handlers/persona-extract-handler"
+);
+const { handleDataRetention } = await import(
+  "~/handlers/data-retention-handler"
 );
 const { handleScheduled } = await import("./scheduled-handler");
 
@@ -41,14 +48,32 @@ describe("handleScheduled", () => {
     expect(handleBroadcastCheck).toHaveBeenCalled();
     expect(handlePollCheck).toHaveBeenCalled();
     expect(handlePersonaExtract).not.toHaveBeenCalled();
+    expect(handleDataRetention).not.toHaveBeenCalled();
   });
 
-  it("'0 18 * * *' は persona extract を呼ぶ", async () => {
+  it("'0 18 * * *' は persona extract → data retention の順で呼ぶ", async () => {
+    const callOrder: string[] = [];
+    vi.mocked(handlePersonaExtract).mockImplementation(async () => {
+      callOrder.push("persona");
+    });
+    vi.mocked(handleDataRetention).mockImplementation(async () => {
+      callOrder.push("retention");
+    });
+
     await handleScheduled(buildEvent("0 18 * * *"), env, ctx);
 
-    expect(handlePersonaExtract).toHaveBeenCalled();
+    expect(callOrder).toEqual(["persona", "retention"]);
     expect(handleBroadcastCheck).not.toHaveBeenCalled();
     expect(handlePollCheck).not.toHaveBeenCalled();
+  });
+
+  it("'0 18 * * *' で persona extract が throw すると data retention は呼ばれない", async () => {
+    vi.mocked(handlePersonaExtract).mockRejectedValue(new Error("boom"));
+
+    await expect(
+      handleScheduled(buildEvent("0 18 * * *"), env, ctx),
+    ).rejects.toThrow("boom");
+    expect(handleDataRetention).not.toHaveBeenCalled();
   });
 
   it("未知の cron 表現は何も呼ばない", async () => {
@@ -57,5 +82,6 @@ describe("handleScheduled", () => {
     expect(handleBroadcastCheck).not.toHaveBeenCalled();
     expect(handlePollCheck).not.toHaveBeenCalled();
     expect(handlePersonaExtract).not.toHaveBeenCalled();
+    expect(handleDataRetention).not.toHaveBeenCalled();
   });
 });

--- a/server/src/handlers/scheduled-handler.ts
+++ b/server/src/handlers/scheduled-handler.ts
@@ -1,4 +1,5 @@
 import { handleBroadcastCheck } from "~/handlers/broadcast-handler";
+import { handleDataRetention } from "~/handlers/data-retention-handler";
 import { handlePersonaExtract } from "~/handlers/persona-extract-handler";
 import { handlePollCheck } from "~/handlers/poll-handler";
 
@@ -11,6 +12,8 @@ export const handleScheduled: ExportedHandlerScheduledHandler<
       await handlePollCheck(event, env, ctx);
       return;
     case "0 18 * * *":
-      return handlePersonaExtract(event, env, ctx);
+      await handlePersonaExtract(event, env, ctx);
+      await handleDataRetention(event, env, ctx);
+      return;
   }
 };

--- a/server/src/services/data-retention.test.ts
+++ b/server/src/services/data-retention.test.ts
@@ -1,0 +1,331 @@
+import { eq } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  dataRetentionLogs,
+  mastraMessages,
+  mastraResources,
+  mastraThreads,
+  messageFeedback,
+  pollSubmissions,
+  polls,
+  threadPersonaStatus,
+} from "~/db";
+import { createTestDb, type TestDb } from "../test-helpers/test-db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+const { loggerMock } = vi.hoisted(() => ({
+  loggerMock: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+vi.mock("~/lib/logger", () => ({
+  logger: loggerMock,
+}));
+
+vi.mock("~/lib/storage", () => ({
+  getStorage: vi.fn().mockResolvedValue({}),
+}));
+
+const { runDataRetention } = await import("./data-retention");
+
+const env = { DB: {} as D1Database } as unknown as CloudflareBindings;
+
+const NOW = new Date("2026-05-13T00:00:00.000Z");
+const DAY = 24 * 60 * 60 * 1000;
+const daysAgo = (n: number) => new Date(NOW.getTime() - n * DAY).toISOString();
+
+describe("runDataRetention", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    testDbHolder.db = await createTestDb();
+  });
+
+  it("mastra_messages のうち 30 日より前のものだけ削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(mastraMessages).values([
+      { id: "old", threadId: "t1", createdAt: daysAgo(31) },
+      { id: "boundary-in", threadId: "t1", createdAt: daysAgo(29) },
+      { id: "fresh", threadId: "t1", createdAt: daysAgo(1) },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const remaining = await db.select().from(mastraMessages);
+    expect(remaining.map((r) => r.id).sort()).toEqual(["boundary-in", "fresh"]);
+  });
+
+  it("mastra_messages 削除後に紐づきが無くなった古い mastra_threads を削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(mastraThreads).values([
+      { id: "orphan", resourceId: "r1", createdAt: daysAgo(31) },
+      { id: "alive", resourceId: "r2", createdAt: daysAgo(31) },
+    ]);
+    await db.insert(mastraMessages).values([
+      { id: "m-old", threadId: "orphan", createdAt: daysAgo(31) },
+      { id: "m-keep", threadId: "alive", createdAt: daysAgo(1) },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const threads = await db.select().from(mastraThreads);
+    expect(threads.map((t) => t.id)).toEqual(["alive"]);
+  });
+
+  it("作成30日以内の空 mastra_threads は削除しない（猶予期間）", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(mastraThreads).values([
+      { id: "new-empty", resourceId: "r1", createdAt: daysAgo(1) },
+      { id: "old-empty", resourceId: "r2", createdAt: daysAgo(31) },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const threads = await db.select().from(mastraThreads);
+    expect(threads.map((t) => t.id)).toEqual(["new-empty"]);
+  });
+
+  it("mastra_messages 削除後に thread_persona_status.last_message_count を実数に再計算する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(mastraThreads).values({
+      id: "t-active",
+      resourceId: "r1",
+      createdAt: daysAgo(1),
+    });
+    // 古い 2 件は削除される、新しい 3 件は残る → 実数 3 件になる
+    await db.insert(mastraMessages).values([
+      { id: "m-old1", threadId: "t-active", createdAt: daysAgo(31) },
+      { id: "m-old2", threadId: "t-active", createdAt: daysAgo(31) },
+      { id: "m-new1", threadId: "t-active", createdAt: daysAgo(1) },
+      { id: "m-new2", threadId: "t-active", createdAt: daysAgo(1) },
+      { id: "m-new3", threadId: "t-active", createdAt: daysAgo(1) },
+    ]);
+    await db.insert(threadPersonaStatus).values({
+      threadId: "t-active",
+      lastExtractedAt: daysAgo(15),
+      lastMessageCount: 5, // 削除前の総数
+    });
+
+    await runDataRetention(env, { now: NOW });
+
+    const status = await db.select().from(threadPersonaStatus).get();
+    expect(status?.lastMessageCount).toBe(3);
+  });
+
+  it("mastra_threads 削除後に紐づかなくなった thread_persona_status を削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(threadPersonaStatus).values([
+      {
+        threadId: "ghost",
+        lastExtractedAt: daysAgo(60),
+        lastMessageCount: 3,
+      },
+      {
+        threadId: "alive",
+        lastExtractedAt: daysAgo(1),
+        lastMessageCount: 2,
+      },
+    ]);
+    await db.insert(mastraThreads).values({
+      id: "alive",
+      resourceId: "r1",
+      createdAt: daysAgo(1),
+    });
+
+    await runDataRetention(env, { now: NOW });
+
+    const remaining = await db.select().from(threadPersonaStatus);
+    expect(remaining.map((r) => r.threadId)).toEqual(["alive"]);
+  });
+
+  it("mastra_resources のうち updatedAt が 180 日より前のものだけ削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(mastraResources).values([
+      { id: "dormant", updatedAt: daysAgo(181) },
+      { id: "boundary-in", updatedAt: daysAgo(179) },
+      { id: "active", updatedAt: daysAgo(1) },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const remaining = await db.select().from(mastraResources);
+    expect(remaining.map((r) => r.id).sort()).toEqual([
+      "active",
+      "boundary-in",
+    ]);
+  });
+
+  it("message_feedback のうち 180 日より前のものだけ削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(messageFeedback).values([
+      {
+        id: "old",
+        threadId: "t1",
+        messageId: "m1",
+        rating: "good",
+        conversationContext: "[]",
+        createdAt: daysAgo(181),
+      },
+      {
+        id: "fresh",
+        threadId: "t1",
+        messageId: "m2",
+        rating: "bad",
+        conversationContext: "[]",
+        createdAt: daysAgo(1),
+      },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const remaining = await db.select().from(messageFeedback);
+    expect(remaining.map((r) => r.id)).toEqual(["fresh"]);
+  });
+
+  it("poll_submissions のうち 365 日より前のものだけ削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(polls).values({
+      id: "p1",
+      title: "x",
+      choices: "[]",
+      createdBy: "admin",
+      createdAt: daysAgo(1),
+    });
+    await db.insert(pollSubmissions).values([
+      {
+        id: "old",
+        pollId: "p1",
+        userId: "u1",
+        selectedChoice: "a",
+        createdAt: daysAgo(366),
+      },
+      {
+        id: "fresh",
+        pollId: "p1",
+        userId: "u2",
+        selectedChoice: "b",
+        createdAt: daysAgo(1),
+      },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const remaining = await db.select().from(pollSubmissions);
+    expect(remaining.map((r) => r.id)).toEqual(["fresh"]);
+  });
+
+  it("data_retention_logs のうち 1095 日より前のものを自身も削除する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(dataRetentionLogs).values([
+      {
+        id: "ancient",
+        executedAt: daysAgo(1096),
+        targetTable: "mastra_messages",
+        deletedCount: 0,
+        createdAt: daysAgo(1096),
+      },
+      {
+        id: "keep",
+        executedAt: daysAgo(1094),
+        targetTable: "mastra_messages",
+        deletedCount: 0,
+        createdAt: daysAgo(1094),
+      },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const logs = await db.select().from(dataRetentionLogs);
+    expect(logs.find((l) => l.id === "ancient")).toBeUndefined();
+    expect(logs.find((l) => l.id === "keep")).toBeDefined();
+  });
+
+  it("削除件数を data_retention_logs に対象テーブルごとに記録する", async () => {
+    const db = testDbHolder.db as TestDb;
+    await db.insert(mastraMessages).values([
+      { id: "m-old1", threadId: "t1", createdAt: daysAgo(31) },
+      { id: "m-old2", threadId: "t1", createdAt: daysAgo(31) },
+    ]);
+
+    await runDataRetention(env, { now: NOW });
+
+    const logs = await db
+      .select()
+      .from(dataRetentionLogs)
+      .where(eq(dataRetentionLogs.executedAt, NOW.toISOString()));
+
+    const byTable = Object.fromEntries(
+      logs.map((l) => [l.targetTable, l.deletedCount]),
+    );
+    expect(byTable.mastra_messages).toBe(2);
+    expect(byTable.mastra_resources).toBe(0);
+    expect(byTable.message_feedback).toBe(0);
+    expect(byTable.poll_submissions).toBe(0);
+    expect(byTable.mastra_threads).toBe(0);
+    expect(byTable.thread_persona_status).toBe(0);
+    expect(byTable.data_retention_logs).toBe(0);
+  });
+
+  it("削除対象 0 件のテーブルについても log を残す", async () => {
+    await runDataRetention(env, { now: NOW });
+
+    const db = testDbHolder.db as TestDb;
+    const logs = await db.select().from(dataRetentionLogs);
+
+    const tables = new Set(logs.map((l) => l.targetTable));
+    expect(tables).toEqual(
+      new Set([
+        "mastra_messages",
+        "mastra_threads",
+        "thread_persona_status",
+        "mastra_resources",
+        "message_feedback",
+        "poll_submissions",
+        "data_retention_logs",
+      ]),
+    );
+    expect(logs.every((l) => l.deletedCount === 0)).toBe(true);
+  });
+
+  it("結果配列を返す", async () => {
+    const results = await runDataRetention(env, { now: NOW });
+
+    expect(results).toEqual([
+      { table: "mastra_messages", deletedCount: 0 },
+      { table: "mastra_threads", deletedCount: 0 },
+      { table: "thread_persona_status", deletedCount: 0 },
+      { table: "mastra_resources", deletedCount: 0 },
+      { table: "message_feedback", deletedCount: 0 },
+      { table: "poll_submissions", deletedCount: 0 },
+      { table: "data_retention_logs", deletedCount: 0 },
+    ]);
+  });
+
+  it("DB エラー時は logger.error を呼んで throw する", async () => {
+    testDbHolder.db = {
+      select: () => {
+        throw new Error("DB down");
+      },
+    } as unknown as TestDb;
+
+    await expect(runDataRetention(env, { now: NOW })).rejects.toThrow(
+      "DB down",
+    );
+    expect(loggerMock.error).toHaveBeenCalled();
+  });
+});

--- a/server/src/services/data-retention.ts
+++ b/server/src/services/data-retention.ts
@@ -1,0 +1,171 @@
+import type { SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+
+import {
+  createDb,
+  type DbClient,
+  dataRetentionLogs,
+  mastraMessages,
+  mastraResources,
+  mastraThreads,
+  messageFeedback,
+  pollSubmissions,
+  threadPersonaStatus,
+} from "~/db";
+import { logger } from "~/lib/logger";
+import { getStorage } from "~/lib/storage";
+
+const RETENTION_DAYS = {
+  mastra_messages: 30,
+  mastra_threads: 30, // 空スレッドへの猶予期間
+  mastra_resources: 180,
+  message_feedback: 180,
+  poll_submissions: 365,
+  data_retention_logs: 1095,
+} as const;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type DataRetentionResult = {
+  table: string;
+  deletedCount: number;
+};
+
+const cutoff = (now: Date, days: number) =>
+  new Date(now.getTime() - days * DAY_MS).toISOString();
+
+const countAndDelete = async (
+  db: DbClient,
+  table: SQLiteTable,
+  where: SQL,
+): Promise<number> => {
+  const row = await db
+    .select({ c: sql<number>`COUNT(*)` })
+    .from(table)
+    .where(where)
+    .get();
+  const count = Number(row?.c ?? 0);
+  if (count > 0) {
+    await db.delete(table).where(where);
+  }
+  return count;
+};
+
+export const runDataRetention = async (
+  env: CloudflareBindings,
+  options: { now?: Date } = {},
+): Promise<DataRetentionResult[]> => {
+  const now = options.now ?? new Date();
+  const executedAt = now.toISOString();
+  const db = createDb(env.DB);
+
+  try {
+    // Mastra テーブルは drizzle の migration 対象外。未初期化の D1 に対して
+    // Cron 起動が最初に届くと "no such table" になるので、テーブルの存在を保証する。
+    await getStorage(env.DB);
+
+    const results: DataRetentionResult[] = [];
+
+    results.push({
+      table: "mastra_messages",
+      deletedCount: await countAndDelete(
+        db,
+        mastraMessages,
+        sql`datetime(${mastraMessages.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.mastra_messages)})`,
+      ),
+    });
+
+    // mastra_messages 削除により thread_persona_status.last_message_count が
+    // 現実より大きいまま残ると、persona-extractor が新規メッセージを抽出対象外と
+    // 判定してしまう。残メッセージ数で再計算して整合性を取る。
+    await db.run(sql`
+      UPDATE thread_persona_status
+      SET last_message_count = COALESCE((
+        SELECT COUNT(*) FROM mastra_messages
+        WHERE mastra_messages.thread_id = thread_persona_status.thread_id
+      ), 0)
+    `);
+
+    // 紐づくメッセージが無く、かつ作成から猶予期間を超えたスレッドのみ削除。
+    // 新規作成直後の空スレッドが Cron で消えると POST /threads → チャット投稿の間に 404 になる。
+    results.push({
+      table: "mastra_threads",
+      deletedCount: await countAndDelete(
+        db,
+        mastraThreads,
+        sql`${mastraThreads.id} NOT IN (SELECT DISTINCT thread_id FROM mastra_messages)
+          AND datetime(${mastraThreads.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.mastra_threads)})`,
+      ),
+    });
+
+    results.push({
+      table: "thread_persona_status",
+      deletedCount: await countAndDelete(
+        db,
+        threadPersonaStatus,
+        sql`${threadPersonaStatus.threadId} NOT IN (SELECT id FROM mastra_threads)`,
+      ),
+    });
+
+    results.push({
+      table: "mastra_resources",
+      deletedCount: await countAndDelete(
+        db,
+        mastraResources,
+        sql`datetime(${mastraResources.updatedAt}) < datetime(${cutoff(now, RETENTION_DAYS.mastra_resources)})`,
+      ),
+    });
+
+    results.push({
+      table: "message_feedback",
+      deletedCount: await countAndDelete(
+        db,
+        messageFeedback,
+        sql`datetime(${messageFeedback.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.message_feedback)})`,
+      ),
+    });
+
+    results.push({
+      table: "poll_submissions",
+      deletedCount: await countAndDelete(
+        db,
+        pollSubmissions,
+        sql`datetime(${pollSubmissions.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.poll_submissions)})`,
+      ),
+    });
+
+    results.push({
+      table: "data_retention_logs",
+      deletedCount: await countAndDelete(
+        db,
+        dataRetentionLogs,
+        sql`datetime(${dataRetentionLogs.executedAt}) < datetime(${cutoff(now, RETENTION_DAYS.data_retention_logs)})`,
+      ),
+    });
+
+    for (const r of results) {
+      await db.insert(dataRetentionLogs).values({
+        id: crypto.randomUUID(),
+        executedAt,
+        targetTable: r.table,
+        deletedCount: r.deletedCount,
+        createdAt: executedAt,
+      });
+    }
+
+    logger.info("data_retention_executed", {
+      event: "data_retention_executed",
+      ...Object.fromEntries(
+        results.map((r) => [`${r.table}_deleted`, r.deletedCount]),
+      ),
+    });
+
+    return results;
+  } catch (error) {
+    logger.error("data_retention_failed", error, {
+      event: "data_retention_failed",
+    });
+    throw error;
+  }
+};

--- a/server/src/test-helpers/test-db.ts
+++ b/server/src/test-helpers/test-db.ts
@@ -139,19 +139,31 @@ export const createTestDb = async () => {
       last_injected_at TEXT NOT NULL
     );
 
+    -- 保管期間ポリシー削除実行ログ
+    CREATE TABLE IF NOT EXISTS data_retention_logs (
+      id TEXT PRIMARY KEY,
+      executed_at TEXT NOT NULL,
+      target_table TEXT NOT NULL,
+      deleted_count INTEGER NOT NULL,
+      created_at TEXT NOT NULL
+    );
+
     -- Mastra 管理テーブル（read-only スキーマ。テストのフィクスチャ生成用に最低限のカラムを定義）
     CREATE TABLE IF NOT EXISTS mastra_threads (
       id TEXT PRIMARY KEY,
-      resourceId TEXT
+      resourceId TEXT,
+      createdAt TEXT
     );
 
     CREATE TABLE IF NOT EXISTS mastra_messages (
       id TEXT PRIMARY KEY,
-      thread_id TEXT NOT NULL
+      thread_id TEXT NOT NULL,
+      createdAt TEXT
     );
 
     CREATE TABLE IF NOT EXISTS mastra_resources (
-      id TEXT PRIMARY KEY
+      id TEXT PRIMARY KEY,
+      updatedAt TEXT
     );
   `);
 


### PR DESCRIPTION
## Summary
- 保管期間ポリシー（個情法第22条 / LINE User Data Policy §3.2.3）を満たす日次 Cron バッチを `0 18 * * *` スロットに統合
- 削除実行ログ用の `data_retention_logs` テーブルを新設
- `mastra_messages` 削除後の `thread_persona_status` 整合性と、新規空スレッドの猶予期間も対応

## 主な変更内容

### 新規テーブル
- `data_retention_logs`（id / executed_at / target_table / deleted_count / created_at）
- マイグレーション `0018_data_retention_logs.sql`

### 削除対象と保管期間

| 対象テーブル | 保管期間 | 判定キー |
|---|---|---|
| `mastra_messages` | 30 日 | `createdAt` |
| `mastra_threads` | 30 日 | 紐づくメッセージが無い AND `createdAt` 経過（空スレッドへの猶予） |
| `thread_persona_status` | - | 紐づく `mastra_threads` が無くなった孤立分 |
| `mastra_resources` | 180 日 | `updatedAt`（working memory の最終更新） |
| `message_feedback` | 180 日 | `created_at` |
| `poll_submissions` | 365 日 | `created_at` |
| `data_retention_logs` | 1095 日（3 年） | `executed_at` |

### 設計上の判断
- **`mastra_resources` のキーは `updatedAt`**: Mastra core 1.10.0 のスキーマに `last_accessed_at` が存在しないため。`updateResource` は agent が working memory を書き換える度に走るので、能動会話のあるユーザーは延命される
- **`mastra_messages` 削除後に `thread_persona_status.last_message_count` を再計算**: `persona-extractor` が `currentMessageCount <= lastMessageCount` で skip 判定するため、削除によって新規メッセージが永久に取りこぼされないようにする
- **`mastra_threads` に 30 日の猶予期間**: `POST /threads` 直後の空スレッドが夜間 Cron で即削除されてチャット投稿時 404 になる事故を防ぐ
- **scheduled-handler 統合**: `0 18 * * *` で `handlePersonaExtract` → `handleDataRetention` を順次実行。persona-extract が失敗したら data-retention をスキップし Cron 再試行に委ねる

## Test plan

- [x] `pnpm --filter @nepp-chan/server test` 690 件全パス
- [x] `pnpm biome check` 変更分クリア / `pnpm exec tsc --noEmit` クリア
- [x] `pnpm db:migrate:local` でローカル D1 にマイグレーション成功
- [x] `codex review --uncommitted` 通過（指摘 2 件を取り込み済み）
- [ ] dev デプロイ後、`wrangler tail` で 03:00 JST 自動実行ログ確認
- [ ] dev D1 で `data_retention_logs` に記録が入ることを確認