### PR TITLE
refactor(server): persona の resource_id を廃止する

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -275,8 +275,6 @@ throw new HTTPException(404, { message: "Not found" });
 
 ### persona
 
-抽象化された村の集合知。案 C（2026-04-21 確定）により `resource_id` は廃止され、個人非紐付けで運用する。
-
 | カラム                | 型   | 説明                     |
 | --------------------- | ---- | ------------------------ |
 | id                    | TEXT | PRIMARY KEY              |

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -275,10 +275,11 @@ throw new HTTPException(404, { message: "Not found" });
 
 ### persona
 
+抽象化された村の集合知。案 C（2026-04-21 確定）により `resource_id` は廃止され、個人非紐付けで運用する。
+
 | カラム                | 型   | 説明                     |
 | --------------------- | ---- | ------------------------ |
 | id                    | TEXT | PRIMARY KEY              |
-| resource_id           | TEXT | リソース ID（NOT NULL）  |
 | category              | TEXT | カテゴリ（NOT NULL）     |
 | tags                  | TEXT | タグ（JSON 配列）        |
 | content               | TEXT | 内容（NOT NULL）         |
@@ -380,7 +381,7 @@ import { sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 export const persona = sqliteTable("persona", {
   id: text("id").primaryKey(),
-  resourceId: text("resource_id").notNull(),
+  category: text("category").notNull(),
   // ...
 });
 

--- a/server/src/db/migrations/0018_drop_persona_resource_id.sql
+++ b/server/src/db/migrations/0018_drop_persona_resource_id.sql
@@ -1,0 +1,6 @@
+-- 案 C: resource_id 廃止 + 既存レコード全削除（個人紐付け解除）
+-- persona テーブル自体は今後の抽象化集合知の入れ物として残す
+DELETE FROM persona;
+DELETE FROM thread_persona_status;
+DROP INDEX IF EXISTS idx_persona_resource_id;
+ALTER TABLE persona DROP COLUMN resource_id;

--- a/server/src/db/migrations/0018_drop_persona_resource_id.sql
+++ b/server/src/db/migrations/0018_drop_persona_resource_id.sql
@@ -1,5 +1,3 @@
--- 案 C: resource_id 廃止 + 既存レコード全削除（個人紐付け解除）
--- persona テーブル自体は今後の抽象化集合知の入れ物として残す
 DELETE FROM persona;
 DELETE FROM thread_persona_status;
 DROP INDEX IF EXISTS idx_persona_resource_id;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -11,7 +11,6 @@ export const emergencyReports = sqliteTable("emergency_reports", {
 });
 
 // ペルソナ（村の集合知）
-// 案 C: resource_id 廃止により個人非紐付けの抽象化集合知として運用
 export const persona = sqliteTable("persona", {
   id: text("id").primaryKey(),
   category: text("category").notNull(),

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -11,9 +11,9 @@ export const emergencyReports = sqliteTable("emergency_reports", {
 });
 
 // ペルソナ（村の集合知）
+// 案 C: resource_id 廃止により個人非紐付けの抽象化集合知として運用
 export const persona = sqliteTable("persona", {
   id: text("id").primaryKey(),
-  resourceId: text("resource_id").notNull(),
   category: text("category").notNull(),
   tags: text("tags"),
   content: text("content").notNull(),

--- a/server/src/mastra/agents/persona-agent.ts
+++ b/server/src/mastra/agents/persona-agent.ts
@@ -13,7 +13,6 @@ export const personaAgent = new Agent({
 純粋な挨拶や天気確認のみの場合は保存不要。それ以外は積極的に保存する。
 
 ## persona-save の使い方
-- resourceId: "otoineppu"
 - category / content / topic / sentiment / tags / demographicSummary: 下記ルール参照
 - source: "会話"
 

--- a/server/src/mastra/agents/persona-analyst-agent.ts
+++ b/server/src/mastra/agents/persona-analyst-agent.ts
@@ -30,11 +30,11 @@ export const personaAnalystAgent = new Agent({
 
 ### 傾向分析
 - 「村民の要望を分析して」「住民の声の傾向は？」
-- persona-aggregate ツールでトピック別集計（resourceId: "otoineppu"）
+- persona-aggregate ツールでトピック別集計
 
 ### 詳細検索
 - 「交通に関する意見は？」「高齢者の声を教えて」
-- persona-get ツールでキーワード・タグ検索（resourceId: "otoineppu"）
+- persona-get ツールでキーワード・タグ検索
 
 ### デモグラフィック分析
 - 「年代別の傾向は？」「属性別に分析して」
@@ -102,7 +102,6 @@ export const personaAnalystAgent = new Agent({
 - 検索結果が0件の場合は「該当する報告はありません」と正直に伝える
 
 ## 注意事項
-- resourceId には "otoineppu" を使用する
 - データがない場合は「データがありません」と正直に報告
 - 推測は「推測」と明記する
 `,

--- a/server/src/mastra/tools/admin-persona-tool.ts
+++ b/server/src/mastra/tools/admin-persona-tool.ts
@@ -64,7 +64,6 @@ export const adminPersonaTool = createTool({
 
       const personas = result.personas.map((p) => ({
         id: p.id,
-        resourceId: p.resourceId,
         category: p.category,
         tags: p.tags,
         content: p.content,

--- a/server/src/mastra/tools/persona-aggregate-tool.test.ts
+++ b/server/src/mastra/tools/persona-aggregate-tool.test.ts
@@ -25,7 +25,7 @@ describe("personaAggregateTool.execute", () => {
 
     const result = await callTool(
       personaAggregateTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       adminValues,
     );
 
@@ -47,7 +47,7 @@ describe("personaAggregateTool.execute", () => {
 
     const result = await callTool(
       personaAggregateTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       adminValues,
     );
 
@@ -67,7 +67,7 @@ describe("personaAggregateTool.execute", () => {
 
     const result = await callTool(
       personaAggregateTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       adminValues,
     );
 
@@ -87,7 +87,7 @@ describe("personaAggregateTool.execute", () => {
 
     const result = await callTool(
       personaAggregateTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       adminValues,
     );
 
@@ -115,7 +115,7 @@ describe("personaAggregateTool.execute", () => {
 
     const result = await callTool(
       personaAggregateTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       adminValues,
     );
 
@@ -125,7 +125,7 @@ describe("personaAggregateTool.execute", () => {
   it("非管理者は NOT_AUTHORIZED", async () => {
     const result = await callTool(
       personaAggregateTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       { db: fakeDb },
     );
 

--- a/server/src/mastra/tools/persona-aggregate-tool.ts
+++ b/server/src/mastra/tools/persona-aggregate-tool.ts
@@ -10,7 +10,6 @@ export const personaAggregateTool = createTool({
   description:
     "【管理者専用】村の集合知をトピック別に集計します。「バスの増便要望が5件（60代が多い）」のような形式で傾向を把握できます。",
   inputSchema: z.object({
-    resourceId: z.string().describe("リソースID（村やグループの識別子）"),
     category: z
       .string()
       .optional()
@@ -51,10 +50,10 @@ export const personaAggregateTool = createTool({
     }
     const { db } = result;
 
-    const { resourceId, category, limit } = inputData;
+    const { category, limit } = inputData;
 
     try {
-      const results = await personaRepository.aggregateByTopic(db, resourceId, {
+      const results = await personaRepository.aggregateByTopic(db, {
         category,
         limit,
       });

--- a/server/src/mastra/tools/persona-get-tool.test.ts
+++ b/server/src/mastra/tools/persona-get-tool.test.ts
@@ -22,7 +22,6 @@ const adminValues = (overrides: Record<string, unknown> = {}) => ({
 
 const samplePersona = {
   id: "p-1",
-  resourceId: "v-1",
   category: "意見",
   tags: null,
   content: "x",
@@ -43,17 +42,12 @@ describe("personaGetTool.execute", () => {
   it("正常系: 結果を返す", async () => {
     vi.mocked(personaRepository.search).mockResolvedValue([samplePersona]);
 
-    const result = await callTool(
-      personaGetTool,
-      { resourceId: "v-1", limit: 20 },
-      adminValues(),
-    );
+    const result = await callTool(personaGetTool, { limit: 20 }, adminValues());
 
     expect(result.success).toBe(true);
     expect(result.count).toBe(1);
     expect(result.personas[0]).toMatchObject({
       id: "p-1",
-      resourceId: "v-1",
       category: "意見",
       content: "x",
     });
@@ -62,11 +56,7 @@ describe("personaGetTool.execute", () => {
   it("ヒット 0 件は専用メッセージ", async () => {
     vi.mocked(personaRepository.search).mockResolvedValue([]);
 
-    const result = await callTool(
-      personaGetTool,
-      { resourceId: "v-1", limit: 20 },
-      adminValues(),
-    );
+    const result = await callTool(personaGetTool, { limit: 20 }, adminValues());
 
     expect(result.success).toBe(true);
     expect(result.count).toBe(0);
@@ -76,7 +66,7 @@ describe("personaGetTool.execute", () => {
   it("非管理者は NOT_AUTHORIZED", async () => {
     const result = await callTool(
       personaGetTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       { db: fakeDb },
     );
 
@@ -88,7 +78,7 @@ describe("personaGetTool.execute", () => {
   it("staff ロールも NOT_AUTHORIZED（admin 以上必須）", async () => {
     const result = await callTool(
       personaGetTool,
-      { resourceId: "v-1", limit: 20 },
+      { limit: 20 },
       { db: fakeDb, adminUser: { id: "u-2", role: "staff" } },
     );
 
@@ -99,11 +89,7 @@ describe("personaGetTool.execute", () => {
   it("search が throw すると success: false", async () => {
     vi.mocked(personaRepository.search).mockRejectedValue(new Error("db"));
 
-    const result = await callTool(
-      personaGetTool,
-      { resourceId: "v-1", limit: 20 },
-      adminValues(),
-    );
+    const result = await callTool(personaGetTool, { limit: 20 }, adminValues());
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("db");

--- a/server/src/mastra/tools/persona-get-tool.ts
+++ b/server/src/mastra/tools/persona-get-tool.ts
@@ -10,7 +10,6 @@ export const personaGetTool = createTool({
   description:
     "【管理者専用】村の集合知（ペルソナ）を検索・取得します。自然言語のキーワードやカテゴリ、タグで検索できます。",
   inputSchema: z.object({
-    resourceId: z.string().describe("リソースID（村やグループの識別子）"),
     category: z
       .string()
       .optional()
@@ -38,7 +37,6 @@ export const personaGetTool = createTool({
     personas: z.array(
       personaOutputSchema.pick({
         id: true,
-        resourceId: true,
         category: true,
         tags: true,
         content: true,
@@ -64,10 +62,10 @@ export const personaGetTool = createTool({
     }
     const { db } = result;
 
-    const { resourceId, category, tags, keyword, limit } = inputData;
+    const { category, tags, keyword, limit } = inputData;
 
     try {
-      const personas = await personaRepository.search(db, resourceId, {
+      const personas = await personaRepository.search(db, {
         category,
         tags,
         keyword,

--- a/server/src/mastra/tools/persona-save-tool.test.ts
+++ b/server/src/mastra/tools/persona-save-tool.test.ts
@@ -14,7 +14,6 @@ import { callTool } from "../../test-helpers/tool-context";
 const fakeDb = {} as D1Database;
 
 const validInput = {
-  resourceId: "village-1",
   category: "意見",
   content: "村民は地元産の野菜を好む",
 };
@@ -34,7 +33,6 @@ describe("personaSaveTool.execute", () => {
     expect(personaRepository.create).toHaveBeenCalledWith(
       fakeDb,
       expect.objectContaining({
-        resourceId: "village-1",
         category: "意見",
         content: "村民は地元産の野菜を好む",
       }),

--- a/server/src/mastra/tools/persona-save-tool.ts
+++ b/server/src/mastra/tools/persona-save-tool.ts
@@ -9,7 +9,6 @@ export const personaSaveTool = createTool({
   description:
     "村の集合知（ペルソナ）を新規保存します。会話から得られた知見、ユーザーの好み、村の価値観、決定事項などを抽象化して蓄積するときに使用します。",
   inputSchema: z.object({
-    resourceId: z.string().describe("リソースID（村やグループの識別子）"),
     category: z
       .string()
       .describe(
@@ -62,7 +61,6 @@ export const personaSaveTool = createTool({
     const conversationEndedAt = getConversationEndedAt(context);
 
     const {
-      resourceId,
       category,
       tags,
       content,
@@ -78,7 +76,6 @@ export const personaSaveTool = createTool({
     try {
       await personaRepository.create(db, {
         id: personaId,
-        resourceId,
         category,
         tags,
         content,

--- a/server/src/repository/persona-repository.test.ts
+++ b/server/src/repository/persona-repository.test.ts
@@ -21,7 +21,6 @@ describe("persona Drizzle クエリ", () => {
     it("新しいペルソナを作成できる", async () => {
       await db.insert(persona).values({
         id: "test-id",
-        resourceId: "village-1",
         category: "好み",
         tags: "男性,高齢者",
         content: "村民は地元産の野菜を好む",
@@ -44,7 +43,6 @@ describe("persona Drizzle クエリ", () => {
     it("オプション項目なしでも作成できる", async () => {
       await db.insert(persona).values({
         id: "test-id-2",
-        resourceId: "village-1",
         category: "価値観",
         content: "助け合いを大切にする",
         createdAt: "2024-01-01T00:00:00Z",
@@ -66,7 +64,6 @@ describe("persona Drizzle クエリ", () => {
     beforeEach(async () => {
       await db.insert(persona).values({
         id: "update-test",
-        resourceId: "village-1",
         category: "好み",
         content: "元の内容",
         createdAt: "2024-01-01T00:00:00Z",
@@ -78,28 +75,8 @@ describe("persona Drizzle クエリ", () => {
         .update(persona)
         .set({
           content: "更新された内容",
-          updatedAt: new Date().toISOString(),
-        })
-        .where(eq(persona.id, "update-test"));
-
-      const updated = await db
-        .select()
-        .from(persona)
-        .where(eq(persona.id, "update-test"))
-        .get();
-
-      expect(updated?.content).toBe("更新された内容");
-      expect(updated?.updatedAt).not.toBeNull();
-    });
-
-    it("複数項目を同時に更新できる", async () => {
-      await db
-        .update(persona)
-        .set({
           category: "新カテゴリ",
           tags: "新タグ",
-          content: "新しい内容",
-          updatedAt: new Date().toISOString(),
         })
         .where(eq(persona.id, "update-test"));
 
@@ -111,7 +88,7 @@ describe("persona Drizzle クエリ", () => {
 
       expect(updated?.category).toBe("新カテゴリ");
       expect(updated?.tags).toBe("新タグ");
-      expect(updated?.content).toBe("新しい内容");
+      expect(updated?.content).toBe("更新された内容");
     });
   });
 
@@ -119,7 +96,6 @@ describe("persona Drizzle クエリ", () => {
     beforeEach(async () => {
       await db.insert(persona).values({
         id: "find-test",
-        resourceId: "village-1",
         category: "好み",
         tags: "男性",
         content: "テスト内容",
@@ -150,55 +126,38 @@ describe("persona Drizzle クエリ", () => {
     });
   });
 
-  describe("select by resourceId", () => {
+  describe("list", () => {
     beforeEach(async () => {
       await db.insert(persona).values([
         {
           id: "1",
-          resourceId: "village-1",
           category: "好み",
           content: "内容1",
           createdAt: "2024-01-01T00:00:00Z",
         },
         {
           id: "2",
-          resourceId: "village-1",
           category: "価値観",
           content: "内容2",
           createdAt: "2024-01-02T00:00:00Z",
         },
         {
           id: "3",
-          resourceId: "village-2",
           category: "好み",
-          content: "別の村",
+          content: "内容3",
           createdAt: "2024-01-03T00:00:00Z",
         },
       ]);
-    });
-
-    it("リソースIDでペルソナ一覧を取得できる", async () => {
-      const result = await db
-        .select()
-        .from(persona)
-        .where(eq(persona.resourceId, "village-1"))
-        .orderBy(desc(persona.createdAt))
-        .all();
-
-      expect(result).toHaveLength(2);
-      expect(result.every((p) => p.resourceId === "village-1")).toBe(true);
     });
 
     it("降順でソートされる", async () => {
       const result = await db
         .select()
         .from(persona)
-        .where(eq(persona.resourceId, "village-1"))
         .orderBy(desc(persona.createdAt))
         .all();
 
-      expect(result[0].id).toBe("2"); // 最新が先頭
-      expect(result[1].id).toBe("1");
+      expect(result.map((p) => p.id)).toEqual(["3", "2", "1"]);
     });
   });
 
@@ -207,7 +166,6 @@ describe("persona Drizzle クエリ", () => {
       await db.insert(persona).values([
         {
           id: "s1",
-          resourceId: "village-1",
           category: "好み",
           tags: "男性,高齢者",
           content: "地元産の野菜が人気",
@@ -215,7 +173,6 @@ describe("persona Drizzle クエリ", () => {
         },
         {
           id: "s2",
-          resourceId: "village-1",
           category: "好み",
           tags: "女性",
           content: "お米を好む",
@@ -223,7 +180,6 @@ describe("persona Drizzle クエリ", () => {
         },
         {
           id: "s3",
-          resourceId: "village-1",
           category: "価値観",
           tags: "男性",
           content: "伝統を大切にする",
@@ -236,12 +192,7 @@ describe("persona Drizzle クエリ", () => {
       const result = await db
         .select()
         .from(persona)
-        .where(
-          and(
-            eq(persona.resourceId, "village-1"),
-            eq(persona.category, "好み"),
-          ),
-        )
+        .where(eq(persona.category, "好み"))
         .all();
 
       expect(result).toHaveLength(2);
@@ -252,12 +203,7 @@ describe("persona Drizzle クエリ", () => {
       const result = await db
         .select()
         .from(persona)
-        .where(
-          and(
-            eq(persona.resourceId, "village-1"),
-            like(persona.tags, "%男性%"),
-          ),
-        )
+        .where(like(persona.tags, "%男性%"))
         .all();
 
       expect(result).toHaveLength(2);
@@ -268,12 +214,7 @@ describe("persona Drizzle クエリ", () => {
       const result = await db
         .select()
         .from(persona)
-        .where(
-          and(
-            eq(persona.resourceId, "village-1"),
-            or(like(persona.tags, "%女性%"), like(persona.tags, "%高齢者%")),
-          ),
-        )
+        .where(or(like(persona.tags, "%女性%"), like(persona.tags, "%高齢者%")))
         .all();
 
       expect(result).toHaveLength(2);
@@ -283,12 +224,7 @@ describe("persona Drizzle クエリ", () => {
       const result = await db
         .select()
         .from(persona)
-        .where(
-          and(
-            eq(persona.resourceId, "village-1"),
-            like(persona.content, "%野菜%"),
-          ),
-        )
+        .where(like(persona.content, "%野菜%"))
         .all();
 
       expect(result).toHaveLength(1);
@@ -301,7 +237,6 @@ describe("persona Drizzle クエリ", () => {
         .from(persona)
         .where(
           and(
-            eq(persona.resourceId, "village-1"),
             eq(persona.category, "好み"),
             like(persona.tags, "%男性%"),
             like(persona.content, "%野菜%"),
@@ -320,28 +255,24 @@ describe("persona Drizzle クエリ", () => {
       await db.insert(persona).values([
         {
           id: "admin-1",
-          resourceId: "village-1",
           category: "好み",
           content: "内容1",
           createdAt: "2024-01-01T00:00:00Z",
         },
         {
           id: "admin-2",
-          resourceId: "village-1",
           category: "価値観",
           content: "内容2",
           createdAt: "2024-01-02T00:00:00Z",
         },
         {
           id: "admin-3",
-          resourceId: "village-2",
           category: "好み",
           content: "内容3",
           createdAt: "2024-01-03T00:00:00Z",
         },
         {
           id: "admin-4",
-          resourceId: "village-1",
           category: "意見",
           content: "内容4",
           createdAt: "2024-01-03T00:00:00Z", // admin-3 と同じ createdAt
@@ -471,7 +402,6 @@ describe("persona Drizzle クエリ", () => {
     beforeEach(async () => {
       await db.insert(persona).values({
         id: "delete-test",
-        resourceId: "village-1",
         category: "好み",
         content: "削除対象",
         createdAt: "2024-01-01T00:00:00Z",

--- a/server/src/repository/persona-repository.ts
+++ b/server/src/repository/persona-repository.ts
@@ -28,7 +28,6 @@ export const personaRepository = {
 
     await db.insert(persona).values({
       id: input.id,
-      resourceId: input.resourceId,
       category: input.category,
       tags: input.tags ?? null,
       content: input.content,
@@ -74,21 +73,8 @@ export const personaRepository = {
     return result ?? null;
   },
 
-  async findByResourceId(d1: D1Database, resourceId: string, limit = 100) {
-    const db = createDb(d1);
-
-    return db
-      .select()
-      .from(persona)
-      .where(eq(persona.resourceId, resourceId))
-      .orderBy(desc(persona.createdAt))
-      .limit(limit)
-      .all();
-  },
-
   async search(
     d1: D1Database,
-    resourceId: string,
     options: {
       category?: string;
       tags?: string[];
@@ -98,7 +84,7 @@ export const personaRepository = {
   ) {
     const db = createDb(d1);
 
-    const conditions = [eq(persona.resourceId, resourceId)];
+    const conditions: SQL[] = [];
 
     if (options.category) {
       conditions.push(eq(persona.category, options.category));
@@ -131,7 +117,7 @@ export const personaRepository = {
     return db
       .select()
       .from(persona)
-      .where(and(...conditions))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
       .orderBy(desc(persona.createdAt))
       .limit(options.limit ?? 50)
       .all();
@@ -139,15 +125,11 @@ export const personaRepository = {
 
   async aggregateByTopic(
     d1: D1Database,
-    resourceId: string,
     options: { category?: string; limit?: number } = {},
   ): Promise<TopicAggregation[]> {
     const db = createDb(d1);
 
-    const conditions = [
-      eq(persona.resourceId, resourceId),
-      sql`${persona.topic} IS NOT NULL`,
-    ];
+    const conditions: SQL[] = [sql`${persona.topic} IS NOT NULL`];
 
     if (options.category) {
       conditions.push(eq(persona.category, options.category));

--- a/server/src/routes/admin/persona.ts
+++ b/server/src/routes/admin/persona.ts
@@ -19,7 +19,6 @@ personaAdminRoutes.use("*", requireRole("admin"));
 
 const PersonaSchema = z.object({
   id: z.string(),
-  resourceId: z.string(),
   category: z.string(),
   tags: z.string().nullable(),
   content: z.string(),

--- a/server/src/schemas/persona-schema.ts
+++ b/server/src/schemas/persona-schema.ts
@@ -46,7 +46,6 @@ export type Persona = z.infer<typeof personaSchema>;
 // ツール output 用のペルソナスキーマ（DB レコード形式）
 export const personaOutputSchema = z.object({
   id: z.string(),
-  resourceId: z.string(),
   category: z.string(),
   tags: z.string().nullable(),
   content: z.string(),

--- a/server/src/services/user-deletion.test.ts
+++ b/server/src/services/user-deletion.test.ts
@@ -142,7 +142,6 @@ const insertFixtures = async (
   // persona は削除対象外（個人データ非該当）
   await db.insert(persona).values({
     id: "pe1",
-    resourceId: targetResourceId,
     category: "cat",
     content: "c",
     createdAt: "2025-01-01T00:00:00Z",

--- a/server/src/test-helpers/test-db.ts
+++ b/server/src/test-helpers/test-db.ts
@@ -19,9 +19,9 @@ export const createTestDb = async () => {
     );
 
     -- 村の集合知（ペルソナ）テーブル
+    -- 案 C: resource_id 廃止により個人非紐付け
     CREATE TABLE IF NOT EXISTS persona (
       id TEXT PRIMARY KEY,
-      resource_id TEXT NOT NULL,
       category TEXT NOT NULL,
       tags TEXT,
       content TEXT NOT NULL,

--- a/server/src/test-helpers/test-db.ts
+++ b/server/src/test-helpers/test-db.ts
@@ -19,7 +19,6 @@ export const createTestDb = async () => {
     );
 
     -- 村の集合知（ペルソナ）テーブル
-    -- 案 C: resource_id 廃止により個人非紐付け
     CREATE TABLE IF NOT EXISTS persona (
       id TEXT PRIMARY KEY,
       category TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- 案 C（2026-04-21 確定）に従い `persona.resource_id` カラムを廃止
- 既存レコードは個人紐付け情報として全削除、`persona` テーブル自体は抽象化集合知の入れ物として残す
- 関連する Drizzle schema / repository / tools / agent instructions / output schema を一括で同期

Issue: kayac/nepp-chan-biz#18 の一部（persona 関連分のみ。`mastra_*` テーブルのデータ全削除は別タスク）

## 主な変更内容

### Migration
- `0018_drop_persona_resource_id.sql`:
  ```sql
  DELETE FROM persona;
  DELETE FROM thread_persona_status;
  DROP INDEX IF EXISTS idx_persona_resource_id;
  ALTER TABLE persona DROP COLUMN resource_id;
  ```
- `idx_persona_resource_id` を先に落とすことで SQLite の DROP COLUMN 制約を回避

### コード変更
- `db/schema.ts`: persona から `resourceId` カラム削除
- `repository/persona-repository.ts`: `create` の resourceId フィールド削除、`search` / `aggregateByTopic` から resourceId 引数撤廃、`findByResourceId` 撤廃
- `mastra/tools/persona-*-tool.ts`: inputSchema から resourceId 削除（LLM が指定する必要なし）
- `mastra/agents/persona-agent.ts` / `persona-analyst-agent.ts`: instructions の `resourceId: "otoineppu"` 言及を削除
- `schemas/persona-schema.ts` / `routes/admin/persona.ts` / `mastra/tools/admin-persona-tool.ts`: 出力スキーマから resourceId 削除
- 全テスト・test-helpers DDL を同期

### 影響
- 案 C 移行後、persona は「特定個人が想起されない粒度に抽象化された集合知」として運用
- 既存の dev 環境の persona レコードは全削除される（マイグレーション実行時）
- `thread_persona_status` も全削除されるため、次回 Cron で全スレッド再抽出が走る

## Test plan

- [x] `pnpm --filter @nepp-chan/server test` 671 件全パス
- [x] `pnpm biome check` クリア（既存の warning のみ）
- [x] `pnpm --filter @nepp-chan/server exec tsc --noEmit` クリア
- [x] `pnpm db:migrate:local` でローカル D1 にマイグレーション成功
- [x] `codex review --uncommitted` 通過
- [ ] dev デプロイ後、persona テーブルから resource_id カラムが消えていることを確認
- [ ] dev で会話 → 翌日 Cron でペルソナが抽象化された集合知として保存されることを確認

## メモ

- prd 反映は別途リリースタイミングで対応（このブランチでは develop のみ）
- PR #564（保管期間自動削除 Cron）と並列で develop に乗る想定。スキーマの衝突なし