### PR TITLE
feat(lp): LINE 友達追加ボタンを公式アカウント URL に反映

### DIFF
--- a/lp/src/components/lp/FinalCTA.tsx
+++ b/lp/src/components/lp/FinalCTA.tsx
@@ -1,5 +1,5 @@
 import { MessageCircleIcon } from "lucide-react";
-import { WEB_URL } from "~/constants/urls";
+import { LINE_FRIEND_URL, WEB_URL } from "~/constants/urls";
 import { useScrollReveal } from "~/hooks/useScrollReveal";
 import { LineIcon } from "./LineIcon";
 
@@ -29,9 +29,10 @@ export const FinalCTA = () => {
             <MessageCircleIcon className="size-4" aria-hidden="true" />
             Web版でいますぐ話しかける
           </a>
-          {/* TODO: LINE 公式アカウント URL 確定後、href を実 URL に差し替え (#541) */}
           <a
-            href="#line"
+            href={LINE_FRIEND_URL}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-(--r-pill) bg-[#06c755] px-6 py-3.5 text-sm font-bold text-white shadow-[0_6px_16px_rgba(6,199,85,0.22)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-[#05b048] hover:shadow-[0_10px_24px_rgba(6,199,85,0.36)]"
           >
             <LineIcon size={20} />

--- a/lp/src/components/lp/FooterSection.tsx
+++ b/lp/src/components/lp/FooterSection.tsx
@@ -1,5 +1,5 @@
 import { MailIcon } from "lucide-react";
-import { WEB_URL } from "~/constants/urls";
+import { LINE_FRIEND_URL, WEB_URL } from "~/constants/urls";
 
 export const FooterSection = () => (
   <footer className="border-t border-(--paper-200) bg-(--paper-100)/40 px-7 pb-10 pt-16">
@@ -42,7 +42,9 @@ export const FooterSection = () => (
           </li>
           <li>
             <a
-              href="#line"
+              href={LINE_FRIEND_URL}
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-(--fg-2) transition-colors hover:text-(--brand)"
             >
               LINEで友達追加

--- a/lp/src/components/lp/Hero.tsx
+++ b/lp/src/components/lp/Hero.tsx
@@ -1,5 +1,5 @@
 import { MessageSquareIcon } from "lucide-react";
-import { WEB_URL } from "~/constants/urls";
+import { LINE_FRIEND_URL, WEB_URL } from "~/constants/urls";
 import { useScrollReveal } from "~/hooks/useScrollReveal";
 import { LineIcon } from "./LineIcon";
 import { MiniChat } from "./MiniChat";
@@ -51,7 +51,9 @@ export const Hero = () => {
               いますぐ話しかける
             </a>
             <a
-              href="#line"
+              href={LINE_FRIEND_URL}
+              target="_blank"
+              rel="noopener noreferrer"
               className="flex items-center justify-center gap-2 rounded-(--r-pill) bg-[#06c755] px-6 py-3.5 text-sm font-bold text-white shadow-[0_6px_16px_rgba(6,199,85,0.22)] transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)] hover:-translate-y-0.5 hover:bg-[#05b048] hover:shadow-[0_10px_24px_rgba(6,199,85,0.36)]"
             >
               <LineIcon size={20} />

--- a/lp/src/components/lp/Line.tsx
+++ b/lp/src/components/lp/Line.tsx
@@ -1,3 +1,4 @@
+import { LINE_FRIEND_URL } from "~/constants/urls";
 import { useScrollReveal } from "~/hooks/useScrollReveal";
 import { LineIcon } from "./LineIcon";
 
@@ -34,16 +35,16 @@ export const Line = () => {
         <p className="mt-3 text-base leading-[1.85] text-(--fg-2)">
           LINEのお友達に追加するだけで、いつでもねっぷちゃんとお話しできます。村の最新情報やお知らせもお届けするよ！
         </p>
-        {/* LINE 公式アカウント URL は別 Issue で確定するため暫定で button + alert に */}
         <div className="mt-6 flex justify-center md:justify-start">
-          <button
-            type="button"
-            onClick={() => window.alert("LINE公式アカウントは準備中です")}
+          <a
+            href={LINE_FRIEND_URL}
+            target="_blank"
+            rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-(--r-pill) bg-[#06c755] px-6 py-3.5 text-sm font-bold text-white shadow-[0_6px_16px_rgba(6,199,85,0.22)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-[#05b048] hover:shadow-[0_10px_24px_rgba(6,199,85,0.36)]"
           >
             <LineIcon size={20} />
             LINE友達追加はこちら
-          </button>
+          </a>
         </div>
       </div>
 

--- a/lp/src/constants/urls.ts
+++ b/lp/src/constants/urls.ts
@@ -1,2 +1,3 @@
 export const API_URL = import.meta.env.PUBLIC_API_URL || "";
 export const WEB_URL = import.meta.env.PUBLIC_WEB_URL || "/";
+export const LINE_FRIEND_URL = "https://lin.ee/V6GYbOrL";


### PR DESCRIPTION
## Summary
- LP の LINE 友達追加導線（Hero / FinalCTA / FooterSection / Line）の `href` を実 URL（`https://lin.ee/V6GYbOrL`）に反映
- 外部リンクとして `target="_blank"` `rel="noopener noreferrer"` を付与
- Line セクション内の暫定 alert ボタンを実リンクに置換
- `LINE_FRIEND_URL` 定数を `lp/src/constants/urls.ts` に追加

## 主な変更内容
- `lp/src/constants/urls.ts`: `LINE_FRIEND_URL` を追加
- `lp/src/components/lp/Hero.tsx`, `FinalCTA.tsx`, `FooterSection.tsx`: `href="#line"` → `LINE_FRIEND_URL`
- `lp/src/components/lp/Line.tsx`: `<button onClick={alert}>` → `<a href={LINE_FRIEND_URL}>` に置換、暫定コメントを削除

## Test plan
- [ ] LP の各 CTA から LINE 友達追加 URL（lin.ee/V6GYbOrL）に遷移する
- [ ] 新規タブで開き、referrer がリーク（鎖断）されている
- [ ] dev / prd 両環境で導線が正しく動作する