### PR TITLE
fix(server): 旧 admin JWT による /threads などの 500 を防ぐ

### DIFF
--- a/server/src/middleware/auth.test.ts
+++ b/server/src/middleware/auth.test.ts
@@ -94,8 +94,9 @@ describe("requireAuth", () => {
   });
 
   it("有効な Admin opaque session で principal がセットされる", async () => {
+    const opaqueToken = "a".repeat(64);
     vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
-      token: "valid-jwt-token",
+      token: opaqueToken,
       userId: "user-1",
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
       createdAt: "2024-01-01T00:00:00Z",
@@ -105,7 +106,7 @@ describe("requireAuth", () => {
     const app = createApp();
     const req = new Request("http://localhost/protected", {
       headers: {
-        Authorization: "Bearer valid-jwt-token",
+        Authorization: `Bearer ${opaqueToken}`,
       },
     });
 

--- a/server/src/middleware/require-role.test.ts
+++ b/server/src/middleware/require-role.test.ts
@@ -58,7 +58,7 @@ describe("requireRole ミドルウェア", () => {
 
   const setupAdminSession = (role: string) => {
     vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
-      token: "valid-token",
+      token: "a".repeat(64),
       userId: "user-1",
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
       createdAt: "2024-01-01T00:00:00Z",
@@ -67,7 +67,7 @@ describe("requireRole ミドルウェア", () => {
   };
 
   // biome-ignore lint/suspicious/noExplicitAny: テスト用ヘルパーのため型制約を緩和
-  const requestWith = (app: Hono<any>, token = "valid-token") =>
+  const requestWith = (app: Hono<any>, token = "a".repeat(64)) =>
     app.request(
       new Request("http://localhost/test", {
         headers: { Authorization: `Bearer ${token}` },

--- a/server/src/middleware/resolve-principal.test.ts
+++ b/server/src/middleware/resolve-principal.test.ts
@@ -74,9 +74,11 @@ describe("resolvePrincipal", () => {
     expect(body.principal).toBeNull();
   });
 
+  const validOpaqueToken = "a".repeat(64);
+
   it("Admin opaque session → AdminPrincipal", async () => {
     vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
-      token: "valid-admin-token",
+      token: validOpaqueToken,
       userId: "user-1",
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
       createdAt: "2024-01-01T00:00:00Z",
@@ -84,7 +86,7 @@ describe("resolvePrincipal", () => {
     vi.mocked(adminUserRepository.findById).mockResolvedValue(testUser);
 
     const req = new Request("http://localhost/test", {
-      headers: { Authorization: "Bearer valid-admin-token" },
+      headers: { Authorization: `Bearer ${validOpaqueToken}` },
     });
     const res = await createApp().request(req, {}, mockEnv);
 
@@ -123,7 +125,7 @@ describe("resolvePrincipal", () => {
 
   it("Admin opaque session が優先される", async () => {
     vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
-      token: "admin-token",
+      token: validOpaqueToken,
       userId: "user-1",
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
       createdAt: "2024-01-01T00:00:00Z",
@@ -131,7 +133,7 @@ describe("resolvePrincipal", () => {
     vi.mocked(adminUserRepository.findById).mockResolvedValue(testUser);
 
     const req = new Request("http://localhost/test", {
-      headers: { Authorization: "Bearer admin-token" },
+      headers: { Authorization: `Bearer ${validOpaqueToken}` },
     });
     const res = await createApp().request(req, {}, mockEnv);
 
@@ -148,11 +150,33 @@ describe("resolvePrincipal", () => {
     );
 
     const req = new Request("http://localhost/test", {
-      headers: { Authorization: "Bearer invalid-token" },
+      headers: { Authorization: `Bearer ${validOpaqueToken}` },
     });
     const res = await createApp().request(req, {}, mockEnv);
 
     expect(res.status).toBe(200);
+    const body = (await res.json()) as TestResponse;
+    expect(body.principal).toBeNull();
+  });
+
+  it("opaque 形式でないトークンは admin DB を引かない（旧 JWT を含む不正トークン耐性）", async () => {
+    vi.mocked(sessionService.verifyAnonymousToken).mockRejectedValue(
+      new Error("invalid"),
+    );
+
+    const legacyJwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ4In0.signature";
+    const req = new Request("http://localhost/test", {
+      headers: { Authorization: `Bearer ${legacyJwt}` },
+    });
+    const res = await createApp().request(req, {}, mockEnv);
+
+    expect(res.status).toBe(200);
+    expect(adminSessionRepository.findValid).not.toHaveBeenCalled();
+    expect(sessionService.verifyAnonymousToken).toHaveBeenCalledWith(
+      legacyJwt,
+      "test-secret-32-chars-long-enough",
+    );
     const body = (await res.json()) as TestResponse;
     expect(body.principal).toBeNull();
   });

--- a/server/src/middleware/resolve-principal.ts
+++ b/server/src/middleware/resolve-principal.ts
@@ -7,6 +7,8 @@ import { adminUserRepository } from "~/repository/admin-user-repository";
 import { adminRoleSchema } from "~/schemas/auth-schema";
 import { verifyAnonymousToken } from "~/services/auth/anonymous-session";
 
+const OPAQUE_SESSION_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+
 export const resolvePrincipal = createMiddleware<{
   Bindings: CloudflareBindings;
   Variables: Partial<PrincipalVariables>;
@@ -18,7 +20,9 @@ export const resolvePrincipal = createMiddleware<{
   }
 
   // opaque session を試行（admin）
-  const session = await adminSessionRepository.findValid(c.env.DB, token);
+  const session = OPAQUE_SESSION_TOKEN_PATTERN.test(token)
+    ? await adminSessionRepository.findValid(c.env.DB, token)
+    : undefined;
   if (session) {
     const user = await adminUserRepository.findById(c.env.DB, session.userId);
     if (user) {

--- a/server/src/routes/admin/broadcast.test.ts
+++ b/server/src/routes/admin/broadcast.test.ts
@@ -47,7 +47,7 @@ import { withResolvePrincipal } from "~/__tests__/helpers/test-app";
 
 const routes = await withResolvePrincipal(rawRoutes);
 
-const TOKEN = "admin-token";
+const TOKEN = "a".repeat(64);
 const adminUser = {
   id: "u-1",
   username: "admin01",

--- a/server/src/routes/admin/emergency.test.ts
+++ b/server/src/routes/admin/emergency.test.ts
@@ -43,8 +43,8 @@ const mockEnv = {
   JWT_SECRET: "test-secret-32-chars-long-enough",
 } as unknown as CloudflareBindings;
 
-const ADMIN_TOKEN = "admin-session-token";
-const STAFF_TOKEN = "staff-session-token";
+const ADMIN_TOKEN = "a".repeat(64);
+const STAFF_TOKEN = "b".repeat(64);
 const ANON_TOKEN = "anonymous-jwt";
 
 const adminUser = {

--- a/server/src/routes/admin/feedback.test.ts
+++ b/server/src/routes/admin/feedback.test.ts
@@ -42,7 +42,7 @@ const mockEnv = {
   JWT_SECRET: "test-secret-32-chars-long-enough",
 } as unknown as CloudflareBindings;
 
-const ADMIN_TOKEN = "admin-token";
+const ADMIN_TOKEN = "a".repeat(64);
 
 const adminUser = {
   id: "u-1",

--- a/server/src/routes/admin/invitations.test.ts
+++ b/server/src/routes/admin/invitations.test.ts
@@ -40,7 +40,7 @@ import { withResolvePrincipal } from "~/__tests__/helpers/test-app";
 
 const routes = await withResolvePrincipal(rawRoutes);
 
-const TOKEN = "admin-token";
+const TOKEN = "a".repeat(64);
 const adminUser = {
   id: "u-1",
   username: "admin01",

--- a/server/src/routes/admin/knowledge/index.test.ts
+++ b/server/src/routes/admin/knowledge/index.test.ts
@@ -66,9 +66,11 @@ const mockEnv = {
   JWT_SECRET: "test-secret-32-chars-long-enough",
 } as unknown as CloudflareBindings;
 
+const VALID_OPAQUE_TOKEN = "a".repeat(64);
+
 const authedRequest = (path: string, init?: RequestInit) => {
   const req = new Request(`http://localhost${path}`, init);
-  req.headers.set("Authorization", "Bearer valid-token");
+  req.headers.set("Authorization", `Bearer ${VALID_OPAQUE_TOKEN}`);
   return req;
 };
 
@@ -103,7 +105,7 @@ describe("knowledge routes 統合テスト", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
-      token: "valid-token",
+      token: VALID_OPAQUE_TOKEN,
       userId: "user-1",
       expiresAt: new Date(Date.now() + 86400000).toISOString(),
       createdAt: "2024-01-01T00:00:00Z",

--- a/server/src/routes/admin/persona.test.ts
+++ b/server/src/routes/admin/persona.test.ts
@@ -41,7 +41,7 @@ const mockEnv = {
   JWT_SECRET: "test-secret-32-chars-long-enough",
 } as unknown as CloudflareBindings;
 
-const ADMIN_TOKEN = "admin-token";
+const ADMIN_TOKEN = "a".repeat(64);
 
 const adminUser = {
   id: "u-1",

--- a/server/src/routes/admin/poll.test.ts
+++ b/server/src/routes/admin/poll.test.ts
@@ -52,7 +52,7 @@ import { withResolvePrincipal } from "~/__tests__/helpers/test-app";
 
 const routes = await withResolvePrincipal(rawRoutes);
 
-const TOKEN = "admin-token";
+const TOKEN = "a".repeat(64);
 const adminUser = {
   id: "u-1",
   username: "admin01",

--- a/server/src/routes/auth.test.ts
+++ b/server/src/routes/auth.test.ts
@@ -398,8 +398,9 @@ describe("auth routes", () => {
 
   describe("GET /me", () => {
     it("有効な opaque session でユーザー情報を返す", async () => {
+      const opaqueToken = "a".repeat(64);
       vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
-        token: "valid-token",
+        token: opaqueToken,
         userId: "user-1",
         expiresAt: new Date(Date.now() + 86400000).toISOString(),
         createdAt: "2024-01-01T00:00:00Z",
@@ -408,7 +409,7 @@ describe("auth routes", () => {
 
       const res = await authRoutes.request(
         new Request("http://localhost/me", {
-          headers: { Authorization: "Bearer valid-token" },
+          headers: { Authorization: `Bearer ${opaqueToken}` },
         }),
         undefined,
         mockEnv,

--- a/web/src/lib/auth-token.ts
+++ b/web/src/lib/auth-token.ts
@@ -25,7 +25,7 @@ export const removeSessionToken = () => {
   localStorage.removeItem(SESSION_TOKEN_KEY);
 };
 
-/** Authorization: Bearer に送るトークンを取得。admin JWT を優先。 */
+/** Authorization: Bearer に送るトークンを取得。admin token を優先。 */
 export const getBearerToken = () => {
   return getAuthToken() ?? getSessionToken();
 };


### PR DESCRIPTION
## Summary
- 旧 admin JWT を localStorage に保持したクライアントが `/threads` などにアクセスすると D1 が `Failed query` を返し、middleware で未捕捉のまま 500 になっていた問題のホットフィックス
- `resolvePrincipal` で opaque session token 形式（64 文字 hex）にマッチするときだけ `adminSessionRepository.findValid` を呼ぶように変更
- リグレッションテスト追加 + 既存テストフィクスチャの opaque token を実形式に揃える

## 背景

2026-04-13 に admin 認証を JWT → opaque session に移行（`refactor(server): admin 認証を JWT から opaque session に移行`）。
旧 JWT を保持し続けているクライアント（admin web の localStorage 残留）が Authorization ヘッダーで JWT を送ると、`resolvePrincipal` 内の `adminSessionRepository.findValid` が PRIMARY KEY 検索に JWT を渡し、D1 が `Failed query` を返していた。これが middleware で catch されないため `app.onError` → 500 として返っていた。

エラーログ例：
```
Failed query: select "token", "user_id", "expires_at", "created_at" from "admin_sessions"
where ("admin_sessions"."token" = ? and "admin_sessions"."expires_at" > ?)
params: eyJhbGciOiJIUzI1NiIs..., 2026-05-21T14:42:06.180Z
```

## 主な変更

### 1. opaque token 形式チェックの追加（`server/src/middleware/resolve-principal.ts`）

`generateToken()` の出力（32 byte hex = 64 文字）と一致する形式のときだけ DB を引く。

```ts
const OPAQUE_SESSION_TOKEN_PATTERN = /^[0-9a-f]{64}$/;

const session = OPAQUE_SESSION_TOKEN_PATTERN.test(token)
  ? await adminSessionRepository.findValid(c.env.DB, token)
  : undefined;
```

### 2. リグレッションテスト追加（`resolve-principal.test.ts`）

「opaque 形式でないトークンは admin DB を引かない」を assert。

### 3. 既存 admin 認証テスト 10 ファイル

opaque token のテスト用リテラル（`"admin-token"` 等）を `"a".repeat(64)` 等の 64 文字 hex に揃える。

### 4. `web/src/lib/auth-token.ts`

`getBearerToken` のコメント `admin JWT を優先` を opaque token 移行に合わせて `admin token を優先` に修正。

## 修正後の挙動

| ケース | 旧挙動 | 新挙動 |
|--------|--------|--------|
| 旧 JWT で `/threads` 等の保護ルート | **500（Failed query）** | **401**（middleware 素通り → requireAuth）。クライアントの `handleUnauthorized` が `removeAuthToken()` で旧トークンを自動掃除 |
| 旧 JWT で `/auth/me` | 500 | 200 + `user: null`（AuthContext が未認証扱いでログイン画面へ誘導） |
| 正しい opaque token | 200 | 200（変化なし） |
| anonymous JWT | 200 | 200（変化なし） |

クライアント側（`web/src/lib/api/client.ts` の `handleUnauthorized`）は元から 401 受信時に admin token を破棄して anonymous session に切り替える実装になっているため、追加の web 側修正は不要。

## Test plan

- [x] `pnpm --filter @nepp-chan/server test` 全パス（99 files / 901 tests）
- [x] `pnpm --filter @nepp-chan/server exec tsc --noEmit` エラーなし
- [x] `pnpm exec biome check server/src` エラーなし
- [x] `codex review --uncommitted` で「明確な破壊的問題は見当たりません」判定
- [ ] dev デプロイ後、旧 JWT を localStorage に手動投入したブラウザで `/threads` GET が 401 を返すこと（500 でないこと）を確認
- [ ] 同状態で dashboard を開いた際にログイン画面へ誘導されること
- [ ] 正常な admin ログインフロー（login → /auth/me が 200 + user オブジェクトを返す）に回帰がないこと

## 本番反映フロー

本ホットフィックスはマージ後の通常フロー（tagpr 経由の patch バンプ → 本番デプロイ）で反映する想定。緊急度が高ければ tagpr の PR マージを早める運用で対応可能。