### PR TITLE
feat: mastra 1.41 の新機能採用とツール表示まわりの疎結合化

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -99,6 +99,9 @@ server/src/
 
 メインキャラクター「ねっぷちゃん」は `createNeppChanAgent({ isAdmin, platform, modelConfig })` で動的に生成される。
 `modelConfig` は `resolveModelTier()` で Intent（casual/thinking）× プラットフォーム × 管理者フラグから決定する。
+各ティアはモデルのフォールバック連鎖（プライマリ障害時に同じ thinking 設定で次のモデルを試行）と
+ツール実行ループ上限 `defaultOptions.maxSteps` を含む。フォールバックエントリの `id` は必ず明示する
+（省略すると Agent 構築時の randomUUID() が workerd のグローバルスコープ制約に抵触する）。
 
 - **一般ユーザー**: 基本機能のみ（天気、Web検索、ナレッジ、緊急報告）
 - **管理者**: 基本機能 + 管理者専用エージェント（emergency, feedback, persona-analyst）

--- a/server/src/lib/chat-stream.ts
+++ b/server/src/lib/chat-stream.ts
@@ -3,9 +3,6 @@ import { createUIMessageStreamResponse } from "ai";
 
 type HandleChatStreamArgs = Parameters<typeof handleChatStream>[0];
 type ChatStreamParams = HandleChatStreamArgs["params"];
-type ChatStreamResponseInit = Parameters<
-  typeof createUIMessageStreamResponse
->[0];
 
 type RespondWithChatStreamArgs = {
   mastra: HandleChatStreamArgs["mastra"];
@@ -19,10 +16,11 @@ type RespondWithChatStreamArgs = {
 /**
  * handleChatStream を AI SDK v6 で実行し、UI message stream の Response を返す。
  *
- * @mastra/core は #422(#14503) の Cloudflare Workers 制約で 1.10 系に固定しており、
- * @mastra/ai-sdk が vendor する ai v6 型とアプリの ai@6 型にスナップショット差がある。
- * messages / stream の境界を関数シグネチャ由来の型へキャストして吸収する
- * （実体は同一の v6 UIMessage / SSE ストリーム）。
+ * @mastra/ai-sdk は ai v6 型のスナップショットを vendor しており、アプリの ai@6 と
+ * 宣言が一部異なる（dynamic-tool パートの input の optionality 等）。さらにルートの
+ * zod スキーマ（looseObject）由来の message はどちらの UIMessage 宣言にも構造一致
+ * しないため、handleChatStream のシグネチャ由来の型へキャストして渡す
+ * （値は v6 UIMessage 形式の JSON）。このキャストを 1 箇所に集約するのがこの関数の役割。
  */
 export const respondWithChatStream = async ({
   mastra,
@@ -44,7 +42,5 @@ export const respondWithChatStream = async ({
     },
   });
 
-  return createUIMessageStreamResponse({
-    stream: stream as ChatStreamResponseInit["stream"],
-  });
+  return createUIMessageStreamResponse({ stream });
 };

--- a/server/src/lib/chat-stream.ts
+++ b/server/src/lib/chat-stream.ts
@@ -16,11 +16,10 @@ type RespondWithChatStreamArgs = {
 /**
  * handleChatStream を AI SDK v6 で実行し、UI message stream の Response を返す。
  *
- * @mastra/ai-sdk は ai v6 型のスナップショットを vendor しており、アプリの ai@6 と
- * 宣言が一部異なる（dynamic-tool パートの input の optionality 等）。さらにルートの
- * zod スキーマ（looseObject）由来の message はどちらの UIMessage 宣言にも構造一致
- * しないため、handleChatStream のシグネチャ由来の型へキャストして渡す
- * （値は v6 UIMessage 形式の JSON）。このキャストを 1 箇所に集約するのがこの関数の役割。
+ * @mastra/ai-sdk は ai v6 型のスナップショットを vendor しておりアプリの ai@6 と
+ * 宣言が一部異なるうえ、zod スキーマ（looseObject）由来の message はどちらの
+ * UIMessage 宣言にも構造一致しないため、handleChatStream のシグネチャ由来の型へ
+ * キャストして渡す（値は v6 UIMessage 形式の JSON）。
  */
 export const respondWithChatStream = async ({
   mastra,

--- a/server/src/lib/llm-models.test.ts
+++ b/server/src/lib/llm-models.test.ts
@@ -126,9 +126,7 @@ describe("resolveModelTier", () => {
       }
     });
 
-    it("全エントリに id が明示されている", () => {
-      // id 未指定だと Agent 構築時に randomUUID() が呼ばれ、
-      // モジュールグローバルで生成する Playground 用 Agent が workerd の起動を壊す
+    it("全エントリに id が明示されている（未指定だと randomUUID が workerd の起動を壊す）", () => {
       const tier = resolveModelTier({
         intent: "casual",
         platform: "web",

--- a/server/src/lib/llm-models.test.ts
+++ b/server/src/lib/llm-models.test.ts
@@ -3,6 +3,7 @@ import {
   GEMINI_FLASH,
   GEMINI_FLASH_LITE,
   type Intent,
+  primaryModelId,
   resolveModelTier,
 } from "./llm-models";
 
@@ -13,66 +14,140 @@ describe("resolveModelTier", () => {
 
     for (const intent of intents) {
       for (const platform of platforms) {
-        it(`intent=${intent}, platform=${platform} でも FLASH + high`, () => {
+        it(`intent=${intent}, platform=${platform} でもプライマリ FLASH + high`, () => {
           const tier = resolveModelTier({ intent, platform, isAdmin: true });
-          expect(tier.model).toBe(GEMINI_FLASH);
-          expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
-            "high",
-          );
+          expect(tier.model[0].model).toBe(GEMINI_FLASH);
+          expect(
+            tier.model[0].providerOptions.google.thinkingConfig.thinkingLevel,
+          ).toBe("high");
         });
       }
     }
   });
 
   describe("Web プラットフォーム（非 Admin）", () => {
-    it("casual → FLASH_LITE + low", () => {
+    it("casual → プライマリ FLASH_LITE + low、フォールバック FLASH", () => {
       const tier = resolveModelTier({
         intent: "casual",
         platform: "web",
         isAdmin: false,
       });
-      expect(tier.model).toBe(GEMINI_FLASH_LITE);
-      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
-        "low",
-      );
+      expect(tier.model.map((m) => m.model)).toEqual([
+        GEMINI_FLASH_LITE,
+        GEMINI_FLASH,
+      ]);
+      expect(
+        tier.model[0].providerOptions.google.thinkingConfig.thinkingLevel,
+      ).toBe("low");
     });
 
-    it("thinking → FLASH + high", () => {
+    it("thinking → プライマリ FLASH + high、フォールバック FLASH_LITE", () => {
       const tier = resolveModelTier({
         intent: "thinking",
         platform: "web",
         isAdmin: false,
       });
-      expect(tier.model).toBe(GEMINI_FLASH);
-      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
-        "high",
-      );
+      expect(tier.model.map((m) => m.model)).toEqual([
+        GEMINI_FLASH,
+        GEMINI_FLASH_LITE,
+      ]);
+      expect(
+        tier.model[0].providerOptions.google.thinkingConfig.thinkingLevel,
+      ).toBe("high");
     });
   });
 
   describe("LINE プラットフォーム（非 Admin）", () => {
-    it("casual → FLASH_LITE + thinking 無効 (thinkingBudget: 0)", () => {
+    it("casual → プライマリ FLASH_LITE + thinking 無効 (thinkingBudget: 0)", () => {
       const tier = resolveModelTier({
         intent: "casual",
         platform: "line",
         isAdmin: false,
       });
-      expect(tier.model).toBe(GEMINI_FLASH_LITE);
-      expect(tier.providerOptions.google.thinkingConfig).toEqual({
+      expect(tier.model[0].model).toBe(GEMINI_FLASH_LITE);
+      expect(tier.model[0].providerOptions.google.thinkingConfig).toEqual({
         thinkingBudget: 0,
       });
     });
 
-    it("thinking → FLASH + medium", () => {
+    it("thinking → プライマリ FLASH + medium", () => {
       const tier = resolveModelTier({
         intent: "thinking",
         platform: "line",
         isAdmin: false,
       });
-      expect(tier.model).toBe(GEMINI_FLASH);
-      expect(tier.providerOptions.google.thinkingConfig.thinkingLevel).toBe(
-        "medium",
-      );
+      expect(tier.model[0].model).toBe(GEMINI_FLASH);
+      expect(
+        tier.model[0].providerOptions.google.thinkingConfig.thinkingLevel,
+      ).toBe("medium");
     });
+  });
+
+  describe("maxSteps", () => {
+    it("casual はツール実行ループ上限 5", () => {
+      const tier = resolveModelTier({
+        intent: "casual",
+        platform: "web",
+        isAdmin: false,
+      });
+      expect(tier.defaultOptions.maxSteps).toBe(5);
+    });
+
+    it("thinking はツール実行ループ上限 10", () => {
+      const tier = resolveModelTier({
+        intent: "thinking",
+        platform: "line",
+        isAdmin: false,
+      });
+      expect(tier.defaultOptions.maxSteps).toBe(10);
+    });
+  });
+
+  describe("フォールバック構成", () => {
+    it("フォールバックはプライマリと同じ thinking 設定を引き継ぐ", () => {
+      const tier = resolveModelTier({
+        intent: "thinking",
+        platform: "line",
+        isAdmin: false,
+      });
+      expect(
+        tier.model[1].providerOptions.google.thinkingConfig.thinkingLevel,
+      ).toBe("medium");
+    });
+
+    it("全エントリに maxRetries が設定されている", () => {
+      const tier = resolveModelTier({
+        intent: "casual",
+        platform: "web",
+        isAdmin: false,
+      });
+      for (const entry of tier.model) {
+        expect(entry.maxRetries).toBe(1);
+      }
+    });
+
+    it("全エントリに id が明示されている", () => {
+      // id 未指定だと Agent 構築時に randomUUID() が呼ばれ、
+      // モジュールグローバルで生成する Playground 用 Agent が workerd の起動を壊す
+      const tier = resolveModelTier({
+        intent: "casual",
+        platform: "web",
+        isAdmin: false,
+      });
+      for (const entry of tier.model) {
+        expect(entry.id).toBe(entry.model);
+      }
+    });
+  });
+});
+
+describe("primaryModelId", () => {
+  it("先頭エントリのモデル ID を返す", () => {
+    const tier = resolveModelTier({
+      intent: "casual",
+      platform: "web",
+      isAdmin: false,
+    });
+    expect(primaryModelId(tier)).toBe(GEMINI_FLASH_LITE);
   });
 });

--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -129,6 +129,5 @@ export const resolveModelTier = ({
   return MODEL_TIERS[intent][platform];
 };
 
-/** 使用量記録などでフォールバック前提のモデル ID が必要なときに使う */
 export const primaryModelId = (config: ModelTierConfig) =>
   config.model[0].model;

--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -16,13 +16,15 @@ export const OPENAI_SCORER = "openai/gpt-4.1-nano";
 // 埋め込みモデル
 export const GEMINI_EMBEDDING = "gemini-embedding-001";
 
+type ThinkingLevel = "high" | "medium" | "low" | "none";
+
 /**
  * Gemini モデルと thinkingConfig を含む Agent 設定を返す。
  * "none" は AI SDK の thinkingLevel enum に存在しないため thinkingBudget: 0 で無効化する。
  */
 export const geminiModelWithThinking = ({
   model = GEMINI_FLASH_LITE,
-  level = "low" as "high" | "medium" | "low" | "none",
+  level = "low" as ThinkingLevel,
 } = {}) => ({
   model,
   providerOptions: {
@@ -35,16 +37,77 @@ export const geminiModelWithThinking = ({
 
 export type Intent = "casual" | "thinking";
 
-export type ModelTierConfig = ReturnType<typeof geminiModelWithThinking>;
+/**
+ * プライマリ障害・レート制限時に同じ thinking 設定のままフォールバックする
+ * モデル連鎖を返す。コスト暴発を避けるため PRO へはフォールバックしない。
+ * id を省略すると Agent 構築時に randomUUID() が呼ばれ、モジュールグローバルで
+ * 生成する Agent が workerd の起動を壊すため必ず明示する。
+ */
+const geminiModelChain = ({
+  primary,
+  fallback,
+  level,
+}: {
+  primary: string;
+  fallback: string;
+  level: ThinkingLevel;
+}) => [
+  {
+    id: primary,
+    ...geminiModelWithThinking({ model: primary, level }),
+    maxRetries: 1,
+  },
+  {
+    id: fallback,
+    ...geminiModelWithThinking({ model: fallback, level }),
+    maxRetries: 1,
+  },
+];
+
+export type ModelTierConfig = {
+  model: ReturnType<typeof geminiModelChain>;
+  defaultOptions: { maxSteps: number };
+};
+
+// ツール実行ループの上限（サブエージェント連鎖の暴走によるコスト事故の保険）
+const MAX_STEPS = { casual: 5, thinking: 10 } as const;
 
 const MODEL_TIERS: Record<Intent, Record<"web" | "line", ModelTierConfig>> = {
   casual: {
-    web: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "low" }),
-    line: geminiModelWithThinking({ model: GEMINI_FLASH_LITE, level: "none" }),
+    web: {
+      model: geminiModelChain({
+        primary: GEMINI_FLASH_LITE,
+        fallback: GEMINI_FLASH,
+        level: "low",
+      }),
+      defaultOptions: { maxSteps: MAX_STEPS.casual },
+    },
+    line: {
+      model: geminiModelChain({
+        primary: GEMINI_FLASH_LITE,
+        fallback: GEMINI_FLASH,
+        level: "none",
+      }),
+      defaultOptions: { maxSteps: MAX_STEPS.casual },
+    },
   },
   thinking: {
-    web: geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
-    line: geminiModelWithThinking({ model: GEMINI_FLASH, level: "medium" }),
+    web: {
+      model: geminiModelChain({
+        primary: GEMINI_FLASH,
+        fallback: GEMINI_FLASH_LITE,
+        level: "high",
+      }),
+      defaultOptions: { maxSteps: MAX_STEPS.thinking },
+    },
+    line: {
+      model: geminiModelChain({
+        primary: GEMINI_FLASH,
+        fallback: GEMINI_FLASH_LITE,
+        level: "medium",
+      }),
+      defaultOptions: { maxSteps: MAX_STEPS.thinking },
+    },
   },
 };
 
@@ -65,3 +128,7 @@ export const resolveModelTier = ({
   }
   return MODEL_TIERS[intent][platform];
 };
+
+/** 使用量記録などでフォールバック前提のモデル ID が必要なときに使う */
+export const primaryModelId = (config: ModelTierConfig) =>
+  config.model[0].model;

--- a/server/src/mastra/agents/emergency-reporter-agent.ts
+++ b/server/src/mastra/agents/emergency-reporter-agent.ts
@@ -1,4 +1,5 @@
 import { Agent } from "@mastra/core/agent";
+import { AGENT_TOOL_NAMES } from "@nepp-chan/shared/constants/agent-tools";
 import { geminiModelWithThinking } from "~/lib/llm-models";
 import { emergencyReportTool } from "~/mastra/tools/emergency-report-tool";
 import { emergencyUpdateTool } from "~/mastra/tools/emergency-update-tool";
@@ -31,7 +32,7 @@ export const emergencyReporterAgent = new Agent({
 ## 対応フロー
 1. ユーザーの安全を確認「大丈夫？安全な場所にいる？」
 2. 会話履歴から得られていない情報のみ確認（何が・どこで）
-3. emergency-report ツールで記録
+3. ${AGENT_TOOL_NAMES.emergencyReport} ツールで記録
 4. 必要に応じて緊急連絡先を案内（110/119）
 
 ## 対話ルール
@@ -43,12 +44,12 @@ export const emergencyReporterAgent = new Agent({
 - 専門用語を使わず、一般住民にわかる言葉で対話する
 
 ## 利用可能なツール
-- emergency-report: 新規の緊急報告を記録
-- emergency-update: 既存の報告に情報を追加
+- ${AGENT_TOOL_NAMES.emergencyReport}: 新規の緊急報告を記録
+- ${AGENT_TOOL_NAMES.emergencyUpdate}: 既存の報告に情報を追加
 `,
   ...geminiModelWithThinking(),
   tools: {
-    emergencyReportTool,
-    emergencyUpdateTool,
+    [AGENT_TOOL_NAMES.emergencyReport]: emergencyReportTool,
+    [AGENT_TOOL_NAMES.emergencyUpdate]: emergencyUpdateTool,
   },
 });

--- a/server/src/mastra/agents/knowledge-agent.ts
+++ b/server/src/mastra/agents/knowledge-agent.ts
@@ -1,7 +1,10 @@
 import { Agent } from "@mastra/core/agent";
 import { getCurrentDateInfo } from "~/lib/date";
 import { GEMINI_FLASH, geminiModelWithThinking } from "~/lib/llm-models";
-import { broadcastGetTool } from "~/mastra/tools/broadcast-get-tool";
+import {
+  broadcastGetTool,
+  broadcastGetToolName,
+} from "~/mastra/tools/broadcast-get-tool";
 import { knowledgeSearchTool } from "~/mastra/tools/knowledge-search-tool";
 
 const baseInstructions = `
@@ -101,7 +104,7 @@ const baseInstructions = `
 検索結果にない情報の推測や捏造は行わない。
 
 ## LINE配信メッセージの検索
-broadcast-get ツールで過去にLINEで配信したお知らせを検索できる。
+${broadcastGetToolName} ツールで過去にLINEで配信したお知らせを検索できる。
 ナレッジ検索で該当情報が見つからない場合や、ユーザーの質問が「お知らせ」「配信」「通知」に関連しそうな場合はこちらも検索する。
 
 ## URLの取り扱い
@@ -130,7 +133,7 @@ export const knowledgeAgent = new Agent({
   ...geminiModelWithThinking({ model: GEMINI_FLASH, level: "high" }),
   tools: {
     knowledgeSearchTool,
-    broadcastGetTool,
+    [broadcastGetToolName]: broadcastGetTool,
   },
 });
 
@@ -144,6 +147,6 @@ export const createKnowledgeAgentWithModel = (model: string) =>
     ...geminiModelWithThinking({ model, level: "high" }),
     tools: {
       knowledgeSearchTool,
-      broadcastGetTool,
+      [broadcastGetToolName]: broadcastGetTool,
     },
   });

--- a/server/src/mastra/agents/nepp-chan-agent.test.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { ModelTierConfig } from "~/lib/llm-models";
-import { createNeppChanAgent } from "./nepp-chan-agent";
+import { GEMINI_FLASH_LITE, type ModelTierConfig } from "~/lib/llm-models";
+import { createNeppChanAgent, neppChanMemoryOptions } from "./nepp-chan-agent";
 
 const modelConfig = { model: "dummy-model" } as unknown as ModelTierConfig;
 
@@ -55,6 +55,22 @@ describe("createNeppChanAgent", () => {
 
     it("withMemory=true でも生成できる（memory を wiring する分岐）", () => {
       expect(build({ withMemory: true })).toBeDefined();
+    });
+  });
+
+  describe("memory オプション", () => {
+    it("タイトル生成は FLASH_LITE + 日本語指示で行う", () => {
+      expect(neppChanMemoryOptions.generateTitle.model).toBe(GEMINI_FLASH_LITE);
+      expect(neppChanMemoryOptions.generateTitle.instructions).toContain(
+        "日本語",
+      );
+    });
+
+    it("working memory は resource スコープで有効", () => {
+      expect(neppChanMemoryOptions.workingMemory).toMatchObject({
+        enabled: true,
+        scope: "resource",
+      });
     });
   });
 });

--- a/server/src/mastra/agents/nepp-chan-agent.test.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.test.ts
@@ -1,6 +1,9 @@
+import { DISPLAY_TOOL_NAMES } from "@nepp-chan/shared/constants/display-tools";
 import { describe, expect, it } from "vitest";
 
 import { GEMINI_FLASH_LITE, type ModelTierConfig } from "~/lib/llm-models";
+import { broadcastGetToolName } from "~/mastra/tools/broadcast-get-tool";
+import { pollGetToolName } from "~/mastra/tools/poll-get-tool";
 import { createNeppChanAgent, neppChanMemoryOptions } from "./nepp-chan-agent";
 
 const modelConfig = { model: "dummy-model" } as unknown as ModelTierConfig;
@@ -40,6 +43,17 @@ describe("createNeppChanAgent", () => {
     it("常に現在の日時セクションを含む", async () => {
       const ins = await instructionsOf(build());
       expect(ins).toContain("現在の日時");
+    });
+
+    it("ツールはモデルに公開される toolName（登録キー）で参照する", async () => {
+      const ins = await instructionsOf(build({ isAdmin: true }));
+      expect(ins).toContain(DISPLAY_TOOL_NAMES.chart);
+      expect(ins).toContain(DISPLAY_TOOL_NAMES.table);
+      expect(ins).toContain(DISPLAY_TOOL_NAMES.timeline);
+      expect(ins).toContain(pollGetToolName);
+
+      const lineIns = await instructionsOf(build({ platform: "line" }));
+      expect(lineIns).toContain(broadcastGetToolName);
     });
   });
 

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -2,7 +2,11 @@ import type { AgentConfig } from "@mastra/core/agent";
 import { Agent } from "@mastra/core/agent";
 import { DISPLAY_TOOL_NAMES } from "@nepp-chan/shared/constants/display-tools";
 import { getCurrentDateInfo } from "~/lib/date";
-import { type ModelTierConfig, resolveModelTier } from "~/lib/llm-models";
+import {
+  GEMINI_FLASH_LITE,
+  type ModelTierConfig,
+  resolveModelTier,
+} from "~/lib/llm-models";
 import { emergencyAgent } from "~/mastra/agents/emergency-agent";
 import { emergencyReporterAgent } from "~/mastra/agents/emergency-reporter-agent";
 import { feedbackAgent } from "~/mastra/agents/feedback-agent";
@@ -198,6 +202,23 @@ const lineInstructions = `
 - 古い配信や会話履歴に無い配信の詳細が必要なときは broadcast-get ツールを使う
 `;
 
+export const neppChanMemoryOptions = {
+  // タイトル生成は会話本体と切り離して常に軽量モデルで行う
+  generateTitle: {
+    model: GEMINI_FLASH_LITE,
+    instructions:
+      "ユーザーの最初のメッセージから15文字以内の簡潔な日本語タイトルを生成する。",
+  },
+  // useStateSignals は schema モードで state signal パイプラインが文字列前提の
+  // zod 検証に落ちる上流バグがあり採用見送り（workerd 実機で確認）
+  workingMemory: {
+    enabled: true,
+    scope: "resource",
+    schema: personaSchema,
+  },
+  lastMessages: 20,
+} as const;
+
 type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   isAdmin?: boolean;
   platform?: Platform;
@@ -235,15 +256,7 @@ export const createNeppChanAgent = ({
     tools,
     ...(withMemory && {
       memory: ({ requestContext }) =>
-        getMemoryFromContext(requestContext, {
-          generateTitle: true,
-          workingMemory: {
-            enabled: true,
-            scope: "resource",
-            schema: personaSchema,
-          },
-          lastMessages: 20,
-        }),
+        getMemoryFromContext(requestContext, neppChanMemoryOptions),
     }),
     ...agentOptions,
   });

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -14,12 +14,15 @@ import { knowledgeAgent } from "~/mastra/agents/knowledge-agent";
 import { personaAnalystAgent } from "~/mastra/agents/persona-analyst-agent";
 import { webResearcherAgent } from "~/mastra/agents/web-researcher-agent";
 import { getMemoryFromContext } from "~/mastra/memory";
-import { broadcastGetTool } from "~/mastra/tools/broadcast-get-tool";
+import {
+  broadcastGetTool,
+  broadcastGetToolName,
+} from "~/mastra/tools/broadcast-get-tool";
 
 import { displayChartTool } from "~/mastra/tools/display-chart-tool";
 import { displayTableTool } from "~/mastra/tools/display-table-tool";
 import { displayTimelineTool } from "~/mastra/tools/display-timeline-tool";
-import { pollGetTool } from "~/mastra/tools/poll-get-tool";
+import { pollGetTool, pollGetToolName } from "~/mastra/tools/poll-get-tool";
 import { personaSchema } from "~/schemas/persona-schema";
 
 type Platform = "web" | "line" | "widget";
@@ -104,9 +107,9 @@ ${
 
 ### サブエージェントの結果の可視化
 サブエージェントの分析結果に件数・割合・時系列が含まれている場合は、テキストで中継せず可視化ツールで表示する。
-- カテゴリ別の件数・割合 → display-chart
-- 日付付きの出来事が複数 → display-timeline
-- 多項目の一覧 → display-table
+- カテゴリ別の件数・割合 → ${DISPLAY_TOOL_NAMES.chart}
+- 日付付きの出来事が複数 → ${DISPLAY_TOOL_NAMES.timeline}
+- 多項目の一覧 → ${DISPLAY_TOOL_NAMES.table}
 
 ## Working Memory
 会話からユーザーの情報を記録し、次回以降の会話で活用する。
@@ -129,8 +132,8 @@ const adminInstructions = `
   例: 「住民の声を教えて」「困ってる人はいる？」「村の調子はどう？」「最近どんな話題が多い？」「年代別の傾向は？」「交通の不満をもっと教えて」
 
 ### 投票の結果・傾向分析
-- 投票結果を踏まえた分析（例: 「最近の投票結果は？」「どの選択肢が人気だった？」「投票の傾向を教えて」）→ pollGetTool
-- 選択肢別の割合や参加人数は display-chart で可視化、複数投票の比較は display-table で一覧化する
+- 投票結果を踏まえた分析（例: 「最近の投票結果は？」「どの選択肢が人気だった？」「投票の傾向を教えて」）→ ${pollGetToolName}
+- 選択肢別の割合や参加人数は ${DISPLAY_TOOL_NAMES.chart} で可視化、複数投票の比較は ${DISPLAY_TOOL_NAMES.table} で一覧化する
 `;
 
 const baseAgents = {
@@ -152,8 +155,8 @@ const widgetAgents = {
 };
 
 const defaultTools = {
-  broadcastGetTool,
-  pollGetTool,
+  [broadcastGetToolName]: broadcastGetTool,
+  [pollGetToolName]: pollGetTool,
 };
 
 const webTools = {
@@ -163,7 +166,7 @@ const webTools = {
 };
 
 const widgetTools = {
-  broadcastGetTool,
+  [broadcastGetToolName]: broadcastGetTool,
 };
 
 const getTools = (platform: Platform) => {
@@ -199,7 +202,7 @@ const lineInstructions = `
 ### LINE配信の記憶
 ユーザーはLINE配信メッセージを受信している。会話履歴に【LINE配信のお知らせ】として含まれている。
 - ユーザーの発言が直近の配信内容に関連していそうなら、その配信を踏まえて応答する。指示語（「これ」「さっきの」「あれ」「この前の」等）に限らず、配信で触れた話題・イベント・告知への反応や質問・感想も対象とする
-- 古い配信や会話履歴に無い配信の詳細が必要なときは broadcast-get ツールを使う
+- 古い配信や会話履歴に無い配信の詳細が必要なときは ${broadcastGetToolName} ツールを使う
 `;
 
 export const neppChanMemoryOptions = {

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -203,14 +203,11 @@ const lineInstructions = `
 `;
 
 export const neppChanMemoryOptions = {
-  // タイトル生成は会話本体と切り離して常に軽量モデルで行う
   generateTitle: {
     model: GEMINI_FLASH_LITE,
     instructions:
       "ユーザーの最初のメッセージから15文字以内の簡潔な日本語タイトルを生成する。",
   },
-  // useStateSignals は schema モードで state signal パイプラインが文字列前提の
-  // zod 検証に落ちる上流バグがあり採用見送り（workerd 実機で確認）
   workingMemory: {
     enabled: true,
     scope: "resource",

--- a/server/src/mastra/tools/broadcast-get-tool.ts
+++ b/server/src/mastra/tools/broadcast-get-tool.ts
@@ -5,6 +5,9 @@ import { broadcastRepository } from "~/repository/broadcast-repository";
 import { broadcastMessageSchema } from "~/schemas/broadcast-schema";
 import { requireDb } from "./helpers";
 
+/** エージェント登録キーと instructions 内の参照を一致させるための toolName */
+export const broadcastGetToolName = "broadcastGetTool";
+
 export const broadcastGetTool = createTool({
   id: "broadcast-get",
   description:

--- a/server/src/mastra/tools/display-chart-tool.ts
+++ b/server/src/mastra/tools/display-chart-tool.ts
@@ -1,8 +1,8 @@
-import { createTool } from "@mastra/core/tools";
 import { displayChartSchema } from "@nepp-chan/shared/schemas/display-tools";
-import { z } from "zod";
 
-export const displayChartTool = createTool({
+import { createDisplayTool } from "./display-tool-factory";
+
+export const displayChartTool = createDisplayTool({
   id: "display-chart",
   description: `データをグラフで可視化するツール。
 サブエージェントの分析結果やツールの集計結果に件数・割合が含まれている場合、テキストで列挙するよりこのツールを使う。
@@ -34,11 +34,4 @@ data: [{ "トピック": "交通", "件数": 5 }, { "トピック": "除雪", "�
 - xKey/yKeyとdata内のキー名が一致していない → グラフが空になる
 - yKeyの値が文字列になっている → 数値にすること`,
   inputSchema: displayChartSchema,
-  outputSchema: z.object({
-    displayed: z.boolean(),
-  }),
-  execute: async () => {
-    // UI側で表示するため、サーバーでは何もしない
-    return { displayed: true };
-  },
 });

--- a/server/src/mastra/tools/display-table-tool.ts
+++ b/server/src/mastra/tools/display-table-tool.ts
@@ -1,8 +1,8 @@
-import { createTool } from "@mastra/core/tools";
 import { displayTableSchema } from "@nepp-chan/shared/schemas/display-tools";
-import { z } from "zod";
 
-export const displayTableTool = createTool({
+import { createDisplayTool } from "./display-tool-factory";
+
+export const displayTableTool = createDisplayTool({
   id: "display-table",
   description: `データをテーブル形式で表示するツール。
 一覧データや複数フィールドの比較を見せたいときに使用する。
@@ -34,10 +34,4 @@ data: [
 - columnsのkeyとdata内のキー名が一致していない → 列が空になる
 - columnsを省略 → 必須フィールド`,
   inputSchema: displayTableSchema,
-  outputSchema: z.object({
-    displayed: z.boolean(),
-  }),
-  execute: async () => {
-    return { displayed: true };
-  },
 });

--- a/server/src/mastra/tools/display-timeline-tool.ts
+++ b/server/src/mastra/tools/display-timeline-tool.ts
@@ -1,8 +1,8 @@
-import { createTool } from "@mastra/core/tools";
 import { displayTimelineSchema } from "@nepp-chan/shared/schemas/display-tools";
-import { z } from "zod";
 
-export const displayTimelineTool = createTool({
+import { createDisplayTool } from "./display-tool-factory";
+
+export const displayTimelineTool = createDisplayTool({
   id: "display-timeline",
   description: `出来事を時系列で表示するツール。
 日付付きのイベントや報告が複数ある場合、テキストで列挙するよりこのツールを使う。
@@ -31,10 +31,4 @@ events: [
 - events が空配列 → 呼ばない
 - date を省略 → 必須フィールド`,
   inputSchema: displayTimelineSchema,
-  outputSchema: z.object({
-    displayed: z.boolean(),
-  }),
-  execute: async () => {
-    return { displayed: true };
-  },
 });

--- a/server/src/mastra/tools/display-tool-factory.ts
+++ b/server/src/mastra/tools/display-tool-factory.ts
@@ -1,0 +1,19 @@
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+/**
+ * display 系ツールを生成する。実描画は web 側（toolsByName）が担うため、
+ * サーバー側は成功応答を返すだけで何もしない。
+ */
+export const createDisplayTool = <TSchema extends z.ZodType>(config: {
+  id: string;
+  description: string;
+  inputSchema: TSchema;
+}) =>
+  createTool({
+    ...config,
+    outputSchema: z.object({
+      displayed: z.boolean(),
+    }),
+    execute: async () => ({ displayed: true }),
+  });

--- a/server/src/mastra/tools/poll-get-tool.test.ts
+++ b/server/src/mastra/tools/poll-get-tool.test.ts
@@ -7,12 +7,12 @@ vi.mock("~/repository/poll-repository", () => ({
   },
 }));
 
-vi.mock("~/services/poll-response", () => ({
+vi.mock("~/services/poll-results", () => ({
   getPollResults: vi.fn(),
 }));
 
 const { pollRepository } = await import("~/repository/poll-repository");
-const { getPollResults } = await import("~/services/poll-response");
+const { getPollResults } = await import("~/services/poll-results");
 const { pollGetTool } = await import("./poll-get-tool");
 
 import { callTool } from "~/__tests__/helpers/tool-context";

--- a/server/src/mastra/tools/poll-get-tool.ts
+++ b/server/src/mastra/tools/poll-get-tool.ts
@@ -2,7 +2,7 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import { logger } from "~/lib/logger";
 import { type Poll, pollRepository } from "~/repository/poll-repository";
-import { getPollResults } from "~/services/poll-response";
+import { getPollResults } from "~/services/poll-results";
 import { requireDb } from "./helpers";
 
 const pollWithResultsSchema = z.object({

--- a/server/src/mastra/tools/poll-get-tool.ts
+++ b/server/src/mastra/tools/poll-get-tool.ts
@@ -24,6 +24,9 @@ const pollWithResultsSchema = z.object({
 
 type PollWithResults = z.infer<typeof pollWithResultsSchema>;
 
+/** エージェント登録キーと instructions 内の参照を一致させるための toolName */
+export const pollGetToolName = "pollGetTool";
+
 export const pollGetTool = createTool({
   id: "poll-get",
   description:

--- a/server/src/routes/admin/poll.test.ts
+++ b/server/src/routes/admin/poll.test.ts
@@ -20,7 +20,7 @@ vi.mock("~/services/poll-delivery", () => ({
   sendPoll: vi.fn(),
 }));
 
-vi.mock("~/services/poll-response", () => ({
+vi.mock("~/services/poll-results", () => ({
   getPollResults: vi.fn(),
 }));
 
@@ -39,7 +39,7 @@ vi.mock("~/services/auth/anonymous-session", () => ({
 const { pollRepository } = await import("~/repository/poll-repository");
 const pollService = await import("~/services/poll");
 const pollDelivery = await import("~/services/poll-delivery");
-const pollResponse = await import("~/services/poll-response");
+const pollResults = await import("~/services/poll-results");
 const { adminSessionRepository } = await import(
   "~/repository/admin-session-repository"
 );
@@ -433,7 +433,7 @@ describe("pollAdminRoutes", () => {
   describe("GET /:id/results", () => {
     it("正常系", async () => {
       useAuth();
-      vi.mocked(pollResponse.getPollResults).mockResolvedValue({
+      vi.mocked(pollResults.getPollResults).mockResolvedValue({
         pollId: "p-1",
         title: "テスト",
         totalSubmissions: 0,
@@ -451,7 +451,7 @@ describe("pollAdminRoutes", () => {
 
     it("存在しないなら 404", async () => {
       useAuth();
-      vi.mocked(pollResponse.getPollResults).mockResolvedValue(null);
+      vi.mocked(pollResults.getPollResults).mockResolvedValue(null);
 
       const res = await routes.request(
         authedJson("GET", "/missing/results"),

--- a/server/src/routes/admin/poll.ts
+++ b/server/src/routes/admin/poll.ts
@@ -22,7 +22,7 @@ import {
   updatePoll,
 } from "~/services/poll";
 import { sendPoll } from "~/services/poll-delivery";
-import { getPollResults } from "~/services/poll-response";
+import { getPollResults } from "~/services/poll-results";
 
 export const pollAdminRoutes = new OpenAPIHono<{
   Bindings: CloudflareBindings;

--- a/server/src/routes/poll.test.ts
+++ b/server/src/routes/poll.test.ts
@@ -6,12 +6,12 @@ vi.mock("~/repository/poll-repository", () => ({
   },
 }));
 
-vi.mock("~/services/poll-response", () => ({
+vi.mock("~/services/poll-results", () => ({
   getPollResults: vi.fn(),
 }));
 
 const { pollRepository } = await import("~/repository/poll-repository");
-const { getPollResults } = await import("~/services/poll-response");
+const { getPollResults } = await import("~/services/poll-results");
 const { pollRoutes: rawRoutes } = await import("./poll");
 
 import { withResolvePrincipal } from "~/__tests__/helpers/test-app";

--- a/server/src/routes/poll.ts
+++ b/server/src/routes/poll.ts
@@ -4,7 +4,7 @@ import { HTTPException } from "hono/http-exception";
 import { errorResponse } from "~/lib/openapi-errors";
 import { pollRepository } from "~/repository/poll-repository";
 import { pollResultsSchema } from "~/schemas/poll-schema";
-import { getPollResults } from "~/services/poll-response";
+import { getPollResults } from "~/services/poll-results";
 
 export const pollRoutes = new OpenAPIHono<{
   Bindings: CloudflareBindings;

--- a/server/src/routes/simple-chat.ts
+++ b/server/src/routes/simple-chat.ts
@@ -2,7 +2,7 @@ import { waitUntil } from "cloudflare:workers";
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { Mastra } from "@mastra/core/mastra";
 import { respondWithChatStream } from "~/lib/chat-stream";
-import { resolveModelTier } from "~/lib/llm-models";
+import { primaryModelId, resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
 import { createRequestContext } from "~/mastra/request-context";
@@ -85,7 +85,7 @@ simpleChatRoutes.openapi(simpleChatRoute, async (c) => {
     onFinish: (event) =>
       waitUntil(
         recordLlmUsage(c.env.DB, {
-          model: event.model?.modelId ?? modelConfig.model,
+          model: event.model?.modelId ?? primaryModelId(modelConfig),
           usage: event.totalUsage,
           platform: "lp",
           source: "chat",

--- a/server/src/routes/threads/chat.ts
+++ b/server/src/routes/threads/chat.ts
@@ -3,7 +3,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
 import { Mastra } from "@mastra/core/mastra";
 import { respondWithChatStream } from "~/lib/chat-stream";
 import { classifyIntent } from "~/lib/classify-intent";
-import { resolveModelTier } from "~/lib/llm-models";
+import { primaryModelId, resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import type { PrincipalVariables } from "~/lib/principal";
 import { getStorage } from "~/lib/storage";
@@ -120,7 +120,7 @@ chatRoutes.openapi(chatRoute, async (c) => {
     onFinish: (event) =>
       waitUntil(
         recordLlmUsage(c.env.DB, {
-          model: event.model?.modelId ?? modelConfig.model,
+          model: event.model?.modelId ?? primaryModelId(modelConfig),
           usage: event.totalUsage,
           platform: "web",
           source: "chat",

--- a/server/src/services/line-messaging.test.ts
+++ b/server/src/services/line-messaging.test.ts
@@ -35,11 +35,11 @@ vi.mock("~/lib/classify-intent", () => ({
   classifyIntent: vi.fn(async () => "casual"),
 }));
 
-vi.mock("~/lib/llm-models", () => ({
-  resolveModelTier: vi.fn(() => ({ tier: "fast", modelId: "fake-model" })),
-  GEMINI_EMBEDDING: "gemini-embedding",
-  GEMINI_FLASH: "gemini-flash",
-  GEMINI_PRO: "gemini-pro",
+vi.mock("~/lib/llm-models", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/lib/llm-models")>()),
+  resolveModelTier: vi.fn(() => ({
+    model: [{ model: "fake-model" }],
+  })),
 }));
 
 vi.mock("~/mastra/agents/nepp-chan-agent", () => ({
@@ -148,8 +148,7 @@ describe("generateReply", () => {
     vi.mocked(resolveModelTier)
       .mockReset()
       .mockReturnValue({
-        tier: "fast",
-        modelId: "fake-model",
+        model: [{ model: "fake-model" }],
       } as never);
     agentHolder.generate.mockReset();
     showLoadingAnimation.mockReset().mockResolvedValue({});
@@ -204,7 +203,7 @@ describe("generateReply", () => {
 
   it("agent.generate 後に usage を platform=line で記録する", async () => {
     vi.mocked(resolveModelTier).mockReturnValue({
-      model: "google/gemini-flash-lite-latest",
+      model: [{ model: "google/gemini-flash-lite-latest" }],
     } as never);
     agentHolder.generate.mockResolvedValueOnce({
       steps: [{ text: "ok" }],

--- a/server/src/services/line-messaging.ts
+++ b/server/src/services/line-messaging.ts
@@ -1,7 +1,7 @@
 import { messagingApi } from "@line/bot-sdk";
 import { Mastra } from "@mastra/core/mastra";
 import { classifyIntent } from "~/lib/classify-intent";
-import { resolveModelTier } from "~/lib/llm-models";
+import { primaryModelId, resolveModelTier } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { splitMessagesForLine } from "~/lib/split-message";
 import { getStorage } from "~/lib/storage";
@@ -92,7 +92,7 @@ export const generateReply = async (params: {
   });
 
   await recordLlmUsage(params.env.DB, {
-    model: modelConfig.model,
+    model: primaryModelId(modelConfig),
     usage: response.totalUsage,
     platform: "line",
     source: "chat",

--- a/server/src/services/poll-response.test.ts
+++ b/server/src/services/poll-response.test.ts
@@ -26,8 +26,9 @@ vi.mock("~/services/line-messaging", () => ({
 }));
 
 const { pollRepository } = await import("~/repository/poll-repository");
-const { handlePollPostback, getPollResults, generatePollFollowUp } =
-  await import("./poll-response");
+const { handlePollPostback, generatePollFollowUp } = await import(
+  "./poll-response"
+);
 
 const env = {
   DB: {} as D1Database,
@@ -171,81 +172,6 @@ describe("handlePollPostback", () => {
       env.DB,
       expect.objectContaining({ selectedChoice: "春 / 桜" }),
     );
-  });
-});
-
-describe("getPollResults", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("存在しなければ null", async () => {
-    vi.mocked(pollRepository.findById).mockResolvedValue(null);
-    expect(await getPollResults(env.DB, "p-1")).toBeNull();
-  });
-
-  it("各選択肢の件数 / パーセンテージを返す", async () => {
-    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
-    vi.mocked(pollRepository.findSubmissionsByPoll).mockResolvedValue([
-      {
-        id: "1",
-        pollId: "p-1",
-        userId: "u1",
-        selectedChoice: "春",
-        createdAt: "x",
-      },
-      {
-        id: "2",
-        pollId: "p-1",
-        userId: "u2",
-        selectedChoice: "春",
-        createdAt: "x",
-      },
-      {
-        id: "3",
-        pollId: "p-1",
-        userId: "u3",
-        selectedChoice: "冬",
-        createdAt: "x",
-      },
-    ]);
-
-    const result = await getPollResults(env.DB, "p-1");
-
-    expect(result?.totalSubmissions).toBe(3);
-    expect(result?.choiceResults).toEqual([
-      { choice: "春", count: 2, percentage: 67 },
-      { choice: "夏", count: 0, percentage: 0 },
-      { choice: "秋", count: 0, percentage: 0 },
-      { choice: "冬", count: 1, percentage: 33 },
-    ]);
-  });
-
-  it("回答ゼロでも全選択肢を 0% で返す", async () => {
-    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
-    vi.mocked(pollRepository.findSubmissionsByPoll).mockResolvedValue([]);
-
-    const result = await getPollResults(env.DB, "p-1");
-
-    expect(result?.totalSubmissions).toBe(0);
-    expect(result?.choiceResults.every((c) => c.percentage === 0)).toBe(true);
-  });
-
-  it("候補外の choice が submission に紛れていても無視される", async () => {
-    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
-    vi.mocked(pollRepository.findSubmissionsByPoll).mockResolvedValue([
-      {
-        id: "1",
-        pollId: "p-1",
-        userId: "u1",
-        selectedChoice: "謎の選択肢",
-        createdAt: "x",
-      },
-    ]);
-
-    const result = await getPollResults(env.DB, "p-1");
-
-    expect(result?.choiceResults.every((c) => c.count === 0)).toBe(true);
   });
 });
 

--- a/server/src/services/poll-response.ts
+++ b/server/src/services/poll-response.ts
@@ -160,34 +160,3 @@ export const generatePollFollowUp = async (
     logger.error("[Poll] Follow-up push failed", error);
   }
 };
-
-export const getPollResults = async (db: D1Database, pollId: string) => {
-  const poll = await pollRepository.findById(db, pollId);
-  if (!poll) return null;
-
-  const submissions = await pollRepository.findSubmissionsByPoll(db, pollId);
-  const choices = JSON.parse(poll.choices) as string[];
-
-  const counts: Record<string, number> = {};
-  for (const c of choices) counts[c] = 0;
-  for (const s of submissions) {
-    if (s.selectedChoice in counts) {
-      counts[s.selectedChoice] = (counts[s.selectedChoice] ?? 0) + 1;
-    }
-  }
-
-  const total = submissions.length;
-  const choiceResults = choices.map((choice) => ({
-    choice,
-    count: counts[choice] ?? 0,
-    percentage:
-      total > 0 ? Math.round(((counts[choice] ?? 0) / total) * 100) : 0,
-  }));
-
-  return {
-    pollId,
-    title: poll.title,
-    totalSubmissions: total,
-    choiceResults,
-  };
-};

--- a/server/src/services/poll-results.test.ts
+++ b/server/src/services/poll-results.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/repository/poll-repository", () => ({
+  pollRepository: {
+    findById: vi.fn(),
+    findSubmissionsByPoll: vi.fn(),
+  },
+}));
+
+const { pollRepository } = await import("~/repository/poll-repository");
+const { getPollResults } = await import("./poll-results");
+
+const env = {
+  DB: {} as D1Database,
+} as unknown as CloudflareBindings;
+
+const dbRow = {
+  id: "p-1",
+  title: "好きな季節",
+  choices: JSON.stringify(["春", "夏", "秋", "冬"]),
+  followUpPrompt: null,
+  status: "sent" as const,
+  createdBy: "u-1",
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: null,
+  scheduledAt: null,
+  sentAt: "2025-01-02T00:00:00Z",
+  closedAt: null,
+};
+
+describe("getPollResults", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("存在しなければ null", async () => {
+    vi.mocked(pollRepository.findById).mockResolvedValue(null);
+    expect(await getPollResults(env.DB, "p-1")).toBeNull();
+  });
+
+  it("各選択肢の件数 / パーセンテージを返す", async () => {
+    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
+    vi.mocked(pollRepository.findSubmissionsByPoll).mockResolvedValue([
+      {
+        id: "1",
+        pollId: "p-1",
+        userId: "u1",
+        selectedChoice: "春",
+        createdAt: "x",
+      },
+      {
+        id: "2",
+        pollId: "p-1",
+        userId: "u2",
+        selectedChoice: "春",
+        createdAt: "x",
+      },
+      {
+        id: "3",
+        pollId: "p-1",
+        userId: "u3",
+        selectedChoice: "冬",
+        createdAt: "x",
+      },
+    ]);
+
+    const result = await getPollResults(env.DB, "p-1");
+
+    expect(result?.totalSubmissions).toBe(3);
+    expect(result?.choiceResults).toEqual([
+      { choice: "春", count: 2, percentage: 67 },
+      { choice: "夏", count: 0, percentage: 0 },
+      { choice: "秋", count: 0, percentage: 0 },
+      { choice: "冬", count: 1, percentage: 33 },
+    ]);
+  });
+
+  it("回答ゼロでも全選択肢を 0% で返す", async () => {
+    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
+    vi.mocked(pollRepository.findSubmissionsByPoll).mockResolvedValue([]);
+
+    const result = await getPollResults(env.DB, "p-1");
+
+    expect(result?.totalSubmissions).toBe(0);
+    expect(result?.choiceResults.every((c) => c.percentage === 0)).toBe(true);
+  });
+
+  it("候補外の choice が submission に紛れていても無視される", async () => {
+    vi.mocked(pollRepository.findById).mockResolvedValue(dbRow);
+    vi.mocked(pollRepository.findSubmissionsByPoll).mockResolvedValue([
+      {
+        id: "1",
+        pollId: "p-1",
+        userId: "u1",
+        selectedChoice: "謎の選択肢",
+        createdAt: "x",
+      },
+    ]);
+
+    const result = await getPollResults(env.DB, "p-1");
+
+    expect(result?.choiceResults.every((c) => c.count === 0)).toBe(true);
+  });
+});

--- a/server/src/services/poll-results.ts
+++ b/server/src/services/poll-results.ts
@@ -1,0 +1,32 @@
+import { pollRepository } from "~/repository/poll-repository";
+
+export const getPollResults = async (db: D1Database, pollId: string) => {
+  const poll = await pollRepository.findById(db, pollId);
+  if (!poll) return null;
+
+  const submissions = await pollRepository.findSubmissionsByPoll(db, pollId);
+  const choices = JSON.parse(poll.choices) as string[];
+
+  const counts: Record<string, number> = {};
+  for (const c of choices) counts[c] = 0;
+  for (const s of submissions) {
+    if (s.selectedChoice in counts) {
+      counts[s.selectedChoice] = (counts[s.selectedChoice] ?? 0) + 1;
+    }
+  }
+
+  const total = submissions.length;
+  const choiceResults = choices.map((choice) => ({
+    choice,
+    count: counts[choice] ?? 0,
+    percentage:
+      total > 0 ? Math.round(((counts[choice] ?? 0) / total) * 100) : 0,
+  }));
+
+  return {
+    pollId,
+    title: poll.title,
+    totalSubmissions: total,
+    choiceResults,
+  };
+};

--- a/shared/src/constants/agent-tools.ts
+++ b/shared/src/constants/agent-tools.ts
@@ -1,0 +1,10 @@
+/**
+ * server と web の両方が参照するエージェント登録 toolName（tools オブジェクトのキー）。
+ * server の登録キー・instructions 内の参照・web のフォールバック表示分類を
+ * この定数で一致させる契約。display 系ツールは display-tools.ts を参照。
+ * server 内に閉じる toolName は各ツール定義ファイルの定数を使う。
+ */
+export const AGENT_TOOL_NAMES = {
+  emergencyReport: "emergencyReportTool",
+  emergencyUpdate: "emergencyUpdateTool",
+} as const;

--- a/web/src/components/chat/AssistantMessage.tsx
+++ b/web/src/components/chat/AssistantMessage.tsx
@@ -9,8 +9,7 @@ import { SpeechBubble } from "~/app/chat/components/SpeechBubble";
 import { useChatContext } from "~/app/chat/contexts/ChatContext";
 import type { FeedbackRating } from "~/types";
 
-import { MarkdownText } from "./MarkdownText";
-import { ToolPart } from "./ToolPart";
+import { MessageParts } from "./MessageParts";
 
 type Props = {
   message: UIMessage;
@@ -72,21 +71,7 @@ export const AssistantMessage = ({ message, isLast }: Props) => {
           variant="assistant"
           className="max-w-[92%] md:max-w-[88%] py-4"
         >
-          {message.parts.map((part, index) => {
-            if (part.type === "text") {
-              return (
-                <MarkdownText
-                  // biome-ignore lint/suspicious/noArrayIndexKey: テキストパートに安定 ID が無く、順序も不変なため位置で識別する
-                  key={`${message.id}-text-${index}`}
-                  text={part.text}
-                />
-              );
-            }
-            if (isToolOrDynamicToolUIPart(part)) {
-              return <ToolPart key={part.toolCallId} part={part} />;
-            }
-            return null;
-          })}
+          <MessageParts message={message} />
           {showTypingDot && <TypingDot />}
           {isLast && error && <MessageError message={error.message} />}
         </SpeechBubble>

--- a/web/src/components/chat/MessageParts.tsx
+++ b/web/src/components/chat/MessageParts.tsx
@@ -1,0 +1,27 @@
+import type { UIMessage } from "ai";
+import { isToolOrDynamicToolUIPart } from "ai";
+
+import { MarkdownText } from "./MarkdownText";
+import { ToolPart } from "./ToolPart";
+
+type Props = {
+  message: UIMessage;
+};
+
+/** message parts を種類ごとの表示コンポーネントへ振り分ける */
+export const MessageParts = ({ message }: Props) =>
+  message.parts.map((part, index) => {
+    if (part.type === "text") {
+      return (
+        <MarkdownText
+          // biome-ignore lint/suspicious/noArrayIndexKey: テキストパートに安定 ID が無く、順序も不変なため位置で識別する
+          key={`${message.id}-text-${index}`}
+          text={part.text}
+        />
+      );
+    }
+    if (isToolOrDynamicToolUIPart(part)) {
+      return <ToolPart key={part.toolCallId} part={part} />;
+    }
+    return null;
+  });

--- a/web/src/components/chat/ToolFallback.tsx
+++ b/web/src/components/chat/ToolFallback.tsx
@@ -10,44 +10,11 @@ import {
 import type { FC, ReactNode } from "react";
 import { useState } from "react";
 
+import { getToolDisplayName } from "~/components/chat/tool-display-text";
 import type {
   ToolPartComponent,
   ToolPartStatus,
 } from "~/components/chat/types";
-
-const REPORT_TOOLS = ["emergencyReportTool", "emergencyUpdateTool"];
-const MEMORY_TOOLS = ["updateWorkingMemory"];
-
-type ToolDisplayText = {
-  running: string;
-  completed: string;
-};
-
-const TOOL_DISPLAY_MAP: Record<string, ToolDisplayText> = {
-  report: {
-    running: "ねっぷちゃんが報告中",
-    completed: "ねっぷちゃんが報告しました",
-  },
-  memory: {
-    running: "ねっぷちゃんが記憶中",
-    completed: "ねっぷちゃんが記憶しました",
-  },
-  default: {
-    running: "ねっぷちゃんが調査中",
-    completed: "ねっぷちゃんが調査しました",
-  },
-};
-
-const getToolDisplayName = (toolName: string, isRunning: boolean) => {
-  const getCategory = () => {
-    if (REPORT_TOOLS.includes(toolName)) return "report";
-    if (MEMORY_TOOLS.includes(toolName)) return "memory";
-    return "default";
-  };
-
-  const display = TOOL_DISPLAY_MAP[getCategory()];
-  return isRunning ? display.running : display.completed;
-};
 
 type ToolStatusInfo = {
   label: string;

--- a/web/src/components/chat/tool-display-text.ts
+++ b/web/src/components/chat/tool-display-text.ts
@@ -1,0 +1,28 @@
+import { AGENT_TOOL_NAMES } from "@nepp-chan/shared/constants/agent-tools";
+
+/** Mastra の Memory 機能が内部で登録する working memory 更新ツールの toolName */
+const MASTRA_MEMORY_TOOL_NAME = "updateWorkingMemory";
+
+const REPORT_TEXT = {
+  running: "ねっぷちゃんが報告中",
+  completed: "ねっぷちゃんが報告しました",
+};
+const MEMORY_TEXT = {
+  running: "ねっぷちゃんが記憶中",
+  completed: "ねっぷちゃんが記憶しました",
+};
+const DEFAULT_TEXT = {
+  running: "ねっぷちゃんが調査中",
+  completed: "ねっぷちゃんが調査しました",
+};
+
+const TEXT_BY_TOOL: Record<string, typeof DEFAULT_TEXT> = {
+  [AGENT_TOOL_NAMES.emergencyReport]: REPORT_TEXT,
+  [AGENT_TOOL_NAMES.emergencyUpdate]: REPORT_TEXT,
+  [MASTRA_MEMORY_TOOL_NAME]: MEMORY_TEXT,
+};
+
+export const getToolDisplayName = (toolName: string, isRunning: boolean) => {
+  const text = TEXT_BY_TOOL[toolName] ?? DEFAULT_TEXT;
+  return isRunning ? text.running : text.completed;
+};

--- a/web/src/components/chat/tool-uis/ChartToolUI.test.tsx
+++ b/web/src/components/chat/tool-uis/ChartToolUI.test.tsx
@@ -14,15 +14,12 @@ const baseArgs = {
   yKey: "sales",
 };
 
-const renderChart = (
-  overrides: Partial<typeof baseArgs> = {},
-  running = false,
-) =>
+const renderChart = (overrides: Partial<typeof baseArgs> = {}) =>
   render(
     <DisplayChartToolComponent
       args={{ ...baseArgs, ...overrides }}
       result={undefined}
-      status={running ? { type: "running" } : { type: "complete" }}
+      status={{ type: "complete" }}
       toolName="displayChartTool"
     />,
   );
@@ -47,11 +44,6 @@ describe("DisplayChartToolComponent", () => {
 
   it("通常データで title を描画する", () => {
     renderChart();
-    expect(screen.getByText("売上推移")).toBeDefined();
-  });
-
-  it("running 状態でも data が揃っていれば Chart を描画する", () => {
-    renderChart({}, true);
     expect(screen.getByText("売上推移")).toBeDefined();
   });
 });

--- a/web/src/components/chat/tool-uis/ChartToolUI.tsx
+++ b/web/src/components/chat/tool-uis/ChartToolUI.tsx
@@ -1,39 +1,19 @@
-import { ToolEmptyState } from "@nepp-chan/shared/ui/EmptyState";
+import { displayChartSchema } from "@nepp-chan/shared/schemas/display-tools";
 import { ToolLoadingState } from "@nepp-chan/shared/ui/Loading";
 import { BarChartIcon } from "lucide-react";
 
-import type { ToolPartComponent } from "~/components/chat/types";
+import { Chart } from "./Chart";
+import { defineToolUI } from "./define-tool-ui";
 
-import { Chart, type ChartArgs } from "./Chart";
-
-const renderChart = (args: ChartArgs, isRunning: boolean) => {
-  if (isRunning && !args.data) {
-    return (
-      <div className="my-4">
-        <ToolLoadingState
-          variant="chart"
-          icon={<BarChartIcon className="size-5 animate-pulse text-teal-400" />}
-        />
-      </div>
-    );
-  }
-
-  if (!args.data || args.data.length === 0) {
-    return (
-      <div className="my-4">
-        <ToolEmptyState message="表示するデータがありません" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="my-4">
-      <Chart args={args} />
-    </div>
-  );
-};
-
-export const DisplayChartToolComponent: ToolPartComponent = ({
-  args,
-  status,
-}) => renderChart(args as ChartArgs, status.type === "running");
+export const DisplayChartToolComponent = defineToolUI({
+  schema: displayChartSchema,
+  loading: (
+    <ToolLoadingState
+      variant="chart"
+      icon={<BarChartIcon className="size-5 animate-pulse text-teal-400" />}
+    />
+  ),
+  emptyMessage: "表示するデータがありません",
+  isEmpty: (args) => args.data.length === 0,
+  Component: Chart,
+});

--- a/web/src/components/chat/tool-uis/DataTableToolUI.tsx
+++ b/web/src/components/chat/tool-uis/DataTableToolUI.tsx
@@ -1,5 +1,8 @@
 import { cn } from "@nepp-chan/shared/lib/class-merge";
-import type { DisplayTableArgs } from "@nepp-chan/shared/schemas/display-tools";
+import {
+  type DisplayTableArgs,
+  displayTableSchema,
+} from "@nepp-chan/shared/schemas/display-tools";
 import { ToolLoadingState } from "@nepp-chan/shared/ui/Loading";
 import {
   ArrowDownIcon,
@@ -10,7 +13,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 
-import type { ToolPartComponent } from "~/components/chat/types";
+import { defineToolUI } from "./define-tool-ui";
 
 type SortConfig = {
   key: string;
@@ -131,24 +134,14 @@ const DataTable = ({ args }: { args: DisplayTableArgs }) => {
   );
 };
 
-const renderDataTable = (args: DisplayTableArgs) => {
-  if (!args.columns || !args.data) {
-    return (
-      <div className="my-4">
-        <ToolLoadingState
-          variant="table"
-          icon={<TableIcon className="size-5 animate-pulse text-(--fg-4)" />}
-        />
-      </div>
-    );
-  }
-
-  return (
-    <div className="my-4">
-      <DataTable args={args} />
-    </div>
-  );
-};
-
-export const DisplayTableToolComponent: ToolPartComponent = ({ args }) =>
-  renderDataTable(args as DisplayTableArgs);
+export const DisplayTableToolComponent = defineToolUI({
+  schema: displayTableSchema,
+  loading: (
+    <ToolLoadingState
+      variant="table"
+      icon={<TableIcon className="size-5 animate-pulse text-(--fg-4)" />}
+    />
+  ),
+  emptyMessage: "表示するデータがありません",
+  Component: DataTable,
+});

--- a/web/src/components/chat/tool-uis/TimelineToolUI.tsx
+++ b/web/src/components/chat/tool-uis/TimelineToolUI.tsx
@@ -1,10 +1,12 @@
 import { cn } from "@nepp-chan/shared/lib/class-merge";
-import type { DisplayTimelineArgs } from "@nepp-chan/shared/schemas/display-tools";
-import { ToolEmptyState } from "@nepp-chan/shared/ui/EmptyState";
+import {
+  type DisplayTimelineArgs,
+  displayTimelineSchema,
+} from "@nepp-chan/shared/schemas/display-tools";
 import { ToolLoadingState } from "@nepp-chan/shared/ui/Loading";
 import { CalendarIcon } from "lucide-react";
 
-import type { ToolPartComponent } from "~/components/chat/types";
+import { defineToolUI } from "./define-tool-ui";
 
 type TimelineEvent = DisplayTimelineArgs["events"][number];
 
@@ -98,36 +100,15 @@ const Timeline = ({ args }: { args: DisplayTimelineArgs }) => (
   </div>
 );
 
-const renderTimeline = (args: DisplayTimelineArgs, isRunning: boolean) => {
-  if (isRunning && !args.events) {
-    return (
-      <div className="my-4">
-        <ToolLoadingState
-          variant="timeline"
-          icon={
-            <CalendarIcon className="size-5 animate-pulse text-indigo-400" />
-          }
-        />
-      </div>
-    );
-  }
-
-  if (!args.events || args.events.length === 0) {
-    return (
-      <div className="my-4">
-        <ToolEmptyState message="表示するイベントがありません" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="my-4">
-      <Timeline args={args} />
-    </div>
-  );
-};
-
-export const DisplayTimelineToolComponent: ToolPartComponent = ({
-  args,
-  status,
-}) => renderTimeline(args as DisplayTimelineArgs, status.type === "running");
+export const DisplayTimelineToolComponent = defineToolUI({
+  schema: displayTimelineSchema,
+  loading: (
+    <ToolLoadingState
+      variant="timeline"
+      icon={<CalendarIcon className="size-5 animate-pulse text-indigo-400" />}
+    />
+  ),
+  emptyMessage: "表示するイベントがありません",
+  isEmpty: (args) => args.events.length === 0,
+  Component: Timeline,
+});

--- a/web/src/components/chat/tool-uis/define-tool-ui.test.tsx
+++ b/web/src/components/chat/tool-uis/define-tool-ui.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { ToolPartStatus } from "~/components/chat/types";
+
+import { defineToolUI } from "./define-tool-ui";
+
+type TestArgs = { value: string };
+
+const schema = {
+  safeParse: (
+    input: unknown,
+  ): { success: true; data: TestArgs } | { success: false } => {
+    const value = (input as { value?: unknown })?.value;
+    return typeof value === "string"
+      ? { success: true, data: { value } }
+      : { success: false };
+  },
+};
+
+const ToolUI = defineToolUI({
+  schema,
+  loading: <span>読み込み中</span>,
+  emptyMessage: "データなし",
+  isEmpty: (args) => args.value === "",
+  Component: ({ args }) => <span>本体: {args.value}</span>,
+});
+
+const renderToolUI = (args: unknown, status: ToolPartStatus) =>
+  render(
+    <ToolUI
+      toolName="testTool"
+      args={args}
+      result={undefined}
+      status={status}
+    />,
+  );
+
+describe("defineToolUI", () => {
+  it("実行中で args がスキーマ検証に失敗したらローディングを表示する", () => {
+    renderToolUI({}, { type: "running" });
+    expect(screen.getByText("読み込み中")).toBeInTheDocument();
+  });
+
+  it("完了後に args がスキーマ検証に失敗したら空状態を表示する", () => {
+    renderToolUI({ value: 1 }, { type: "complete" });
+    expect(screen.getByText("データなし")).toBeInTheDocument();
+  });
+
+  it("isEmpty に該当したら空状態を表示する", () => {
+    renderToolUI({ value: "" }, { type: "complete" });
+    expect(screen.getByText("データなし")).toBeInTheDocument();
+  });
+
+  it("検証に通った args を Component に渡して描画する", () => {
+    renderToolUI({ value: "ok" }, { type: "complete" });
+    expect(screen.getByText("本体: ok")).toBeInTheDocument();
+  });
+
+  it("実行中でも args が揃っていれば Component を描画する", () => {
+    renderToolUI({ value: "streaming" }, { type: "running" });
+    expect(screen.getByText("本体: streaming")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/chat/tool-uis/define-tool-ui.tsx
+++ b/web/src/components/chat/tool-uis/define-tool-ui.tsx
@@ -1,0 +1,52 @@
+import { ToolEmptyState } from "@nepp-chan/shared/ui/EmptyState";
+import type { ComponentType, ReactNode } from "react";
+
+import type { ToolPartComponent } from "~/components/chat/types";
+
+/** web の直接依存に zod を増やさないための safeParse 構造型 */
+type SchemaLike<TArgs> = {
+  safeParse: (
+    input: unknown,
+  ) => { success: true; data: TArgs } | { success: false };
+};
+
+type Config<TArgs> = {
+  schema: SchemaLike<TArgs>;
+  loading: ReactNode;
+  emptyMessage: string;
+  isEmpty?: (args: TArgs) => boolean;
+  Component: ComponentType<{ args: TArgs }>;
+};
+
+/**
+ * display 系ツール UI の共通枠を生成する。
+ * LLM が生成する args はストリーミング途中・完了後ともに不完全でありうるため、
+ * スキーマ検証に通った場合のみ Component へ渡す。
+ * - 検証失敗: 実行中ならローディング、完了後は空状態
+ * - isEmpty に該当: 空状態
+ */
+export const defineToolUI = <TArgs,>({
+  schema,
+  loading,
+  emptyMessage,
+  isEmpty,
+  Component,
+}: Config<TArgs>): ToolPartComponent => {
+  const ToolUI: ToolPartComponent = ({ args, status }) => {
+    const empty = <ToolEmptyState message={emptyMessage} />;
+    const parsed = schema.safeParse(args);
+
+    const content = () => {
+      if (!parsed.success) {
+        return status.type === "running" ? loading : empty;
+      }
+      if (isEmpty?.(parsed.data)) {
+        return empty;
+      }
+      return <Component args={parsed.data} />;
+    };
+
+    return <div className="my-4">{content()}</div>;
+  };
+  return ToolUI;
+};


### PR DESCRIPTION
## Summary
- モデルティアにフォールバック連鎖を導入（casual: flash-lite→flash / thinking: flash→flash-lite）。プライマリのレート制限・障害時も応答が返るようにする
- ティアごとにツール実行ループ上限 `maxSteps` を宣言（casual 5 / thinking 10）し、サブエージェント連鎖の暴走によるコスト事故を防ぐ（従来は実質無制限）
- スレッドタイトル生成を常に FLASH_LITE + 日本語指示へ分離（従来は thinking ティアだと FLASH + thinking で生成されていた）
- chat-stream の不要になった stream キャストを除去し、messages キャストが残る理由をコメントに明記
- **追加**: ツール表示（generative UI）まわりを疎結合化。ツール名の契約一元化・args のスキーマ検証導入・既存の循環 import 解消

## 主な変更内容

### モデルフォールバック（llm-models.ts）
`ModelTierConfig` を `{ model: ModelWithRetries[], defaultOptions: { maxSteps } }` に変更し、Agent へ spread で渡す。フォールバックは同じ thinking 設定を引き継ぎ、コスト暴発を避けるため PRO へは連鎖しない。使用量記録は `primaryModelId()` で追従。

**注意点**: フォールバックエントリの `id` は必ず明示する。省略すると Agent 構築時に `randomUUID()` が呼ばれ、モジュールグローバルで生成する Playground 用 Agent が workerd の起動を壊す（実機で確認、回帰テストで固定）。

### chat-stream のキャスト整理
mastra 更新で `stream` 側のキャストは不要になったため除去。`messages` 側は @mastra/ai-sdk が vendor する ai v6 型スナップショットとアプリの ai@6 の宣言差（dynamic-tool パートの `input` の optionality 等）に加え、zod looseObject 由来の message がどちらの宣言にも構造一致しないため引き続き必要。このキャストを 1 箇所に集約するのが `respondWithChatStream` の役割であることをコメントへ明記した。

### ツール表示まわりの疎結合化

#### ツール名契約の一元化（fix）
モデルに公開されるツール名は `tools` オブジェクトのキーだが、instructions はツール ID（`display-chart` / `broadcast-get` 等）で参照しており不一致だった。LLM の頑健性で動いていた状態を解消する。
- web も参照する emergency 系 → shared の `AGENT_TOOL_NAMES` 契約
- server 内に閉じる名前 → 各ツール定義ファイルの `*ToolName` 定数が正本
- web `ToolFallback` にハードコードされていた server ツール名も契約参照へ
- instructions が登録キーを参照することを固定する契約テストを追加

#### 既存の循環 import 解消
`line-messaging → nepp-chan-agent → poll-get-tool → poll-response → line-messaging` の循環により、モジュール評価順次第で import 値が未初期化になる問題が契約テスト追加で顕在化した。LINE 配信に依存しない `getPollResults` を `services/poll-results.ts` へ分離して解消（madge で循環ゼロを確認）。

#### web: ツール UI の defineToolUI 統合
各ツール UI が個別に持っていた `args as X` キャストとローディング・空状態分岐を `defineToolUI` factory に集約。LLM が生成する args は不完全でありうるため、shared の zod スキーマで検証して通った場合のみ描画する（バンドル影響は +1.5KB、zod 自体は ai SDK 経由で既存）。新ツールは「純粋な表示コンポーネント + スキーマ」を `toolsByName` に登録するだけで追加できる。

#### server: createDisplayTool factory / web: MessageParts 切り出し
display ツール 3 つで同一だった outputSchema・no-op execute を factory に集約。web は part dispatch を `MessageParts` に分離し、AssistantMessage をレイアウト専任にした。

## Test plan
- [x] server 1017 / web 423 / shared 118 テスト全パス、tsc・format クリーン
- [x] workerd（wrangler dev）実機: working memory 保存・マージ更新・knowledgeAgent 委譲・displayTimeline・タイトル生成設定で eval/validation エラーなし
- [x] フォールバック連鎖の発動を実機ログで確認（flash-lite 失敗時に flash を試行）
- [x] wrangler deploy ドライラン（gzip 5.1 MiB）
- [x] madge で循環依存ゼロを確認
- [x] codex review --uncommitted（指摘なし）
- [ ] dev デプロイ後に web / LINE で実会話確認（フォールバック・maxSteps・ツール名変更が通常会話に影響しないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
