### PR TITLE
feat(data-retention): Sentry Cron Monitor で不起動検知を有効化 (closes #36)

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -501,7 +501,7 @@ thread_persona_status 更新
 | -------------- | --------------------------------------- | ----------------------------------------------------------------- |
 | `*/5 * * * *`  | handleBroadcastCheck                    | 配信予約チェック（5分ごと）                                        |
 | `*/5 * * * *`  | handlePollCheck                         | 投票予約配信チェック（5分ごと）                                    |
-| `0 18 * * *`   | handlePersonaExtract → handleDataRetention | ペルソナ抽出 + 保管期間自動削除（毎日03:00 JST、順次実行）        |
+| `0 18 * * *`   | handlePersonaExtract → handleDataRetention | ペルソナ抽出 + 保管期間自動削除（毎日03:00 JST、順次実行。retention は Sentry Cron Monitor で不起動検知） |
 
 ### 保管期間自動削除
 

--- a/server/src/handlers/data-retention-handler.test.ts
+++ b/server/src/handlers/data-retention-handler.test.ts
@@ -1,4 +1,13 @@
+import * as Sentry from "@sentry/cloudflare";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const scope = { setLevel: vi.fn(), setTag: vi.fn() };
+
+vi.mock("@sentry/cloudflare", () => ({
+  withMonitor: vi.fn(async (_slug, callback) => callback()),
+  getCurrentScope: vi.fn(() => scope),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
 
 vi.mock("~/services/data-retention", () => ({
   runDataRetention: vi.fn(),
@@ -23,7 +32,7 @@ describe("handleDataRetention", () => {
     vi.clearAllMocks();
   });
 
-  it("正常系: runDataRetention を env つきで呼ぶ", async () => {
+  it("runDataRetention を env つきで呼ぶ", async () => {
     vi.mocked(runDataRetention).mockResolvedValue([]);
 
     await handleDataRetention(buildEvent(), env, ctx);
@@ -31,15 +40,18 @@ describe("handleDataRetention", () => {
     expect(runDataRetention).toHaveBeenCalledWith(env);
   });
 
-  it("結果をログに残して完了する", async () => {
+  it("削除件数とテーブル数を集計してログに残す", async () => {
     vi.mocked(runDataRetention).mockResolvedValue([
       { table: "mastra_messages", deletedCount: 3 },
       { table: "mastra_threads", deletedCount: 1 },
     ]);
 
-    await expect(
-      handleDataRetention(buildEvent(), env, ctx),
-    ).resolves.toBeUndefined();
+    await handleDataRetention(buildEvent(), env, ctx);
+
+    expect(Sentry.logger.info).toHaveBeenCalledWith(
+      "[DataRetention] Completed: 4 total rows deleted across 2 tables",
+      undefined,
+    );
   });
 
   it("失敗時は throw して Cron Trigger に再試行させる", async () => {
@@ -47,6 +59,35 @@ describe("handleDataRetention", () => {
 
     await expect(handleDataRetention(buildEvent(), env, ctx)).rejects.toThrow(
       "db",
+    );
+  });
+
+  it("Sentry Cron Monitor の data-retention slug と crontab schedule で wrap される", async () => {
+    vi.mocked(runDataRetention).mockResolvedValue([]);
+
+    await handleDataRetention(buildEvent(), env, ctx);
+
+    expect(Sentry.withMonitor).toHaveBeenCalledWith(
+      "data-retention",
+      expect.any(Function),
+      expect.objectContaining({
+        schedule: { type: "crontab", value: "0 18 * * *" },
+        timezone: "UTC",
+      }),
+    );
+  });
+
+  it("失敗時は scope に privacy_critical タグを付けてから throw する", async () => {
+    vi.mocked(runDataRetention).mockRejectedValue(new Error("db"));
+
+    await expect(handleDataRetention(buildEvent(), env, ctx)).rejects.toThrow(
+      "db",
+    );
+    expect(scope.setLevel).toHaveBeenCalledWith("fatal");
+    expect(scope.setTag).toHaveBeenCalledWith("privacy_critical", "true");
+    expect(scope.setTag).toHaveBeenCalledWith(
+      "component",
+      "data-retention-handler",
     );
   });
 });

--- a/server/src/handlers/data-retention-handler.ts
+++ b/server/src/handlers/data-retention-handler.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/cloudflare";
 import { logger } from "~/lib/logger";
 import { markPrivacyCriticalScope } from "~/lib/sentry-helpers";
 import { runDataRetention } from "~/services/data-retention";
@@ -5,14 +6,29 @@ import { runDataRetention } from "~/services/data-retention";
 export const handleDataRetention: ExportedHandlerScheduledHandler<
   CloudflareBindings
 > = async (_event, env, _ctx) => {
-  logger.info(`[DataRetention] Cron triggered at ${new Date().toISOString()}`);
-
   try {
-    const results = await runDataRetention(env);
-    const total = results.reduce((sum, r) => sum + r.deletedCount, 0);
+    await Sentry.withMonitor(
+      "data-retention",
+      async () => {
+        logger.info(
+          `[DataRetention] Cron triggered at ${new Date().toISOString()}`,
+        );
 
-    logger.info(
-      `[DataRetention] Completed: ${total} total rows deleted across ${results.length} tables`,
+        const results = await runDataRetention(env);
+        const total = results.reduce((sum, r) => sum + r.deletedCount, 0);
+
+        logger.info(
+          `[DataRetention] Completed: ${total} total rows deleted across ${results.length} tables`,
+        );
+      },
+      {
+        schedule: { type: "crontab", value: "0 18 * * *" },
+        timezone: "UTC",
+        // 同 cron で先行する handlePersonaExtract の処理時間を吸収する
+        checkinMargin: 30,
+        maxRuntime: 30,
+        failureIssueThreshold: 1,
+      },
     );
   } catch (error) {
     markPrivacyCriticalScope("data-retention-handler");


### PR DESCRIPTION
## Summary

- `handleDataRetention` を `Sentry.withMonitor("data-retention", ...)` で wrap し、Sentry Cron Monitor 経由で **Cron が起動しなかった場合** を検知する経路を追加した（#36 対応）。
- Monitor は初回 check-in 時に Sentry 側で auto-create されるため、Sentry UI 側での事前作成は不要。
- missed / failed / timeout は Sentry Issue として発火するため、既存 Issue Alert の経路（Slack 等）にそのまま乗る。

## 背景

`.brain/pii-log-review.md` および kayac/nepp-chan-biz#36 で議論された通り、Sentry の exception 検知は「実行中のエラー」しか拾えず、Cron Trigger が起動すらしないケースを観測できない。`mastra_messages` 等の自動削除が走らないと個情法第22条「遅滞ない消去」リスクになるため、不起動検知を補完する。

## 設計判断

- **schedule**: `0 18 * * *` (UTC) = 毎日 03:00 JST、wrangler.jsonc / scheduled-handler.ts の cron と一致させる
- **timezone**: `UTC`
- **checkinMargin**: `30` 分。同 cron で先行する `handlePersonaExtract`（全スレッド順次 LLM 処理）の処理時間を吸収する。実運用で false positive が出始めたら調整する想定
- **maxRuntime**: `30` 分
- **failureIssueThreshold**: `1`（privacy-critical なので即時通知）
- **try/catch を `withMonitor` の外側に置く**: `withMonitor` 内部は isolation scope なので、callback 内で `markPrivacyCriticalScope` を呼んでも外に伝播しない。外側で呼べば通常 scope に setTag され、`withSentry` の自動 capture でタグが反映される
- **`reportPrivacyCriticalError` を使わない**: 明示 capture すると `withSentry` の自動 capture と二重送信になるため、scope tagging + throw → 自動 capture に任せる #618 のパターンを維持

## Test plan

- [x] `pnpm --filter @nepp-chan/server test`: 894 通過
- [x] `pnpm lint`: clean
- [x] `codex review --base develop`: 指摘なし
- [ ] dev デプロイ後、ローカルから `curl "http://localhost:8787/__scheduled?cron=0+18+*+*+*"` で擬似発火 or 03:00 JST の初回 cron 発火を待つ
- [ ] Sentry UI の Crons メニュー（environment=development）で `data-retention` monitor が auto-create されていることを確認
- [ ] Monitor 詳細で schedule / timezone / grace period / max runtime / failure threshold が反映されていることを確認
- [ ] 既存 Issue Alert ルールが Cron Monitor の Issue を捕捉するか確認（必要なら専用ルール追加）
- [ ] prd デプロイ後、prd 環境でも auto-create 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)