### PR TITLE
perf(server): webhook 受信時にローディングを先出しする

### DIFF
--- a/server/src/routes/line.test.ts
+++ b/server/src/routes/line.test.ts
@@ -1,6 +1,10 @@
 import crypto from "node:crypto";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const { showLoadingAnimation } = vi.hoisted(() => ({
+  showLoadingAnimation: vi.fn(),
+}));
+
 vi.mock("~/services/broadcast-response", () => ({
   generateBroadcastExplanation: vi.fn(),
   handleBroadcastPostback: vi.fn(),
@@ -9,6 +13,10 @@ vi.mock("~/services/broadcast-response", () => ({
 vi.mock("~/services/poll-response", () => ({
   generatePollFollowUp: vi.fn(),
   handlePollPostback: vi.fn(),
+}));
+
+vi.mock("~/services/line-messaging", () => ({
+  createLineClient: vi.fn(() => ({ showLoadingAnimation })),
 }));
 
 const broadcastResponse = await import("~/services/broadcast-response");
@@ -59,6 +67,7 @@ const baseTextEvent = {
 describe("lineRoutes: POST /webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    showLoadingAnimation.mockResolvedValue({});
   });
 
   describe("署名検証", () => {
@@ -126,6 +135,36 @@ describe("lineRoutes: POST /webhook", () => {
         userMessage: "こんにちは",
         replyToken: "reply-1",
       });
+    });
+
+    it("text message では showLoadingAnimation を waitUntil で先出しする", async () => {
+      await sendWebhook([baseTextEvent]);
+
+      expect(showLoadingAnimation).toHaveBeenCalledWith({
+        chatId: "U123",
+        loadingSeconds: 60,
+      });
+      expect(waitUntil).toHaveBeenCalled();
+    });
+
+    it("showLoadingAnimation が失敗しても webhook 自体は 200 を返す", async () => {
+      showLoadingAnimation.mockRejectedValueOnce(new Error("loading failed"));
+
+      const res = await sendWebhook([baseTextEvent]);
+
+      expect(res.status).toBe(200);
+      expect(queueSend).toHaveBeenCalled();
+    });
+
+    it("sticker message では showLoadingAnimation を呼ばない", async () => {
+      const stickerEvent = {
+        ...baseTextEvent,
+        message: { type: "sticker", id: "s1" },
+      };
+
+      await sendWebhook([stickerEvent]);
+
+      expect(showLoadingAnimation).not.toHaveBeenCalled();
     });
 
     it("unfollow event は { type: 'unfollow', userId } を LINE_QUEUE に送る", async () => {

--- a/server/src/routes/line.ts
+++ b/server/src/routes/line.ts
@@ -8,6 +8,7 @@ import {
   generateBroadcastExplanation,
   handleBroadcastPostback,
 } from "~/services/broadcast-response";
+import { createLineClient } from "~/services/line-messaging";
 import {
   generatePollFollowUp,
   handlePollPostback,
@@ -112,12 +113,23 @@ const enqueueLineEvents = async (
     if (!event.source?.userId) continue;
 
     if (event.message.type === "text") {
+      const userId = event.source.userId;
       const message: LineEventMessage = {
         type: "message",
-        userId: event.source.userId,
+        userId,
         userMessage: event.message.text,
         replyToken: event.replyToken,
       };
+      const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
+      executionCtx.waitUntil(
+        client
+          .showLoadingAnimation({ chatId: userId, loadingSeconds: 60 })
+          .catch((error) =>
+            logger.warn("[LINE] early showLoadingAnimation failed", {
+              errorName: error instanceof Error ? error.name : "unknown",
+            }),
+          ),
+      );
       await env.LINE_QUEUE.send(message);
       continue;
     }


### PR DESCRIPTION
## Summary
- LINE webhook で text message を受け取った時点で \`executionCtx.waitUntil(showLoadingAnimation)\` を発火
- queue consumer 起動 + D1 init を待たずに「入力中…」表示できるようにする

## 背景

PR #676 で導入した \`showLoadingAnimation\` は \`generateReply\` 内で発火していたが、実機で確認したところ表示まで約 3 秒の遅延があった。内訳:

\`\`\`
[1] webhook 受信 → 200 OK（数十ms）
[2] LINE_QUEUE.send（数百ms）
[3] Queue consumer 起動 cold start（500ms〜2s）★
[4] handleLineEvent → generateReply
[5] getStorage（D1 init, 数百ms）★
[6] showLoadingAnimation 発火 ← ようやく「入力中…」が出る
\`\`\`

★ の合計 1〜3 秒は queue/D1 のオーバーヘッドで、ローディング表示には不要な待ち。

## 主な変更内容

\`server/src/routes/line.ts\` で text message を enqueue する直前に、\`executionCtx.waitUntil\` で \`showLoadingAnimation\` を発火する。webhook 応答は止めない fire-and-forget。

\`\`\`ts
const client = createLineClient(env.LINE_CHANNEL_ACCESS_TOKEN);
executionCtx.waitUntil(
  client
    .showLoadingAnimation({ chatId: userId, loadingSeconds: 60 })
    .catch((error) => logger.warn(\"[LINE] early showLoadingAnimation failed\", { ... })),
);
await env.LINE_QUEUE.send(message);
\`\`\`

\`generateReply\` 内の既存 \`showLoadingAnimation\` 呼び出しは保険として残置。LINE 公式仕様で「Re-requesting overrides the timeout」のため、後勝ち上書きされるだけで害なし。

### 対象範囲

- text message のみ。sticker は短文即返答なので対象外、postback は queue 経由でなく直接実行されるので元から対象外

### 追加テスト
- text message で \`showLoadingAnimation\` が \`waitUntil\` で発火されることを検証
- \`showLoadingAnimation\` が失敗しても webhook が 200 を返すことを検証
- sticker message では発火しないことを検証

## Test plan
- [x] \`pnpm test\` (server) 910 件 green
- [x] \`pnpm lint\` 0 errors
- [x] \`codex review --uncommitted\` 指摘なし
- [ ] dev 環境にデプロイし、LINE Bot dev チャネルで挨拶を投げて **発話直後** にローディングが出るか目視確認