### PR TITLE
feat(web/chat): モバイルでもチャット画面にマスコットを表示する

### DIFF
--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -28,6 +28,9 @@ export default defineConfig({
         "~": "/src",
       },
     },
+    optimizeDeps: {
+      exclude: ["msw", "msw/node"],
+    },
     build: {
       sourcemap: "hidden",
     },

--- a/web/src/app/chat/components/ChatStandingMascot.tsx
+++ b/web/src/app/chat/components/ChatStandingMascot.tsx
@@ -109,7 +109,7 @@ export const ChatStandingMascot = () => {
     <div
       className={cn(
         "pointer-events-none fixed z-[5]",
-        "-right-1 bottom-[calc(72px+env(safe-area-inset-bottom))] w-28 h-28",
+        "-right-[3px] bottom-[calc(72px+env(safe-area-inset-bottom))] w-28 h-28",
         "lg:left-[max(0px,calc(50%-520px))] lg:bottom-2 lg:w-[170px] lg:h-[220px]",
       )}
       style={{

--- a/web/src/app/chat/components/ChatStandingMascot.tsx
+++ b/web/src/app/chat/components/ChatStandingMascot.tsx
@@ -95,9 +95,9 @@ const useMascotPresentation = (): Presentation => {
 };
 
 /**
- * 画面左下に固定配置するマスコット。Composer (中央配置) と被らないよう
- * 画面端寄りに張り付ける。lg 以上で表示。
+ * 画面左下に固定配置するマスコット。
  *
+ * 表情:
  * - idle (待機): expr-wave-smile
  * - thinking + ツール実行中: pose-thinking
  * - thinking + テキスト生成のみ: expr-content
@@ -108,11 +108,9 @@ export const ChatStandingMascot = () => {
   return (
     <div
       className={cn(
-        "pointer-events-none fixed z-[5] hidden lg:block",
-        // Composer (max-w 672px / 中央配置) の左外側に寄せる。
-        // 画面が狭い場合は左端 0 に張り付け。
-        "left-[max(0px,calc(50%-520px))] bottom-2",
-        "w-[170px] h-[220px]",
+        "pointer-events-none fixed z-[5]",
+        "-right-1 bottom-[calc(72px+env(safe-area-inset-bottom))] w-28 h-28",
+        "lg:left-[max(0px,calc(50%-520px))] lg:bottom-2 lg:w-[170px] lg:h-[220px]",
       )}
       style={{
         animation: "mascot-float-sm 4.5s ease-in-out infinite",

--- a/web/src/components/assistant-ui/Thread.tsx
+++ b/web/src/components/assistant-ui/Thread.tsx
@@ -178,8 +178,16 @@ const AssistantMessage = () => (
     className="aui-assistant-message-root fade-in slide-in-from-bottom-1 relative mx-auto w-full max-w-(--thread-max-width) animate-in py-4 duration-200"
     data-role="assistant"
   >
-    <div className="text-xs text-(--fg-3) mb-2 font-(family-name:--font-display) tracking-wide pl-1">
-      ねっぷちゃん
+    <div className="flex items-center gap-1.5 mb-2 pl-1">
+      <img
+        src="/mascot/icon.png"
+        alt=""
+        aria-hidden="true"
+        className="size-6 rounded-full bg-(--teal-50) object-cover"
+      />
+      <span className="text-xs text-(--fg-3) font-(family-name:--font-display) tracking-wide">
+        ねっぷちゃん
+      </span>
     </div>
     <div className="flex justify-start">
       <SpeechBubble


### PR DESCRIPTION
## Summary

- モバイル画面でもねっぷちゃんを表示する。送信ボタンの上 (頭の中心が送信ボタン中央) に配置し、視覚補正で -3px だけ右にずらす
- assistant メッセージのヘッダー左にマスコットアイコンを追加し、誰の発言か視覚的に分かりやすくする
- 開発時の HMR 安定化のため、`msw` を Vite の `optimizeDeps.exclude` に追加

lg 以上の画面では従来通り左下配置を維持。

## 表示確認 (375px viewport)

<img width="1000" height="1624" alt="mascot-375" src="https://github.com/user-attachments/assets/b21b4291-7a15-4a37-b263-d525b5314e0e" />

## Test plan

- [ ] iPhone サイズ (375px) でマスコットが送信ボタンの上に表示される
- [ ] lg 以上で従来通り左下に表示される
- [ ] assistant メッセージのヘッダーにマスコットアイコンが表示される
- [ ] `pnpm --filter @nepp-chan/web test` (337/337 passed 済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)