### PR TITLE
feat(server): LINE スタンプ受信時にねっぷちゃんが返信

### DIFF
--- a/server/src/handlers/line-event-handler.test.ts
+++ b/server/src/handlers/line-event-handler.test.ts
@@ -30,7 +30,7 @@ const buildMessage = (body: {
   userId: string;
   userMessage?: string;
   replyToken?: string;
-  type?: "message" | "unfollow";
+  type?: "message" | "unfollow" | "sticker";
 }) => ({
   body: {
     type: body.type ?? "message",
@@ -131,6 +131,44 @@ describe("handleLineEvent", () => {
     expect(mockSendLineMessages).not.toHaveBeenCalled();
     expect(msg.ack).toHaveBeenCalled();
     expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  it("sticker はねっぷちゃんの定型文を sendLineMessages で送って ack（generateReply は呼ばない）", async () => {
+    mockSendLineMessages.mockResolvedValue(undefined);
+
+    const msg = buildMessage({
+      userId: "U-stk",
+      replyToken: "rt-stk",
+      type: "sticker",
+    });
+
+    await handleLineEvent(buildBatch([msg]), env);
+
+    expect(mockGenerateReply).not.toHaveBeenCalled();
+    expect(mockSendLineMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToken: "rt-stk",
+        userId: "U-stk",
+        texts: ["ごめんね、スタンプはわからないんだ〜🥲"],
+      }),
+    );
+    expect(msg.ack).toHaveBeenCalled();
+    expect(msg.retry).not.toHaveBeenCalled();
+  });
+
+  it("sticker の送信が失敗したら retry", async () => {
+    mockSendLineMessages.mockRejectedValue(new Error("LINE down"));
+
+    const msg = buildMessage({
+      userId: "U-stk",
+      replyToken: "rt-stk",
+      type: "sticker",
+    });
+
+    await handleLineEvent(buildBatch([msg]), env);
+
+    expect(msg.ack).not.toHaveBeenCalled();
+    expect(msg.retry).toHaveBeenCalled();
   });
 
   it("unfollow の削除が失敗したら retry", async () => {

--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -11,6 +11,8 @@ import {
 } from "~/services/line-messaging";
 import { deleteAllByLineUserId } from "~/services/user-deletion";
 
+const STICKER_REPLY_TEXT = "ごめんね、スタンプはわからないんだ〜🥲";
+
 export const handleLineEvent = async (
   batch: MessageBatch<LineEventMessage>,
   env: CloudflareBindings,
@@ -28,6 +30,34 @@ export const handleLineEvent = async (
       } catch (error) {
         reportPrivacyCriticalError(error, "line-unfollow-handler");
         logger.error("LINE unfollow deletion failed", error);
+        message.retry();
+      }
+      continue;
+    }
+
+    if (body.type === "sticker") {
+      let threadId: string | undefined;
+      try {
+        const principal: LinePrincipal = { type: "line", id: body.userId };
+        const { threadId: t } = await toLineIds(principal, secret);
+        threadId = t;
+        await sendLineMessages({
+          client,
+          replyToken: body.replyToken,
+          userId: body.userId,
+          threadId,
+          texts: [STICKER_REPLY_TEXT],
+        });
+        message.ack();
+      } catch (error) {
+        Sentry.captureException(error, {
+          tags: { handler: "line-event", event: "sticker" },
+        });
+        logger.error(
+          "LINE sticker reply failed",
+          error,
+          threadId ? { threadId } : undefined,
+        );
         message.retry();
       }
       continue;

--- a/server/src/routes/line.test.ts
+++ b/server/src/routes/line.test.ts
@@ -152,13 +152,28 @@ describe("lineRoutes: POST /webhook", () => {
       expect(queueSend).not.toHaveBeenCalled();
     });
 
-    it("非テキスト message はキューに送らない", async () => {
+    it("sticker message は { type: 'sticker', userId, replyToken } を LINE_QUEUE に送る", async () => {
       const stickerEvent = {
         ...baseTextEvent,
         message: { type: "sticker", id: "s1" },
       };
 
       await sendWebhook([stickerEvent]);
+
+      expect(queueSend).toHaveBeenCalledWith({
+        type: "sticker",
+        userId: "U123",
+        replyToken: "reply-1",
+      });
+    });
+
+    it("text / sticker 以外の message はキューに送らない", async () => {
+      const imageEvent = {
+        ...baseTextEvent,
+        message: { type: "image", id: "i1" },
+      };
+
+      await sendWebhook([imageEvent]);
 
       expect(queueSend).not.toHaveBeenCalled();
     });

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -107,17 +107,28 @@ const enqueueLineEvents = async (
       continue;
     }
 
-    if (event.type !== "message" || event.message.type !== "text") continue;
+    if (event.type !== "message") continue;
     if (!("replyToken" in event) || !event.replyToken) continue;
     if (!event.source?.userId) continue;
 
-    const message: LineEventMessage = {
-      type: "message",
-      userId: event.source.userId,
-      userMessage: event.message.text,
-      replyToken: event.replyToken,
-    };
+    if (event.message.type === "text") {
+      const message: LineEventMessage = {
+        type: "message",
+        userId: event.source.userId,
+        userMessage: event.message.text,
+        replyToken: event.replyToken,
+      };
+      await env.LINE_QUEUE.send(message);
+      continue;
+    }
 
-    await env.LINE_QUEUE.send(message);
+    if (event.message.type === "sticker") {
+      const sticker: LineEventMessage = {
+        type: "sticker",
+        userId: event.source.userId,
+        replyToken: event.replyToken,
+      };
+      await env.LINE_QUEUE.send(sticker);
+    }
   }
 };

--- a/server/src/schemas/line-schema.ts
+++ b/server/src/schemas/line-schema.ts
@@ -7,9 +7,18 @@ export type LineMessageEvent = {
   replyToken: string;
 };
 
+export type LineStickerEvent = {
+  type: "sticker";
+  userId: string;
+  replyToken: string;
+};
+
 export type LineUnfollowEvent = {
   type: webhook.UnfollowEvent["type"];
   userId: string;
 };
 
-export type LineEventMessage = LineMessageEvent | LineUnfollowEvent;
+export type LineEventMessage =
+  | LineMessageEvent
+  | LineStickerEvent
+  | LineUnfollowEvent;


### PR DESCRIPTION
## Summary

- LINE でスタンプメッセージを受信した時に、ねっぷちゃんが「ごめんね、スタンプはわからないんだ〜🥲」と返す
- スタンプは LLM を呼ばず固定文で reply（コスト・レイテンシ削減）
- 既存の text / unfollow と同じ `LINE_QUEUE` パイプラインに乗せて一貫性を保つ

## 変更点

- `server/src/schemas/line-schema.ts`: `LineStickerEvent` を `LineEventMessage` の union に追加
- `server/src/routes/line.ts`: webhook で `event.message.type === "sticker"` の場合に sticker イベントを Queue に enqueue
- `server/src/handlers/line-event-handler.ts`: `body.type === "sticker"` の分岐で `sendLineMessages` を使い固定文を返信、失敗時は retry
- 各種テスト追加・更新

## Test plan

- [x] `pnpm test`: server 904 件 all pass
- [x] `pnpm lint`: 0 errors / 0 warnings
- [x] `pnpm format`: 整形済み
- [x] `codex review --uncommitted`: 既存挙動を壊す不具合なし
- [ ] dev 環境で LINE 公式アカウントにスタンプを送信して動作確認