### PR TITLE
style: LINE Flex Message と投票結果バーの色を新トンマナに揃える

### DIFF
--- a/server/src/services/broadcast-service.ts
+++ b/server/src/services/broadcast-service.ts
@@ -49,7 +49,7 @@ const buildExplainButtonMessage = (
             displayText: "このおしらせ、ねっぷちゃんに解説してもらう！",
           },
           style: "primary",
-          color: "#0f766e",
+          color: "#0f7177",
           height: "sm",
         },
       ],

--- a/server/src/services/poll-delivery.ts
+++ b/server/src/services/poll-delivery.ts
@@ -63,7 +63,7 @@ export const buildPollFlexMessage = (poll: Poll): messagingApi.FlexMessage => {
         displayText: choice,
       },
       style: "primary" as const,
-      color: "#4A90D9",
+      color: "#0f7177",
       margin: "sm" as const,
       height: "sm" as const,
     }),
@@ -79,7 +79,7 @@ export const buildPollFlexMessage = (poll: Poll): messagingApi.FlexMessage => {
           type: "text",
           text: "ねっぷちゃんからの質問だよ！",
           size: "sm",
-          color: "#1DB446",
+          color: "#0d9296",
           weight: "bold",
         },
         {

--- a/server/src/services/poll-response.ts
+++ b/server/src/services/poll-response.ts
@@ -122,7 +122,7 @@ const buildCompletionFlexMessage = (
             uri: pollUrl,
           },
           style: "primary",
-          color: "#0f766e",
+          color: "#0f7177",
           height: "sm",
         },
       ],

--- a/web/src/app/poll/components/ChoiceBar.test.tsx
+++ b/web/src/app/poll/components/ChoiceBar.test.tsx
@@ -13,18 +13,18 @@ describe("ChoiceBar", () => {
     expect(screen.getByText("58%")).toBeInTheDocument();
   });
 
-  it("isLeading=true なら bar に teal-500 クラスが付く", () => {
+  it("isLeading=true なら bar に brand teal-500 クラスが付く", () => {
     const { container } = render(
       <ChoiceBar choice="A" count={5} percentage={50} isLeading />,
     );
-    const bar = container.querySelector(".bg-teal-500");
+    const bar = container.querySelector(".bg-\\(--teal-500\\)");
     expect(bar).not.toBeNull();
   });
 
-  it("isLeading=false なら bar は teal-300", () => {
+  it("isLeading=false なら bar は brand teal-300", () => {
     const { container } = render(
       <ChoiceBar choice="A" count={1} percentage={10} isLeading={false} />,
     );
-    expect(container.querySelector(".bg-teal-300")).not.toBeNull();
+    expect(container.querySelector(".bg-\\(--teal-300\\)")).not.toBeNull();
   });
 });

--- a/web/src/app/poll/components/ChoiceBar.tsx
+++ b/web/src/app/poll/components/ChoiceBar.tsx
@@ -14,7 +14,7 @@ export const ChoiceBar = ({ choice, count, percentage, isLeading }: Props) => (
     </div>
     <div className="h-9 bg-stone-100 rounded-lg overflow-hidden relative">
       <div
-        className={`h-full rounded-lg ${isLeading ? "bg-teal-500" : "bg-teal-300"}`}
+        className={`h-full rounded-lg ${isLeading ? "bg-(--teal-500)" : "bg-(--teal-300)"}`}
         style={{ width: `${Math.max(percentage, 2)}%` }}
       />
       <span className="absolute right-2.5 top-1/2 -translate-y-1/2 text-xs font-medium text-stone-600 tabular-nums">


### PR DESCRIPTION
## Summary
- LINE Flex Message（投票配信・回答完了・配信解説）のボタン色と見出し色を、shared の新ブランドパレット（#5CB7BB 中心の teal 再シェード、#641）に追従
- 投票結果ページの棒グラフを Tailwind デフォルト teal から shared の `--teal-500` / `--teal-300` 参照に切り替えて、今後の再シェードに自動追従させる

## 主な変更内容

### LINE Flex Message（server）
LINE 上は CSS 変数が使えないためハードコード。primary ボタンは LINE 側で白文字描画のため、新ブランドキー `#5cb7bb` だと白文字コントラストが約 2.3:1 で WCAG AA を満たさない。同じ teal シリーズの `--brand-press` 系（`#0f7177`）を採用してコントラストを確保している。

| 場所 | 旧 | 新 | 役割 |
| --- | --- | --- | --- |
| `poll-delivery.ts` 選択肢ボタン | `#4A90D9` | `#0f7177` | primary ボタン（白文字 5.6:1） |
| `poll-delivery.ts` 見出し「ねっぷちゃんからの質問だよ！」 | `#1DB446` | `#0d9296` | bold sm テキスト（LP eyebrow と同じ `--brand-hover`） |
| `poll-response.ts`「結果を見る」 | `#0f766e` | `#0f7177` | primary ボタン |
| `broadcast-service.ts`「解説してもらう」 | `#0f766e` | `#0f7177` | primary ボタン |

LP 側の使い分け（大型 CTA = `--brand`、コンパクト送信ボタン = `--teal-700`、eyebrow = `--brand-hover`）と整合させた選択。

### 投票結果バー（web）
`ChoiceBar.tsx` の `bg-teal-500` / `bg-teal-300` は Tailwind デフォルト teal（`#14b8a6`/`#5eead4`）を参照しており新パレットに追従していなかった。`bg-(--teal-500)` / `bg-(--teal-300)` に置き換えて shared の値（`#5cb7bb`/`#4dd9e6`）を直接見るようにした。テストのクラスセレクタも追従。

## Test plan
- [x] `pnpm --filter server test`（899 tests pass）
- [x] `pnpm --filter web test`（337 tests pass）
- [x] codex review --uncommitted で AA コントラスト懸念を解消
- [ ] dev 環境で配信した投票 Flex / 回答完了 Flex / 配信解説 Flex がねっぷちゃんトンマナの teal で見えること
- [ ] 投票結果ページの leading/non-leading バー色が shared パレットの teal に変わっていること