### PR TITLE
ci: Dependabot の同時オープン PR 上限を 99 に引き上げる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 99


### PR DESCRIPTION
## Summary
- Dependabot のデフォルト上限 5 件で週次更新が滞留していたため、`open-pull-requests-limit: 99` を追加して全件検知できるようにする

## Test plan
- [ ] マージ後、次回の Dependabot 実行で 5 件超の PR が立つことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)