### PR TITLE
refactor(logger): logger.error の Workers Logs 出力を serializeError 経由に揃えて PII 流出を防ぐ

### DIFF
--- a/server/src/lib/logger.test.ts
+++ b/server/src/lib/logger.test.ts
@@ -1,0 +1,74 @@
+import { HTTPFetchError } from "@line/bot-sdk";
+import * as Sentry from "@sentry/cloudflare";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "./logger";
+
+vi.mock("@sentry/cloudflare", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("logger.error", () => {
+  const consoleErrorSpy = vi
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleErrorSpy.mockClear();
+    vi.mocked(Sentry.logger.error).mockClear();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("Error の class field を Workers Logs に流さない", () => {
+    const error = new HTTPFetchError("400 - Bad Request", {
+      status: 400,
+      statusText: "Bad Request",
+      headers: new Headers({ authorization: "Bearer secret-token" }),
+      body: JSON.stringify({ message: "invalid", to: "U_LINE_USER_ID_RAW" }),
+    });
+
+    logger.error("LINE reply failed", error);
+
+    const [, attrs] = consoleErrorSpy.mock.calls[0];
+    expect(attrs).toEqual({
+      "error.type": "HTTPFetchError",
+      "error.message": "400 - Bad Request",
+    });
+  });
+
+  it("console.error と Sentry.logger.error に同一 payload を渡す", () => {
+    const error = new Error("boom");
+
+    logger.error("op failed", error, { threadId: "line-thread:abc" });
+
+    const expected = {
+      "error.type": "Error",
+      "error.message": "boom",
+      threadId: "line-thread:abc",
+    };
+    expect(consoleErrorSpy).toHaveBeenCalledWith("op failed", expected);
+    expect(Sentry.logger.error).toHaveBeenCalledWith("op failed", expected);
+  });
+
+  it("error が undefined でも attrs だけで動く", () => {
+    logger.error("just a message", undefined, { count: 3 });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("just a message", {
+      count: 3,
+    });
+  });
+
+  it("Error 以外の値は error.message に String 化される", () => {
+    logger.error("non-error", "string-error");
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith("non-error", {
+      "error.message": "string-error",
+    });
+  });
+});

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -20,7 +20,8 @@ export const logger = {
     Sentry.logger.warn(message, attrs);
   },
   error: (message: string, error?: unknown, attrs?: LogAttributes) => {
-    console.error(message, error ?? "");
-    Sentry.logger.error(message, { ...serializeError(error), ...attrs });
+    const merged = { ...serializeError(error), ...attrs };
+    console.error(message, merged);
+    Sentry.logger.error(message, merged);
   },
 } as const;

--- a/server/src/routes/admin/broadcast.ts
+++ b/server/src/routes/admin/broadcast.ts
@@ -392,10 +392,7 @@ broadcastAdminRoutes.openapi(sendRoute, async (c) => {
 
   const result = await sendBroadcast(c.env, id);
   if (!result.success) {
-    logger.error("[Broadcast] Failed to send broadcast", {
-      id,
-      error: result.error,
-    });
+    logger.error("[Broadcast] Failed to send broadcast", result.error, { id });
     throw new HTTPException(500, {
       message: "配信の送信に失敗しました",
     });


### PR DESCRIPTION
## Summary

- `lib/logger.ts` の `logger.error` 呼び出し時、`console.error(message, error ?? "")` で Error オブジェクト全体を Workers Logs に流していた経路を、Sentry 側と同じ `{...serializeError(error), ...attrs}` 形に揃えた。
- LINE SDK `HTTPFetchError.body` 等の class field 経由で PII（API レスポンス本文に含まれうる userId 等）が Workers Logs に流出する経路を構造的に閉じる。
- `routes/admin/broadcast.ts` で `logger.error` の第2引数に plain object（`{ id, error: result.error }`）を渡していた箇所を、`error` 引数と `attrs` に分離する形に修正（修正前は文脈情報がそのまま出ていたが、`serializeError` 経由化により `"[object Object]"` に潰れる回帰になるため）。

## 背景

`.brain/pii-log-review.md` の 🟡 Medium #5-12 で指摘した「`logger.error(message, error)` で error 第2引数経由の PII 混入リスク」への構造的対処。元々 Sentry 側は `serializeError` で `error.name + error.message` に絞っていたが、`console.error` 側は素の error を渡していたため、Workers Logs 側だけ無防備になっていた。

## Test plan

- [x] `pnpm --filter @nepp-chan/server test`: 全通過
- [x] `pnpm lint`: clean
- [x] `codex review --uncommitted`: P2 指摘 1 件（plain object 第2引数の回帰）→ broadcast.ts:395 を修正して取り込み済
- [ ] dev デプロイ後、Workers Logs で `logger.error` の出力形が `{"error.type": ..., "error.message": ...}` 形になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)