### PR TITLE
perf(server): LINE の体感レイテンシを改善する

### DIFF
--- a/server/src/handlers/line-event-handler.ts
+++ b/server/src/handlers/line-event-handler.ts
@@ -74,6 +74,7 @@ export const handleLineEvent = async (
       } = await toLineIds(principal, secret);
       threadId = t;
       const replyTexts = await generateReply({
+        client,
         userMessage,
         userId,
         hashedUserId,

--- a/server/src/lib/llm-models.test.ts
+++ b/server/src/lib/llm-models.test.ts
@@ -51,16 +51,16 @@ describe("resolveModelTier", () => {
   });
 
   describe("LINE プラットフォーム（非 Admin）", () => {
-    it("casual → FLASH_LITE + low", () => {
+    it("casual → FLASH_LITE + thinking 無効 (thinkingBudget: 0)", () => {
       const tier = resolveModelTier({
         intent: "casual",
         platform: "line",
         isAdmin: false,
       });
       expect(tier.model).toBe(GEMINI_FLASH_LITE);
-      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
-        "low",
-      );
+      expect(tier.providerOptions.google.thinkingConfig).toEqual({
+        thinkingBudget: 0,
+      });
     });
 
     it("thinking → FLASH + medium", () => {

--- a/server/src/lib/llm-models.test.ts
+++ b/server/src/lib/llm-models.test.ts
@@ -63,7 +63,7 @@ describe("resolveModelTier", () => {
       );
     });
 
-    it("thinking → FLASH + high", () => {
+    it("thinking → FLASH + medium", () => {
       const tier = resolveModelTier({
         intent: "thinking",
         platform: "line",
@@ -71,7 +71,7 @@ describe("resolveModelTier", () => {
       });
       expect(tier.model).toBe(GEMINI_FLASH);
       expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
-        "high",
+        "medium",
       );
     });
   });

--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -17,16 +17,18 @@ export const OPENAI_SCORER = "openai/gpt-4.1-nano";
 export const GEMINI_EMBEDDING = "gemini-embedding-001";
 
 /**
- * Gemini モデルと thinkingConfig を含む Agent 設定を返す
+ * Gemini モデルと thinkingConfig を含む Agent 設定を返す。
+ * "none" は AI SDK の thinkingLevel enum に存在しないため thinkingBudget: 0 で無効化する。
  */
 export const geminiModelWithThinking = ({
   model = GEMINI_FLASH_LITE,
-  level = "low" as "high" | "medium" | "low",
+  level = "low" as "high" | "medium" | "low" | "none",
 } = {}) => ({
   model,
   providerOptions: {
     google: {
-      thinkingConfig: { thinkingLevel: level },
+      thinkingConfig:
+        level === "none" ? { thinkingBudget: 0 } : { thinkingLevel: level },
     },
   },
 });
@@ -38,7 +40,7 @@ export type ModelTierConfig = ReturnType<typeof geminiModelWithThinking>;
 const MODEL_TIERS: Record<Intent, Record<"web" | "line", ModelTierConfig>> = {
   casual: {
     web: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "low" }),
-    line: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "low" }),
+    line: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "none" }),
   },
   thinking: {
     web: geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),

--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -42,7 +42,7 @@ const MODEL_TIERS: Record<Intent, Record<"web" | "line", ModelTierConfig>> = {
   },
   thinking: {
     web: geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
-    line: geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
+    line: geminiModelWithThinking({ model: GEMINI_FLASH, level: "medium" }),
   },
 };
 

--- a/server/src/services/broadcast-response.ts
+++ b/server/src/services/broadcast-response.ts
@@ -68,7 +68,9 @@ export const generateBroadcastExplanation = async (
 【おしらせ本文】
 ${bodyText}`;
 
+    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
     const replyTexts = await generateReply({
+      client,
       userMessage,
       userId,
       hashedUserId,
@@ -79,7 +81,6 @@ ${bodyText}`;
 
     if (replyTexts.length === 0) return;
 
-    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
     await sendLineMessages({
       client,
       replyToken,

--- a/server/src/services/line-messaging.test.ts
+++ b/server/src/services/line-messaging.test.ts
@@ -119,7 +119,13 @@ describe("sendLineMessages", () => {
 });
 
 describe("generateReply", () => {
+  const showLoadingAnimation = vi.fn();
+  const client = {
+    showLoadingAnimation,
+  } as unknown as messagingApi.MessagingApiClient;
+
   const baseParams = {
+    client,
     userMessage: "こんにちは",
     userId: "user-1",
     hashedUserId: "hashed-1",
@@ -141,6 +147,7 @@ describe("generateReply", () => {
         modelId: "fake-model",
       } as never);
     agentHolder.generate.mockReset();
+    showLoadingAnimation.mockReset().mockResolvedValue({});
   });
 
   it("通常系: step.text を返し stripMarkdown を通す", async () => {
@@ -217,5 +224,51 @@ describe("generateReply", () => {
       platform: "line",
       isAdmin: false,
     });
+  });
+
+  it("agent.generate 前に showLoadingAnimation を chatId=userId / loadingSeconds=60 で呼ぶ", async () => {
+    agentHolder.generate.mockResolvedValueOnce({
+      steps: [{ text: "x" }],
+      text: "x",
+    });
+
+    await generateReply(baseParams);
+
+    expect(showLoadingAnimation).toHaveBeenCalledWith({
+      chatId: "user-1",
+      loadingSeconds: 60,
+    });
+    const loadingCallOrder = showLoadingAnimation.mock.invocationCallOrder[0];
+    const generateCallOrder = agentHolder.generate.mock.invocationCallOrder[0];
+    expect(loadingCallOrder).toBeLessThan(generateCallOrder!);
+  });
+
+  it("showLoadingAnimation の失敗は warn ログのみで generateReply を止めない", async () => {
+    showLoadingAnimation.mockRejectedValueOnce(new Error("loading failed"));
+    agentHolder.generate.mockResolvedValueOnce({
+      steps: [{ text: "ok" }],
+      text: "ok",
+    });
+
+    await expect(generateReply(baseParams)).resolves.toEqual(["ok"]);
+  });
+
+  it("showLoadingAnimation の Promise が未解決でも agent.generate は開始する (fire-and-forget)", async () => {
+    let releaseLoading: () => void = () => undefined;
+    showLoadingAnimation.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseLoading = resolve;
+      }),
+    );
+    agentHolder.generate.mockResolvedValueOnce({
+      steps: [{ text: "ok" }],
+      text: "ok",
+    });
+
+    const result = await generateReply(baseParams);
+
+    expect(agentHolder.generate).toHaveBeenCalled();
+    expect(result).toEqual(["ok"]);
+    releaseLoading();
   });
 });

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -31,7 +31,6 @@ export const generateReply = async (params: {
     env: params.env,
   });
 
-  // 並行で発火する。await すると D1 注入や classifyIntent と直列化してしまい意味がない
   params.client
     .showLoadingAnimation({
       chatId: params.userId,

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -15,6 +15,7 @@ export const createLineClient = (token: string) =>
   new messagingApi.MessagingApiClient({ channelAccessToken: token });
 
 export const generateReply = async (params: {
+  client: messagingApi.MessagingApiClient;
   userMessage: string;
   userId: string;
   hashedUserId: string;
@@ -29,6 +30,19 @@ export const generateReply = async (params: {
     db: params.env.DB,
     env: params.env,
   });
+
+  // 並行で発火する。await すると D1 注入や classifyIntent と直列化してしまい意味がない
+  params.client
+    .showLoadingAnimation({
+      chatId: params.userId,
+      loadingSeconds: 60,
+    })
+    .catch((error) =>
+      logger.warn("[LINE] showLoadingAnimation failed", {
+        threadId: params.threadId,
+        errorName: error instanceof Error ? error.name : "unknown",
+      }),
+    );
 
   await Promise.all([
     injectBroadcastsToThread({

--- a/server/src/services/poll-response.ts
+++ b/server/src/services/poll-response.ts
@@ -139,7 +139,9 @@ export const generatePollFollowUp = async (
 
     const userMessage = `（投票）「${poll.title}」で「${selectedChoice}」を選んだよ。`;
 
+    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
     const replyTexts = await generateReply({
+      client,
       userMessage,
       userId,
       hashedUserId,
@@ -150,7 +152,6 @@ export const generatePollFollowUp = async (
 
     if (replyTexts.length === 0) return;
 
-    const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
     await client.pushMessage({
       to: userId,
       messages: replyTexts.map((text) => ({ type: "text" as const, text })),


### PR DESCRIPTION
## Summary
- LINE 返信前に Loading Animation (\`showLoadingAnimation\`) を fire-and-forget で発火し、agent.generate 完了までの沈黙を「入力中…」表示に置き換える
- LINE 経路の thinkingLevel を 1 段ずつ下げる (\`thinking\`: high → medium, \`casual\`: low → none)
- Web 経路は思考力優先のため high / low を維持

## 背景

LINE では返信が約 10 秒、Web では約 3 秒という体感差が報告されていた。調査の結果、両者は同じ \`MODEL_TIERS\` を共有しており LLM 完了時間自体は同等で、差は **Web が streaming で動いて見えるのに対し LINE は完成待ちで沈黙する** ことが本質。さらに \`gemini-flash-latest\` は alias で hot-swap される (2026-05-19 に Gemini 3.5 Flash リリース) ため、推論力上昇分のレイテンシ増の影響も受けやすい状態だった。

ユーザー方針:
- 「考える系の難しいタスクは遅くてよい、挨拶が遅いのが困る」
- 「LINE は high じゃなくて medium でいいかも」
- 「low も none があるなら none でもいいかも、雑談程度だったら問題ないよね」

## 主な変更内容

### 1. LINE Loading Animation の導入

\`server/src/services/line-messaging.ts\` の \`generateReply\` で、D1 注入 (\`Promise.all\`) や intent 分類より前に \`client.showLoadingAnimation({ chatId: userId, loadingSeconds: 60 })\` を fire-and-forget で呼び出す。失敗は warn ログのみで握り、本体処理を止めない。

- \`generateReply\` のシグネチャに \`client: messagingApi.MessagingApiClient\` を追加
- 呼び出し元 (\`line-event-handler.ts\`, \`broadcast-response.ts\`, \`poll-response.ts\`) を更新し、既存の \`createLineClient\` から得た client を渡す
- 追加テスト 3 件: 呼び出し引数 / 失敗時の握り潰し / fire-and-forget の挙動

### 2. MODEL_TIERS の thinking 設定見直し

| Intent / Platform | モデル | thinking (Before → After) |
|---|---|---|
| casual / web | gemini-flash-lite-latest | low (維持) |
| casual / line | gemini-flash-lite-latest | **low → thinkingBudget: 0** |
| thinking / web | gemini-flash-latest | high (維持) |
| thinking / line | gemini-flash-latest | **high → medium** |

\`thinkingLevel: \"none\"\` は \`@ai-sdk/google\` の enum (\`low | medium | high\`) に含まれないため、\`thinkingBudget: 0\` で thinking 無効化を表現する (codex review の P1 指摘を反映)。\`geminiModelWithThinking\` ヘルパで \`level === \"none\"\` のとき分岐するよう拡張。

## Test plan
- [x] \`pnpm test\` (server) 907 件 green
- [x] \`pnpm lint\` 0 errors
- [x] \`codex review --uncommitted\` 指摘なし
- [ ] dev 環境にデプロイし、LINE Bot dev チャネルで「入力中…」表示を目視確認
- [ ] 挨拶 (casual) / 質問 (thinking) それぞれで体感レイテンシを確認
- [ ] tagpr の minor バンプ判定が走るか確認