### PR TITLE
chore(deps): AI SDK を v6 系へ更新（server/web/lp）

### DIFF
--- a/lp/package.json
+++ b/lp/package.json
@@ -12,11 +12,11 @@
     "deploy:prd": "pnpm build && wrangler pages deploy --project-name nepp-chan-lp-prd --branch main"
   },
   "dependencies": {
-    "@ai-sdk/react": "^2.0.109",
+    "@ai-sdk/react": "^3.0.200",
     "@astrojs/check": "^0.9.9",
     "@astrojs/react": "^5.0.5",
     "@nepp-chan/shared": "workspace:*",
-    "ai": "^5.0.108",
+    "ai": "^6.0.198",
     "astro": "^6.3.8",
     "lucide-react": "^1.16.0",
     "react": "^19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
   lp:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^2.0.109
-        version: 2.0.122(react@19.2.6)(zod@4.4.3)
+        specifier: ^3.0.200
+        version: 3.0.200(react@19.2.6)(zod@4.4.3)
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
@@ -39,8 +39,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       ai:
-        specifier: ^5.0.108
-        version: 5.0.120(zod@4.4.3)
+        specifier: ^6.0.198
+        version: 6.0.198(zod@4.4.3)
       astro:
         specifier: ^6.3.8
         version: 6.3.8(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
@@ -85,8 +85,8 @@ importers:
   server:
     dependencies:
       '@ai-sdk/google':
-        specifier: ^2.0.46
-        version: 2.0.46(zod@4.4.3)
+        specifier: ^3.0.80
+        version: 3.0.80(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^3.0.66
         version: 3.0.66(zod@4.4.3)
@@ -100,8 +100,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1
       '@mastra/ai-sdk':
-        specifier: 1.4.3
-        version: 1.4.3(@mastra/core@1.10.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))(zod@4.4.3)
+        specifier: ^1.4.4
+        version: 1.4.4(@mastra/core@1.10.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))(zod@4.4.3)
       '@mastra/cloudflare-d1':
         specifier: 1.0.4
         version: 1.0.4(@mastra/core@1.10.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))
@@ -136,8 +136,8 @@ importers:
         specifier: ^10.54.0
         version: 10.54.0
       ai:
-        specifier: ^5.0.112
-        version: 5.0.120(zod@4.4.3)
+        specifier: ^6.0.198
+        version: 6.0.198(zod@4.4.3)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)
@@ -237,8 +237,8 @@ importers:
   web:
     dependencies:
       '@ai-sdk/react':
-        specifier: ^2.0.109
-        version: 2.0.122(react@19.2.6)(zod@4.4.3)
+        specifier: ^3.0.200
+        version: 3.0.200(react@19.2.6)(zod@4.4.3)
       '@astrojs/check':
         specifier: ^0.9.9
         version: 0.9.9(prettier@3.8.3)(typescript@6.0.3)
@@ -258,8 +258,8 @@ importers:
         specifier: ^5.100.14
         version: 5.100.14(react@19.2.6)
       ai:
-        specifier: ^5.0.108
-        version: 5.0.120(zod@4.4.3)
+        specifier: ^6.0.198
+        version: 6.0.198(zod@4.4.3)
       astro:
         specifier: ^6.3.8
         version: 6.3.8(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
@@ -352,14 +352,14 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@2.0.26':
-    resolution: {integrity: sha512-ACxps7/yUkv/TTmh8GdH/KTAWBoK1vH5ZirqftR4txmePruvSWFmXWiMgLdw9APPC0LIfP2pogMSc2CjtJk9SQ==}
+  '@ai-sdk/gateway@3.0.126':
+    resolution: {integrity: sha512-OHwcwdVkzLo7Rx4eeFyyH3e/vlsYg11HIgKPf5yH6jkptI1Kzq8BX9xZPIBq4BrLBTF2p6pgvWqRfy6AvARGkQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@2.0.46':
-    resolution: {integrity: sha512-8PK6u4sGE/kXebd7ZkTp+0aya4kNqzoqpS5m7cHY2NfTK6fhPc6GNvE+MZIZIoHQTp5ed86wGBdeBPpFaaUtyg==}
+  '@ai-sdk/google@3.0.80':
+    resolution: {integrity: sha512-5ORbm/yFUPO0MEvZsxBMN0cdKw2+lwU/wVn5KN3KF8Dmk1LughuDuUohMh/7iU/XFTiyB0OvmTW/tdV/J7O9zg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -375,12 +375,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.23.8
-
-  '@ai-sdk/provider-utils@3.0.19':
-    resolution: {integrity: sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@3.0.20':
     resolution: {integrity: sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==}
@@ -420,15 +414,11 @@ packages:
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@2.0.122':
-    resolution: {integrity: sha512-Q7z/P16U9NgMkF6XHcHFd3eorcgGILwbhstpiWv0adsl/nge8uRih879C6BRbMyo/NV7iKu0+nJSU9gfWeyMyw==}
+  '@ai-sdk/react@3.0.200':
+    resolution: {integrity: sha512-OzO/raYhgzQo5iVDRJYNCrlDj0gMmS8TBlOdGtZo5Elzl5unGEVQrtn0zjP3u4sFiKflr6D2En+qeeBMUzPZDA==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-      zod: ^3.25.76 || ^4.1.8
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@ai-sdk/ui-utils@1.2.11':
     resolution: {integrity: sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==}
@@ -2001,8 +1991,8 @@ packages:
     resolution: {integrity: sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==}
     engines: {node: '>=8'}
 
-  '@mastra/ai-sdk@1.4.3':
-    resolution: {integrity: sha512-M1zVWRqQ51jRR8exiwefj3xzfLtp/SjWflrJ2thaOh0ypf5fRc+1HN49CZ2duaORdVWd6dhYUz5Q9qwSyjOYgA==}
+  '@mastra/ai-sdk@1.4.4':
+    resolution: {integrity: sha512-03Mt0wQLK/80phsEM7P0BilIpXAW776vYxAb74qpBBRkuxP3WtHT2HThWMTqiLEV9v7P1c8iJ99VtLqXas44Gg==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       '@mastra/core': '>=1.5.0-0 <2.0.0-0'
@@ -2151,10 +2141,6 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
-
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
-    engines: {node: '>=8.0.0'}
 
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
@@ -2942,8 +2928,8 @@ packages:
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vitejs/plugin-react@5.2.0':
@@ -3053,8 +3039,8 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@5.0.120:
-    resolution: {integrity: sha512-2U+6nYaO2ZC+xoBu0ZgWMvuPoKcVrHwLpl9IhMDMgN5s8ayc8qGAXfDcbdJbYugVJw1Vi+6HzvsPNSTHAk8K5A==}
+  ai@6.0.198:
+    resolution: {integrity: sha512-NEXlYGu3n7VTG6cn3SAeimfy60FLH/R5uRpl7zqDu0BLtIuoY1lALBGoJzltoVqd/iFQH1asIy/VqZqLPDWv0w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6556,17 +6542,17 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@2.0.26(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.126(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google@2.0.46(zod@4.4.3)':
+  '@ai-sdk/google@3.0.80(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/openai@3.0.66(zod@4.4.3)':
@@ -6580,13 +6566,6 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.12
       secure-json-parse: 2.7.0
-      zod: 4.4.3
-
-  '@ai-sdk/provider-utils@3.0.19(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@3.0.20(zod@4.4.3)':
@@ -6630,15 +6609,15 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@2.0.122(react@19.2.6)(zod@4.4.3)':
+  '@ai-sdk/react@3.0.200(react@19.2.6)(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
-      ai: 5.0.120(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      ai: 6.0.198(zod@4.4.3)
       react: 19.2.6
       swr: 2.3.7(react@19.2.6)
       throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.4.3
+    transitivePeerDependencies:
+      - zod
 
   '@ai-sdk/ui-utils@1.2.11(zod@4.4.3)':
     dependencies:
@@ -7909,7 +7888,7 @@ snapshots:
     dependencies:
       '@lukeed/csprng': 1.1.0
 
-  '@mastra/ai-sdk@1.4.3(@mastra/core@1.10.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))(zod@4.4.3)':
+  '@mastra/ai-sdk@1.4.4(@mastra/core@1.10.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@mastra/core': 1.10.0(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.4.3)
       zod: 4.4.3
@@ -8165,8 +8144,6 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
-
-  '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -8867,7 +8844,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -9033,12 +9010,12 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@5.0.120(zod@4.4.3):
+  ai@6.0.198(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 2.0.26(zod@4.4.3)
-      '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@4.4.3)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 3.0.126(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.1
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.20.0):

--- a/server/package.json
+++ b/server/package.json
@@ -26,12 +26,12 @@
     "api:quota": "tsx scripts/api-quota.ts"
   },
   "dependencies": {
-    "@ai-sdk/google": "^2.0.46",
+    "@ai-sdk/google": "^3.0.80",
     "@ai-sdk/openai": "^3.0.66",
     "@hono/swagger-ui": "^0.6.1",
     "@hono/zod-openapi": "^1.4.0",
     "@line/bot-sdk": "^11.0.1",
-    "@mastra/ai-sdk": "1.4.3",
+    "@mastra/ai-sdk": "^1.4.4",
     "@mastra/cloudflare-d1": "1.0.4",
     "@mastra/core": "1.10.0",
     "@mastra/evals": "1.2.3",
@@ -43,7 +43,7 @@
     "@mastra/rag": "2.2.1",
     "@nepp-chan/shared": "workspace:*",
     "@sentry/cloudflare": "^10.54.0",
-    "ai": "^5.0.112",
+    "ai": "^6.0.198",
     "drizzle-orm": "^0.45.2",
     "glob": "^13.0.6",
     "gray-matter": "^4.0.3",

--- a/server/src/lib/chat-stream.ts
+++ b/server/src/lib/chat-stream.ts
@@ -1,0 +1,47 @@
+import { handleChatStream } from "@mastra/ai-sdk";
+import { createUIMessageStreamResponse } from "ai";
+
+type HandleChatStreamArgs = Parameters<typeof handleChatStream>[0];
+type ChatStreamParams = HandleChatStreamArgs["params"];
+type ChatStreamResponseInit = Parameters<
+  typeof createUIMessageStreamResponse
+>[0];
+
+type RespondWithChatStreamArgs = {
+  mastra: HandleChatStreamArgs["mastra"];
+  agentId: string;
+  message: unknown;
+  requestContext: ChatStreamParams["requestContext"];
+  memory?: ChatStreamParams["memory"];
+};
+
+/**
+ * handleChatStream を AI SDK v6 で実行し、UI message stream の Response を返す。
+ *
+ * @mastra/core は #422(#14503) の Cloudflare Workers 制約で 1.10 系に固定しており、
+ * @mastra/ai-sdk が vendor する ai v6 型とアプリの ai@6 型にスナップショット差がある。
+ * messages / stream の境界を関数シグネチャ由来の型へキャストして吸収する
+ * （実体は同一の v6 UIMessage / SSE ストリーム）。
+ */
+export const respondWithChatStream = async ({
+  mastra,
+  agentId,
+  message,
+  requestContext,
+  memory,
+}: RespondWithChatStreamArgs) => {
+  const stream = await handleChatStream({
+    mastra,
+    agentId,
+    version: "v6",
+    params: {
+      messages: [message] as ChatStreamParams["messages"],
+      requestContext,
+      memory,
+    },
+  });
+
+  return createUIMessageStreamResponse({
+    stream: stream as ChatStreamResponseInit["stream"],
+  });
+};

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -1,7 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { handleChatStream } from "@mastra/ai-sdk";
 import { Mastra } from "@mastra/core/mastra";
-import { createUIMessageStreamResponse, type UIMessage } from "ai";
+import { respondWithChatStream } from "~/lib/chat-stream";
 import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
@@ -75,14 +74,10 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
     env: c.env,
   });
 
-  const stream = await handleChatStream({
+  return respondWithChatStream({
     mastra,
     agentId: "neppChanAgent",
-    params: {
-      messages: [message] as UIMessage[],
-      requestContext,
-    },
+    message,
+    requestContext,
   });
-
-  return createUIMessageStreamResponse({ stream });
 });

--- a/server/src/routes/threads/chat.ts
+++ b/server/src/routes/threads/chat.ts
@@ -1,7 +1,6 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { handleChatStream } from "@mastra/ai-sdk";
 import { Mastra } from "@mastra/core/mastra";
-import { createUIMessageStreamResponse, type UIMessage } from "ai";
+import { respondWithChatStream } from "~/lib/chat-stream";
 import { classifyIntent } from "~/lib/classify-intent";
 import { resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
@@ -105,18 +104,14 @@ chatRoutes.openapi(chatRoute, async (c) => {
     adminUser,
   });
 
-  const stream = await handleChatStream({
+  return respondWithChatStream({
     mastra,
     agentId: "neppChanAgent",
-    params: {
-      messages: [message] as UIMessage[],
-      requestContext,
-      memory: {
-        resource: thread.resourceId,
-        thread: threadId,
-      },
+    message,
+    requestContext,
+    memory: {
+      resource: thread.resourceId,
+      thread: threadId,
     },
   });
-
-  return createUIMessageStreamResponse({ stream });
 });

--- a/web/package.json
+++ b/web/package.json
@@ -15,14 +15,14 @@
     "openapi:generate": "openapi-typescript http://localhost:8787/doc -o ../shared/src/api/types.d.ts"
   },
   "dependencies": {
-    "@ai-sdk/react": "^2.0.109",
+    "@ai-sdk/react": "^3.0.200",
     "@astrojs/check": "^0.9.9",
     "@astrojs/react": "^5.0.5",
     "@heroicons/react": "^2.2.0",
     "@nepp-chan/shared": "workspace:*",
     "@sentry/react": "^10.54.0",
     "@tanstack/react-query": "^5.100.14",
-    "ai": "^5.0.108",
+    "ai": "^6.0.198",
     "astro": "^6.3.8",
     "lucide-react": "^1.16.0",
     "openapi-fetch": "^0.17.0",


### PR DESCRIPTION
## Summary
- `ai` v5→v6、`@ai-sdk/google` v2→v3、`@ai-sdk/react` v2→v3、`@mastra/ai-sdk` 1.4.3→`^1.4.4` をスタック全体（server/web/lp）で更新
- `@mastra/core` は #422 / 上流 mastra-ai/mastra#14503（Cloudflare Workers の `new Function` 非互換）により **1.10 系に据え置き**
- chat ストリーミングを AI SDK v6 プロトコルへ移行

## 主な変更内容
- **chat ルート**: `handleChatStream({ version: "v6" })` で v6 オーバーロードを選択。v6 ストリームの型ブリッジ（messages / stream の境界キャスト）と `createUIMessageStreamResponse` を `server/src/lib/chat-stream.ts` の `respondWithChatStream()` に集約し、両ルートから利用
  - 型ドリフトの原因: `@mastra/ai-sdk` が vendor する ai v6 型スナップショットとアプリの `ai@6` 最新の差。`@mastra/ai-sdk` が `V6UIMessage` を public export しないため、関数シグネチャ由来の型でキャスト。実体は同一の v6 UIMessage / SSE でランタイムは無害
  - 公式も同方針（mastra-ai/mastra#14292 を PR #14405 の `version:'v6'` で修正）
- **web / lp**: `useChat` / `DefaultChatTransport` / `UIMessage` 等は v6 で型互換のためコード修正なし
- **embeddings / search / grounding**: `embed` / `embedMany` / `@ai-sdk/google` v3・`google.tools.googleSearch` は無修正で型クリーン

## Test plan
- [x] server `tsc` 0 / vitest 913 pass / `wrangler deploy --dry-run` バンドル OK
- [x] web `tsc` 0 / `astro check` 0 / vitest 367 pass / build OK
- [x] lp `tsc` 0 / `astro check` 0 / build OK
- [x] dev デプロイ後、チャットの v6 SSE ストリーミング実挙動を1往復スモーク（web / LINE）