### PR TITLE
feat(lp): LINE 友だち追加用の OGP リダイレクトページを追加

### DIFF
--- a/lp/src/layouts/Layout.astro
+++ b/lp/src/layouts/Layout.astro
@@ -57,6 +57,8 @@ const ogImageUrl = new URL(ogImage, Astro.site);
 		<meta name="twitter:title" content={title} />
 		<meta name="twitter:description" content={description} />
 		<meta name="twitter:image" content={ogImageUrl} />
+
+		<slot name="head" />
 	</head>
 	<body class={bodyClass}>
 		<slot />

--- a/lp/src/pages/line.astro
+++ b/lp/src/pages/line.astro
@@ -1,0 +1,23 @@
+---
+import { LINE_FRIEND_URL } from "~/constants/urls";
+import Layout from "~/layouts/Layout.astro";
+---
+
+<Layout
+  title="ねっぷちゃん｜音威子府村 AI副村長"
+  bodyClass="bg-(--paper-50) text-(--fg-1)"
+>
+  <meta
+    slot="head"
+    http-equiv="refresh"
+    content={`0;url=${LINE_FRIEND_URL}`}
+  />
+  <meta slot="head" name="robots" content="noindex" />
+  <main class="flex min-h-dvh flex-col items-center justify-center gap-4 p-6">
+    <p>LINEに移動しています…</p>
+    <p>
+      自動で移動しない場合は
+      <a href={LINE_FRIEND_URL} class="underline">こちら</a>
+    </p>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- LINE 友だち追加リンク（lin.ee）を SNS 等で共有すると lin.ee 側の簡素な OGP が表示されてしまう問題への対応
- ねっぷちゃんと同じ OGP（画像・説明文言）を表示しつつ、開いたユーザーは即座に友だち追加へリダイレクトするクッションページ `/line` を lp に追加

## 主な変更内容
- `lp/src/layouts/Layout.astro`: `</head>` 直前に `<slot name="head" />` を追加し、ページ側から head 要素を注入できるようにした（slot 未使用の既存ページへの影響なし）
- `lp/src/pages/line.astro`: 新規作成
  - title / description / og:image はトップページと同一（Layout のデフォルトを利用）
  - `<meta http-equiv="refresh" content="0;url=https://lin.ee/V6GYbOrL">` で即時リダイレクト。クローラーは meta refresh を追わず静的 HTML の OGP を読むため、共有プレビューには自サイトの OGP が表示される
  - `<meta name="robots" content="noindex">` で検索インデックスを除外
  - メタリフレッシュが効かない環境向けに手動リンクのフォールバックを配置
- 公開 URL: https://nepp-chan.ai/line （dev: https://dev.nepp-chan.ai/line）

## Test plan
- [x] `curl http://localhost:5174/line` で OGP メタタグ（og:title / og:description / og:image / og:url）とメタリフレッシュの出力を確認
- [x] `astro check`（0 errors）/ `astro build`（/line 含む 4 ページ生成）を確認
- [ ] dev デプロイ後、LINE トークや OGP チェッカーで共有プレビューを確認
- [ ] dev デプロイ後、https://dev.nepp-chan.ai/line が友だち追加へリダイレクトすることを確認