### PR TITLE
fix(server): ペルソナ一覧を会話日時優先で並び替え

### DIFF
--- a/server/src/repository/persona-repository.test.ts
+++ b/server/src/repository/persona-repository.test.ts
@@ -318,23 +318,37 @@ describe("personaRepository", () => {
   });
 
   describe("listForAdmin", () => {
-    it("createdAt + id の複合ソートとカーソル", async () => {
-      // 同じ createdAt で id が違う persona を作る
+    it("conversationEndedAt 優先 + id の複合ソートとカーソル", async () => {
+      // conversationEndedAt が null の場合は createdAt にフォールバックして比較する
       await personaRepository.create(
         fakeD1,
-        baseInput({ id: "p-a", createdAt: "2030-01-01T00:00:00Z" }),
+        baseInput({
+          id: "p-a",
+          createdAt: "2030-01-01T00:00:00Z",
+          conversationEndedAt: "2030-03-01T00:00:00Z",
+        }),
       );
       await personaRepository.create(
         fakeD1,
-        baseInput({ id: "p-b", createdAt: "2030-01-01T00:00:00Z" }),
+        baseInput({
+          id: "p-b",
+          createdAt: "2030-01-01T00:00:00Z",
+          conversationEndedAt: "2030-03-01T00:00:00Z",
+        }),
       );
       await personaRepository.create(
         fakeD1,
-        baseInput({ id: "p-c", createdAt: "2030-02-01T00:00:00Z" }),
+        baseInput({
+          id: "p-c",
+          createdAt: "2030-02-15T00:00:00Z",
+          conversationEndedAt: null,
+        }),
       );
 
       const first = await personaRepository.listForAdmin(fakeD1, { limit: 1 });
-      expect(first.personas[0].id).toBe("p-c");
+      // p-a / p-b は会話日時 2030-03-01、p-c は会話日時なし → createdAt フォールバック 2030-02-15
+      // 同日付なら id 降順なので先頭は p-b
+      expect(first.personas[0].id).toBe("p-b");
       expect(first.total).toBe(3);
       expect(first.hasMore).toBe(true);
 
@@ -342,8 +356,14 @@ describe("personaRepository", () => {
         limit: 1,
         cursor: first.nextCursor!,
       });
-      // 同 createdAt なら id 降順
-      expect(next.personas[0].id).toBe("p-b");
+      expect(next.personas[0].id).toBe("p-a");
+
+      const last = await personaRepository.listForAdmin(fakeD1, {
+        limit: 1,
+        cursor: next.nextCursor!,
+      });
+      expect(last.personas[0].id).toBe("p-c");
+      expect(last.hasMore).toBe(false);
     });
   });
 

--- a/server/src/repository/persona-repository.ts
+++ b/server/src/repository/persona-repository.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, like, lt, or, type SQL, sql } from "drizzle-orm";
+import { and, count, desc, eq, like, or, type SQL, sql } from "drizzle-orm";
 
 import { createDb, type NewPersona, type Persona, persona } from "~/db";
 
@@ -216,20 +216,19 @@ export const personaRepository = {
     const db = createDb(d1);
     const limit = options.limit ?? 30;
 
+    const sortDate = sql`COALESCE(${persona.conversationEndedAt}, ${persona.createdAt})`;
+
     let cursorCondition: SQL | undefined;
     if (options.cursor) {
-      const [cursorCreatedAt, cursorId] = options.cursor.split("_");
-      cursorCondition = or(
-        lt(persona.createdAt, cursorCreatedAt),
-        and(eq(persona.createdAt, cursorCreatedAt), lt(persona.id, cursorId)),
-      );
+      const [cursorDate, cursorId] = options.cursor.split("_");
+      cursorCondition = sql`(${sortDate} < ${cursorDate} OR (${sortDate} = ${cursorDate} AND ${persona.id} < ${cursorId}))`;
     }
 
     const results = await db
       .select()
       .from(persona)
       .where(cursorCondition)
-      .orderBy(desc(persona.createdAt), desc(persona.id))
+      .orderBy(sql`${sortDate} DESC`, desc(persona.id))
       .limit(limit + 1)
       .all();
 
@@ -239,7 +238,7 @@ export const personaRepository = {
     const lastPersona = personas[personas.length - 1];
     const nextCursor =
       hasMore && lastPersona
-        ? `${lastPersona.createdAt}_${lastPersona.id}`
+        ? `${lastPersona.conversationEndedAt ?? lastPersona.createdAt}_${lastPersona.id}`
         : null;
 
     const countResult = await db.select({ count: count() }).from(persona).get();


### PR DESCRIPTION
## Summary
- 管理ダッシュボードに表示している「会話日時」と一覧の並び順を一致させる
- `listForAdmin` のソートキーを `createdAt` → `COALESCE(conversationEndedAt, createdAt)` 降順に変更
- カーソル形式も同様に変更（`{conversationEndedAt ?? createdAt}_{id}`）

## Why
PersonaPanel に表示されているのは `conversationEndedAt`（会話日時）だが、API 側は `createdAt`（抽出日時）で並んでいて、表示順と実態がズレていた。会話日時が無い古いレコードは `createdAt` にフォールバック。

## Test plan
- [x] `personaRepository.test.ts` の listForAdmin テストを会話日時ベースの仕様に更新
- [x] `pnpm --filter @nepp-chan/server test` 全 901 件 pass
- [x] biome / tsc クリーン
- [ ] dev デプロイ後、ダッシュボードのペルソナ一覧が会話日時降順で並ぶか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)