### PR TITLE
chore: dev LP のドメインを dev.nepp-chan.ai に統一 + README 更新

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -61,7 +61,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PUBLIC_API_URL: https://dev-api.nepp-chan.ai
-          PUBLIC_LP_URL: https://dev-lp.nepp-chan.ai
+          PUBLIC_LP_URL: https://dev.nepp-chan.ai
           PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_WEB }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT_WEB: ${{ secrets.SENTRY_PROJECT_WEB }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ wrangler secret put GOOGLE_GENERATIVE_AI_API_KEY
 | 環境 | LP | Web | API |
 | ---- | --- | --- | --- |
 | ローカル | http://localhost:5174 | http://localhost:5173 | http://localhost:8787 |
-| dev | https://dev-lp.nepp-chan.ai | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
+| dev | https://dev.nepp-chan.ai | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
 | prd | https://nepp-chan.ai | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
 
 ## テスト

--- a/README.en.md
+++ b/README.en.md
@@ -108,46 +108,20 @@ pnpm db:migrate:local
 ## Development
 
 ```bash
-# Start API server (http://localhost:8787)
-pnpm server:dev
-
-# Start Web dev server (http://localhost:5173)
-pnpm web:dev
-
-# Start LP dev server (http://localhost:5174)
-pnpm lp:dev
-
-# Start Mastra Playground
-pnpm mastra:dev
+pnpm server:dev   # API
+pnpm web:dev      # Web
+pnpm lp:dev       # LP
+pnpm mastra:dev   # Mastra Playground
 ```
 
-## Deployment
+See [CLAUDE.md](CLAUDE.md) for local/dev URLs and detailed commands.
 
-### Environments
+## Production
 
-| Environment | Trigger | LP | Web | API |
-|-------------|---------|----|-----|-----|
-| Local | - | http://localhost:5174 | http://localhost:5173 | http://localhost:8787 |
-| dev | `develop` push | https://dev.nepp-chan.ai | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
-| prd | `v*` tag (tagpr) | https://nepp-chan.ai | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
+| | URL |
+| --- | --- |
+| LP | https://nepp-chan.ai |
+| Web | https://web.nepp-chan.ai |
+| API | https://api.nepp-chan.ai |
 
-### Manual Deployment
-
-```bash
-# dev environment
-pnpm server:deploy:dev
-pnpm web:deploy:dev
-pnpm lp:deploy:dev
-
-# prd environment
-pnpm server:deploy:prd
-pnpm web:deploy:prd
-pnpm lp:deploy:prd
-```
-
-### CI/CD
-
-Automatic deployment via GitHub Actions:
-- Push to `develop` → CI (lint + test) + dev deployment
-- Push to `develop` → tagpr creates version bump PR automatically
-- Merge version bump PR → tag + GitHub Release → prd deployment
+Merging into `develop` triggers CI, and [tagpr](https://github.com/Songmu/tagpr) automatically opens a version bump PR. Merging the bump PR creates a tag + GitHub Release + production deployment.

--- a/README.en.md
+++ b/README.en.md
@@ -3,7 +3,8 @@
 **AI Deputy Mayor for Otoineppu Village**
 
 [![AGPLv3 License](https://img.shields.io/badge/License-AGPLv3-blue.svg?style=for-the-badge)](LICENSE)
-[![Website](https://img.shields.io/badge/Website-nepp--chan.ai-blue?style=for-the-badge)](https://web.nepp-chan.ai)
+[![Website](https://img.shields.io/badge/Website-nepp--chan.ai-blue?style=for-the-badge)](https://nepp-chan.ai)
+[![Chat](https://img.shields.io/badge/Chat-web.nepp--chan.ai-blue?style=for-the-badge)](https://web.nepp-chan.ai)
 
 A chat application where you can talk with "Nepp-chan," the AI Deputy Mayor of Otoineppu Village, Hokkaido. By learning directly from village-specific official documents to local culture, Nepp-chan delivers natural conversations with a deep understanding of local nicknames, shops, winter snow removal, community events, and other contexts unique to Otoineppu.
 
@@ -11,7 +12,7 @@ In Otoineppu Village, we are experimenting with a world where AI is embraced not
 
 This is an **Open R&D** initiative that fully discloses the development process, serving as a model case for municipalities nationwide to introduce AI-based resident support at low cost.
 
-[Website](https://web.nepp-chan.ai) · [Getting Started](#getting-started) · [Roadmap](#roadmap) · [日本語](README.md)
+[Website](https://nepp-chan.ai) · [Chat](https://web.nepp-chan.ai) · [Getting Started](#getting-started) · [Roadmap](#roadmap) · [日本語](README.md)
 
 ---
 
@@ -54,11 +55,13 @@ To ensure no one is left behind — including those unfamiliar with digital tech
 
 ## Project Structure
 
-| Directory                   | Description                                 |
-| --------------------------- | ------------------------------------------- |
-| [server/](server/README.md) | Backend API (Cloudflare Workers)            |
-| [web/](web/README.md)       | Frontend Web (Cloudflare Pages)             |
-| knowledge/                  | Knowledge files for RAG                     |
+| Directory                   | Description                                       |
+| --------------------------- | ------------------------------------------------- |
+| [server/](server/README.md) | Backend API (Cloudflare Workers)                  |
+| [web/](web/README.md)       | Chat web app (Cloudflare Pages)                   |
+| lp/                         | Landing page (Cloudflare Pages)                   |
+| shared/                     | Shared TypeScript package for web / lp / server   |
+| knowledge/                  | Knowledge files for RAG                           |
 
 ## Getting Started
 
@@ -79,14 +82,18 @@ pnpm install
 Copy `.env.example` to create `.env` files.
 
 ```bash
+# root (for knowledge upload scripts)
+cp .env.example .env
+
 # server
 cp server/.env.example server/.env
-cp server/.env.example server/.env.production
 cp server/.dev.vars.example server/.dev.vars
 
 # web
 cp web/.env.example web/.env
-cp web/.env.example web/.env.production
+
+# lp
+cp lp/.env.example lp/.env
 ```
 
 Set appropriate values in each `.env` file.
@@ -95,18 +102,20 @@ Set appropriate values in each `.env` file.
 
 ```bash
 # Development (apply migrations)
-cd server
 pnpm db:migrate:local
 ```
 
 ## Development
 
 ```bash
-# Start API server
+# Start API server (http://localhost:8787)
 pnpm server:dev
 
-# Start Web dev server
+# Start Web dev server (http://localhost:5173)
 pnpm web:dev
+
+# Start LP dev server (http://localhost:5174)
+pnpm lp:dev
 
 # Start Mastra Playground
 pnpm mastra:dev
@@ -116,11 +125,11 @@ pnpm mastra:dev
 
 ### Environments
 
-| Environment | Trigger | Web URL | API URL |
-|-------------|---------|---------|---------|
-| Local | - | http://localhost:5173 | http://localhost:8787 |
-| dev | develop push | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
-| prd | `v*` tag (tagpr) | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
+| Environment | Trigger | LP | Web | API |
+|-------------|---------|----|-----|-----|
+| Local | - | http://localhost:5174 | http://localhost:5173 | http://localhost:8787 |
+| dev | `develop` push | https://dev.nepp-chan.ai | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
+| prd | `v*` tag (tagpr) | https://nepp-chan.ai | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
 
 ### Manual Deployment
 
@@ -128,10 +137,12 @@ pnpm mastra:dev
 # dev environment
 pnpm server:deploy:dev
 pnpm web:deploy:dev
+pnpm lp:deploy:dev
 
 # prd environment
 pnpm server:deploy:prd
 pnpm web:deploy:prd
+pnpm lp:deploy:prd
 ```
 
 ### CI/CD

--- a/README.md
+++ b/README.md
@@ -108,46 +108,20 @@ pnpm db:migrate:local
 ## 開発
 
 ```bash
-# API サーバー起動（http://localhost:8787）
-pnpm server:dev
-
-# Web 開発サーバー起動（http://localhost:5173）
-pnpm web:dev
-
-# LP 開発サーバー起動（http://localhost:5174）
-pnpm lp:dev
-
-# Mastra Playground 起動
-pnpm mastra:dev
+pnpm server:dev   # API
+pnpm web:dev      # Web
+pnpm lp:dev       # LP
+pnpm mastra:dev   # Mastra Playground
 ```
 
-## デプロイ
+開発・dev 環境の URL、各種コマンドの詳細は [CLAUDE.md](CLAUDE.md) を参照してください。
 
-### 環境構成
+## 本番環境
 
-| 環境 | トリガー | LP | Web | API |
-|------|----------|----|-----|-----|
-| ローカル | - | http://localhost:5174 | http://localhost:5173 | http://localhost:8787 |
-| dev | `develop` push | https://dev.nepp-chan.ai | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
-| prd | `v*` タグ（tagpr） | https://nepp-chan.ai | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
+| | URL |
+| --- | --- |
+| LP | https://nepp-chan.ai |
+| Web | https://web.nepp-chan.ai |
+| API | https://api.nepp-chan.ai |
 
-### 手動デプロイ
-
-```bash
-# dev 環境
-pnpm server:deploy:dev
-pnpm web:deploy:dev
-pnpm lp:deploy:dev
-
-# prd 環境
-pnpm server:deploy:prd
-pnpm web:deploy:prd
-pnpm lp:deploy:prd
-```
-
-### CI/CD
-
-GitHub Actions で自動デプロイ:
-- `develop` push → CI（lint + test）+ dev 環境デプロイ
-- `develop` push → tagpr がバージョンバンプ PR を自動作成
-- バージョンバンプ PR マージ → タグ + GitHub Release → prd 環境デプロイ
+`develop` への merge で CI が走り、[tagpr](https://github.com/Songmu/tagpr) がバージョンバンプ PR を自動作成。バンプ PR をマージするとタグ + GitHub Release + 本番デプロイが連動します。

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 **音威子府村 AI 副村長**
 
 [![AGPLv3 License](https://img.shields.io/badge/License-AGPLv3-blue.svg?style=for-the-badge)](LICENSE)
-[![Website](https://img.shields.io/badge/Website-nepp--chan.ai-blue?style=for-the-badge)](https://web.nepp-chan.ai)
+[![Website](https://img.shields.io/badge/Website-nepp--chan.ai-blue?style=for-the-badge)](https://nepp-chan.ai)
+[![Chat](https://img.shields.io/badge/Chat-web.nepp--chan.ai-blue?style=for-the-badge)](https://web.nepp-chan.ai)
 
 北海道音威子府村のAI副村長「ねっぷちゃん」と会話できるチャットアプリケーションです。村独自の公的資料から地域文化まで直接学習することで、地元の通称、お店、冬の除雪相談、コミュニティイベントなど、音威子府村ならではの文脈を深く理解した自然な対話を実現します。
 
@@ -11,7 +12,7 @@
 
 このプロジェクトは、全国の自治体が低コストで「AIによる住民支援」を導入できるモデルケースとして、開発プロセスを全面公開する**オープンR&D**の取り組みです。
 
-[Website](https://web.nepp-chan.ai) · [セットアップ](#セットアップ) · [ロードマップ](#ロードマップ) · [English](README.en.md)
+[Website](https://nepp-chan.ai) · [チャット](https://web.nepp-chan.ai) · [セットアップ](#セットアップ) · [ロードマップ](#ロードマップ) · [English](README.en.md)
 
 ---
 
@@ -57,7 +58,9 @@
 | ディレクトリ                | 説明                                        |
 | --------------------------- | ------------------------------------------- |
 | [server/](server/README.md) | バックエンド API（Cloudflare Workers）      |
-| [web/](web/README.md)       | フロントエンド WEB （Cloudflare Pages）     |
+| [web/](web/README.md)       | チャット Web アプリ（Cloudflare Pages）     |
+| lp/                         | ランディングページ（Cloudflare Pages）      |
+| shared/                     | web / lp / server 共通の TypeScript パッケージ |
 | knowledge/                  | RAG 用ナレッジファイル                      |
 
 ## セットアップ
@@ -79,14 +82,18 @@ pnpm install
 `.env.example` をコピーして `.env` を作成します。
 
 ```bash
+# ルート（ナレッジアップロードスクリプト用）
+cp .env.example .env
+
 # server
 cp server/.env.example server/.env
-cp server/.env.example server/.env.production
 cp server/.dev.vars.example server/.dev.vars
 
 # web
 cp web/.env.example web/.env
-cp web/.env.example web/.env.production
+
+# lp
+cp lp/.env.example lp/.env
 ```
 
 各 `.env` ファイルに適切な値を設定してください。
@@ -95,18 +102,20 @@ cp web/.env.example web/.env.production
 
 ```bash
 # 開発環境（マイグレーション適用）
-cd server
 pnpm db:migrate:local
 ```
 
 ## 開発
 
 ```bash
-# API サーバー起動
+# API サーバー起動（http://localhost:8787）
 pnpm server:dev
 
-# Web 開発サーバー起動
+# Web 開発サーバー起動（http://localhost:5173）
 pnpm web:dev
+
+# LP 開発サーバー起動（http://localhost:5174）
+pnpm lp:dev
 
 # Mastra Playground 起動
 pnpm mastra:dev
@@ -116,11 +125,11 @@ pnpm mastra:dev
 
 ### 環境構成
 
-| 環境 | トリガー | Web URL | API URL |
-|------|----------|---------|---------|
-| ローカル | - | http://localhost:5173 | http://localhost:8787 |
-| dev | develop push | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
-| prd | `v*` タグ（tagpr） | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
+| 環境 | トリガー | LP | Web | API |
+|------|----------|----|-----|-----|
+| ローカル | - | http://localhost:5174 | http://localhost:5173 | http://localhost:8787 |
+| dev | `develop` push | https://dev.nepp-chan.ai | https://dev-web.nepp-chan.ai | https://dev-api.nepp-chan.ai |
+| prd | `v*` タグ（tagpr） | https://nepp-chan.ai | https://web.nepp-chan.ai | https://api.nepp-chan.ai |
 
 ### 手動デプロイ
 
@@ -128,10 +137,12 @@ pnpm mastra:dev
 # dev 環境
 pnpm server:deploy:dev
 pnpm web:deploy:dev
+pnpm lp:deploy:dev
 
 # prd 環境
 pnpm server:deploy:prd
 pnpm web:deploy:prd
+pnpm lp:deploy:prd
 ```
 
 ### CI/CD

--- a/server/worker-configuration.d.ts
+++ b/server/worker-configuration.d.ts
@@ -13,7 +13,7 @@ declare namespace Cloudflare {
 		LINE_QUEUE: Queue;
 		ENVIRONMENT: "development";
 		WEB_URL: "https://dev-web.nepp-chan.ai";
-		LP_URL: "https://dev-lp.nepp-chan.ai";
+		LP_URL: "https://dev.nepp-chan.ai";
 		GOOGLE_GENERATIVE_AI_API_KEY: string;
 		GOOGLE_SEARCH_ENGINE_ID: string;
 		JWT_SECRET: string;

--- a/server/wrangler.jsonc
+++ b/server/wrangler.jsonc
@@ -119,7 +119,7 @@
       "vars": {
         "ENVIRONMENT": "development",
         "WEB_URL": "https://dev-web.nepp-chan.ai",
-        "LP_URL": "https://dev-lp.nepp-chan.ai"
+        "LP_URL": "https://dev.nepp-chan.ai"
       }
     },
     "production": {


### PR DESCRIPTION
## Summary

- 本番 apex (`nepp-chan.ai`) に合わせて、dev LP のドメインを `dev-lp.nepp-chan.ai` → `dev.nepp-chan.ai` に統一
- README（日本語/英語）を現状の構成（LP / shared / 各種 pnpm スクリプト）に合わせて最新化

## 主な変更内容

### ドメイン統一 (`55867dc`)

| ファイル | 内容 |
| --- | --- |
| `server/wrangler.jsonc` | development env の `LP_URL` |
| `server/worker-configuration.d.ts` | `LP_URL` の型注釈 |
| `.github/workflows/deploy-dev.yml` | Web ビルド時の `PUBLIC_LP_URL` |
| `CLAUDE.md` | デプロイ環境表の dev LP |

### README 最新化 (`e16c728`)

- LP（apex 配信の Astro）と shared（共通 TS パッケージ）をプロジェクト構成に追記
- Website バッジ・ナビを LP（`nepp-chan.ai`）とチャット（`web.nepp-chan.ai`）の 2 つに分離
- 環境構成テーブル・手動デプロイに LP の URL とコマンドを追加
- env セットアップを実態に合わせて修正
  - 存在しない `server/.env.production` への謎コピーを削除
  - `lp/.env` を追記
- D1 マイグレーション手順を `cd server` 不要な形に修正
- `pnpm lp:dev` を開発コマンドに追加

## 別途必要な作業（コード外）

Cloudflare 側でドメイン切替の手動作業が必要です。

- Cloudflare Pages（`nepp-chan-lp-dev`）の Custom Domain
  - `dev.nepp-chan.ai` を追加
  - 切替確認後に `dev-lp.nepp-chan.ai` を削除
- DNS（`nepp-chan.ai` zone）
  - `dev` の CNAME を Pages 用に追加
  - 旧 `dev-lp` レコードを削除

旧ドメインを残したまま新ドメインを追加 → dev デプロイで動作確認 → 旧削除、の順が安全です。

## Test plan

- [ ] dev へデプロイし `https://dev.nepp-chan.ai` で LP が表示される
- [ ] `https://dev-web.nepp-chan.ai` のチャットから LP リンク（`PUBLIC_LP_URL`）が新ドメインを向いている
- [ ] CORS が落ちていない（server の `LP_URL` 反映）