### PR TITLE
fix(server): ペルソナ抽出を全件取得＋差分更新に修正

### DIFF
--- a/server/src/services/persona-extractor.test.ts
+++ b/server/src/services/persona-extractor.test.ts
@@ -369,4 +369,80 @@ describe("extractAllPendingThreads", () => {
     });
     expect(threadPersonaStatusRepository.upsert).toHaveBeenCalled();
   });
+
+  it("recall を全件・古い順（perPage:false / createdAt ASC）で呼ぶ", async () => {
+    vi.mocked(threadPersonaStatusRepository.findAll).mockResolvedValue([]);
+    mockAll
+      .mockResolvedValueOnce([{ id: "t1", resourceId: "r1" }])
+      .mockResolvedValueOnce([{ threadId: "t1", count: 2 }]);
+    mockMemoryRecall.mockResolvedValue({
+      messages: [
+        { role: "user", content: "u1", createdAt: new Date() },
+        { role: "assistant", content: "a1", createdAt: new Date() },
+      ],
+    });
+
+    await extractAllPendingThreads(mockEnv);
+
+    expect(mockMemoryRecall).toHaveBeenCalledWith({
+      threadId: "t1",
+      perPage: false,
+      orderBy: { field: "createdAt", direction: "ASC" },
+    });
+  });
+
+  it("差分更新: 前回処理位置以降の新規メッセージのみ分析し lastMessageCount を全件数まで前進", async () => {
+    vi.mocked(threadPersonaStatusRepository.findAll).mockResolvedValue([
+      {
+        threadId: "t1",
+        lastExtractedAt: "2024-01-01T00:00:00Z",
+        lastMessageCount: 2,
+      },
+    ]);
+    mockAll
+      .mockResolvedValueOnce([{ id: "t1", resourceId: "r1" }])
+      .mockResolvedValueOnce([{ threadId: "t1", count: 4 }]);
+    mockMemoryRecall.mockResolvedValue({
+      messages: [
+        { role: "user", content: "古い発言1", createdAt: new Date() },
+        { role: "assistant", content: "古い発言2", createdAt: new Date() },
+        { role: "user", content: "新規発言3", createdAt: new Date() },
+        { role: "assistant", content: "新規発言4", createdAt: new Date() },
+      ],
+    });
+
+    await extractAllPendingThreads(mockEnv);
+
+    const prompt = mockGenerate.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain("新規発言3");
+    expect(prompt).toContain("新規発言4");
+    expect(prompt).not.toContain("古い発言1");
+    expect(prompt).not.toContain("古い発言2");
+    expect(threadPersonaStatusRepository.upsert).toHaveBeenCalledWith(
+      mockEnv.DB,
+      expect.objectContaining({ threadId: "t1", lastMessageCount: 4 }),
+    );
+  });
+
+  it("extraction_error 時は upsert せず次回再試行に回す", async () => {
+    vi.mocked(threadPersonaStatusRepository.findAll).mockResolvedValue([]);
+    mockAll
+      .mockResolvedValueOnce([{ id: "t1", resourceId: "r1" }])
+      .mockResolvedValueOnce([{ threadId: "t1", count: 2 }]);
+    mockMemoryRecall.mockResolvedValue({
+      messages: [
+        { role: "user", content: "u1", createdAt: new Date() },
+        { role: "assistant", content: "a1", createdAt: new Date() },
+      ],
+    });
+    mockGenerate.mockRejectedValueOnce(new Error("boom"));
+
+    const result = await extractAllPendingThreads(mockEnv);
+
+    expect(result[0].result).toMatchObject({
+      skipped: true,
+      reason: "extraction_error",
+    });
+    expect(threadPersonaStatusRepository.upsert).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/services/persona-extractor.ts
+++ b/server/src/services/persona-extractor.ts
@@ -49,7 +49,13 @@ export const extractPersonaFromThread = async (
 ): Promise<ExtractResult> => {
   const memory = await getMemory(env.DB);
 
-  const result = await memory.recall({ threadId });
+  // perPage: false で全件取得（暗黙のデフォルト lastMessages: 10 を回避）。
+  // createdAt 昇順に固定し、slice(lastMessageCount) が前回処理位置以降の差分になるようにする。
+  const result = await memory.recall({
+    threadId,
+    perPage: false,
+    orderBy: { field: "createdAt", direction: "ASC" },
+  });
 
   const totalMessages = result.messages.length;
   if (totalMessages <= lastMessageCount) {
@@ -116,13 +122,10 @@ export const extractPersonaFromThread = async (
         messageCount: totalMessages,
       };
     }
-    // その他のエラーはログに出力してスキップ
+    // その他のエラーは一時的な失敗の可能性があるため処理位置を前進させない。
+    // messageCount を返さないことで status を更新せず、次回バッチで再試行する。
     logger.error(`Persona extraction failed for thread ${threadId}`, error);
-    return {
-      skipped: true,
-      reason: "extraction_error",
-      messageCount: totalMessages,
-    };
+    return { skipped: true, reason: "extraction_error" };
   }
 
   return { extracted: true, messageCount: totalMessages };


### PR DESCRIPTION
## Summary
- ペルソナ抽出（`server/src/services/persona-extractor.ts`）が `memory.recall` の暗黙デフォルト（直近10件）に依存しており、10件超のスレッドで古い発言を取りこぼし、`lastMessageCount` が10で頭打ちになって抽出が恒久停止する欠陥を修正
- 一時的なエラー（`extraction_error`）で処理位置を前進させてしまい、失敗した会話が再試行されない不整合を解消

## 主な変更内容
- `recall({ threadId })` → `recall({ threadId, perPage: false, orderBy: { field: "createdAt", direction: "ASC" } })`
  - `perPage: false` で全件取得（暗黙の `lastMessages: 10` を回避）
  - `createdAt` 昇順に固定し、`slice(lastMessageCount)` が「前回処理位置以降の差分」になることを保証（初回は全件、以降は差分）
- `extraction_error` 分岐から `messageCount` を除去
  - status を更新せず次回バッチで再試行（取りこぼし防止）
  - `no_persona_found`（保存対象なしの確定判断）は従来どおり前進させ、無限再処理を防止
- テスト追加（TDD）: recall 引数の回帰防止 / 差分更新で新規分のみ分析し全件数まで前進 / `extraction_error` 時に upsert しない

## Test plan
- [x] `pnpm --filter server test`（913 passed）
- [x] `pnpm lint`（Biome + tsc + astro、0 errors）
- [x] `pnpm format`（修正なし）