### PR TITLE
feat(web): location クエリパラメータで歓迎挨拶を開始する

### DIFF
--- a/web/src/app/chat/contexts/ChatProvider.tsx
+++ b/web/src/app/chat/contexts/ChatProvider.tsx
@@ -4,13 +4,11 @@ import { type ReactNode, useEffect, useMemo, useRef } from "react";
 
 import { API_BASE } from "~/lib/api/client";
 import { getBearerToken } from "~/lib/auth-token";
+import { getLocationParam } from "~/lib/location-param";
 
 import { getMessageContent } from "../feedback-helpers";
+import { buildGreetingPrompt, isGreetingPrompt } from "../greeting-prompt";
 import { ChatContext, type ChatContextValue } from "./ChatContext";
-
-/** 既存スレッドの再開時に system 役で送る挨拶要求プロンプト */
-export const GREETING_PROMPT =
-  "新しい会話が始まりました。時間帯や季節に合った短い挨拶をしてください。";
 
 export type InitialMessage =
   | { type: "greeting" }
@@ -43,7 +41,7 @@ export const ChatProvider = ({
         prepareSendMessagesRequest({ messages }) {
           const lastMessage = messages[messages.length - 1];
           const lastText = lastMessage ? getMessageContent(lastMessage) : "";
-          const intent = lastText === GREETING_PROMPT ? "casual" : undefined;
+          const intent = isGreetingPrompt(lastText) ? "casual" : undefined;
           return {
             body: {
               message: lastMessage,
@@ -67,7 +65,7 @@ export const ChatProvider = ({
     sent.current = true;
     const text =
       initialMessage.type === "greeting"
-        ? GREETING_PROMPT
+        ? buildGreetingPrompt(getLocationParam())
         : initialMessage.text;
     void sendMessage({ text });
   }, [sendMessage, initialMessage]);

--- a/web/src/app/chat/greeting-prompt.test.ts
+++ b/web/src/app/chat/greeting-prompt.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildGreetingPrompt,
+  GREETING_PROMPT,
+  isGreetingPrompt,
+} from "./greeting-prompt";
+
+describe("buildGreetingPrompt", () => {
+  it("location が null なら汎用の挨拶プロンプトを返す", () => {
+    expect(buildGreetingPrompt(null)).toBe(GREETING_PROMPT);
+  });
+
+  it("location があればその場所への歓迎を依頼するプロンプトを返す", () => {
+    const prompt = buildGreetingPrompt("天塩川温泉");
+    expect(prompt).toContain("天塩川温泉");
+    expect(prompt).toContain("歓迎");
+  });
+});
+
+describe("isGreetingPrompt", () => {
+  it("汎用の挨拶プロンプトを greeting と判定する", () => {
+    expect(isGreetingPrompt(GREETING_PROMPT)).toBe(true);
+  });
+
+  it("location 入りの挨拶プロンプトも greeting と判定する", () => {
+    expect(isGreetingPrompt(buildGreetingPrompt("天塩川温泉"))).toBe(true);
+  });
+
+  it("通常のユーザー発話は greeting と判定しない", () => {
+    expect(isGreetingPrompt("こんにちは")).toBe(false);
+  });
+
+  it("同じ接頭辞で始まる通常発話は greeting と判定しない", () => {
+    expect(
+      isGreetingPrompt("新しい会話が始まりました。今日は何をしようかな"),
+    ).toBe(false);
+  });
+});

--- a/web/src/app/chat/greeting-prompt.ts
+++ b/web/src/app/chat/greeting-prompt.ts
@@ -1,0 +1,18 @@
+const GREETING_PREFIX = "新しい会話が始まりました。";
+const GREETING_SUFFIX = "時間帯や季節に合った短い挨拶をしてください。";
+
+/** 新規スレッド開始時に挨拶を促すプロンプト */
+export const GREETING_PROMPT = `${GREETING_PREFIX}${GREETING_SUFFIX}`;
+
+/** location があれば、その場所への歓迎挨拶を促すプロンプトを返す */
+export const buildGreetingPrompt = (location: string | null) =>
+  location
+    ? `${GREETING_PREFIX}ユーザーは今「${location}」にいます。${location}を訪れたことを歓迎しつつ、${GREETING_SUFFIX}`
+    : GREETING_PROMPT;
+
+/**
+ * 送信テキストが生成済みの挨拶プロンプト（汎用 / location 版）かどうか。
+ * intent 判定と UI 非表示に使う。前後の定型句で囲まれているかで判定する。
+ */
+export const isGreetingPrompt = (text: string) =>
+  text.startsWith(GREETING_PREFIX) && text.endsWith(GREETING_SUFFIX);

--- a/web/src/components/chat/UserMessage.test.tsx
+++ b/web/src/components/chat/UserMessage.test.tsx
@@ -2,7 +2,10 @@ import { render, screen } from "@testing-library/react";
 import type { UIMessage } from "ai";
 import { describe, expect, it } from "vitest";
 
-import { GREETING_PROMPT } from "~/app/chat/contexts/ChatProvider";
+import {
+  buildGreetingPrompt,
+  GREETING_PROMPT,
+} from "~/app/chat/greeting-prompt";
 
 import { UserMessage } from "./UserMessage";
 
@@ -21,6 +24,13 @@ describe("UserMessage", () => {
   it("挨拶要求プロンプトは表示しない", () => {
     const { container } = render(
       <UserMessage message={userMessage(GREETING_PROMPT)} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("location 入りの挨拶要求プロンプトも表示しない", () => {
+    const { container } = render(
+      <UserMessage message={userMessage(buildGreetingPrompt("天塩川温泉"))} />,
     );
     expect(container).toBeEmptyDOMElement();
   });

--- a/web/src/components/chat/UserMessage.tsx
+++ b/web/src/components/chat/UserMessage.tsx
@@ -1,12 +1,12 @@
 import type { UIMessage } from "ai";
 import { SpeechBubble } from "~/app/chat/components/SpeechBubble";
-import { GREETING_PROMPT } from "~/app/chat/contexts/ChatProvider";
 import { getMessageContent } from "~/app/chat/feedback-helpers";
+import { isGreetingPrompt } from "~/app/chat/greeting-prompt";
 
 export const UserMessage = ({ message }: { message: UIMessage }) => {
   const text = getMessageContent(message);
 
-  if (text === GREETING_PROMPT) return null;
+  if (isGreetingPrompt(text)) return null;
 
   return (
     <div

--- a/web/src/lib/location-param.test.ts
+++ b/web/src/lib/location-param.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const searchString = { current: "" };
+vi.mock("~/lib/redirect", () => ({
+  getCurrentSearchParams: () => new URLSearchParams(searchString.current),
+}));
+
+const { getLocationParam } = await import("./location-param");
+
+beforeEach(() => {
+  searchString.current = "";
+});
+
+describe("getLocationParam", () => {
+  it("location があれば返す", () => {
+    searchString.current = "?location=天塩川温泉";
+    expect(getLocationParam()).toBe("天塩川温泉");
+  });
+
+  it("location が無ければ null", () => {
+    searchString.current = "?foo=bar";
+    expect(getLocationParam()).toBeNull();
+  });
+
+  it("location が空なら null", () => {
+    searchString.current = "?location=";
+    expect(getLocationParam()).toBeNull();
+  });
+});

--- a/web/src/lib/location-param.ts
+++ b/web/src/lib/location-param.ts
@@ -1,0 +1,5 @@
+import { getCurrentSearchParams } from "~/lib/redirect";
+
+/** クエリ ?location=... を返す。未指定・空なら null */
+export const getLocationParam = () =>
+  getCurrentSearchParams().get("location") || null;


### PR DESCRIPTION
## Summary
- `?location=<場所>` でアクセスすると、その場所への歓迎挨拶から会話を開始する機能を追加
- QR コード等に location を仕込んで「その場の案内役」として会話を始める用途を想定

## 主な変更内容
- `web/src/lib/location-param.ts`（新規）: URL クエリ `?location=` を読み取る（未指定・空なら null）。既存の `getCurrentSearchParams` を再利用
- `web/src/app/chat/greeting-prompt.ts`（新規）: 挨拶プロンプトの組み立てを集約
  - `buildGreetingPrompt(location)` が location 入りの歓迎挨拶プロンプトを生成
  - `isGreetingPrompt` が生成済み挨拶プロンプト（汎用 / location 版）を判定（前後の定型句で判定）
- `web/src/app/chat/contexts/ChatProvider.tsx`: 初回 greeting 送信を `buildGreetingPrompt(getLocationParam())` に、intent 判定を `isGreetingPrompt` に変更
- `web/src/components/chat/UserMessage.tsx`: 挨拶プロンプト（location 版含む）を UI 非表示にする判定を `isGreetingPrompt` に統一

## 設計メモ
- 挨拶はサーバ側エージェントが生成し、クライアントは location をプロンプトに埋め込むのみ。サーバ変更なし
- location 文脈は会話の起点（初回挨拶）に限定。深掘りの長文解説は対象外のため、毎ターン注入する設計にはしていない

## Test plan
- [x] `?location=天塩川温泉` でアクセスし、その場所に言及した歓迎挨拶から会話が始まる
- [x] クエリなしアクセスで従来どおり汎用挨拶になる
- [x] 挨拶プロンプト本文がチャット欄に表示されない（location 版含む）
- [x] web ユニットテスト green / lint 0 errors / build 成功
