### PR TITLE
feat(web): Landing を吹き出し化し location 初回訪問で歓迎挨拶を開始する

### DIFF
--- a/web/src/app/chat/components/Landing.tsx
+++ b/web/src/app/chat/components/Landing.tsx
@@ -73,12 +73,16 @@ export const Landing = ({ onSubmit, disabled = false }: Props) => {
                 onClick={() => handlePromptTap(p.text)}
                 disabled={disabled}
                 className={cn(
-                  "w-full text-left flex items-center gap-2.5",
-                  "rounded-full border border-(--paper-200) bg-(--paper-0)",
+                  "relative w-full text-left flex items-center gap-2.5",
+                  "rounded-2xl border border-(--paper-200) bg-(--paper-0)",
                   "px-4 py-2.5 text-sm text-(--snow-700) font-medium",
                   "transition-colors hover:border-(--teal-300) hover:text-(--teal-700)",
                   "shadow-(--shadow-float-sm)",
                   "disabled:opacity-60 disabled:cursor-not-allowed",
+                  // ねっぷちゃん側（右）へ向けた吹き出しのしっぽ
+                  "after:absolute after:top-1/2 after:-right-1.5 after:size-3 after:-translate-y-1/2 after:rotate-45",
+                  "after:bg-(--paper-0) after:border-t after:border-r after:border-(--paper-200)",
+                  "after:transition-colors hover:after:border-(--teal-300)",
                 )}
               >
                 <span aria-hidden="true">{p.icon}</span>

--- a/web/src/app/chat/contexts/ChatProvider.tsx
+++ b/web/src/app/chat/contexts/ChatProvider.tsx
@@ -4,14 +4,13 @@ import { type ReactNode, useEffect, useMemo, useRef } from "react";
 
 import { API_BASE } from "~/lib/api/client";
 import { getBearerToken } from "~/lib/auth-token";
-import { getLocationParam } from "~/lib/location-param";
 
 import { getMessageContent } from "../feedback-helpers";
 import { buildGreetingPrompt, isGreetingPrompt } from "../greeting-prompt";
 import { ChatContext, type ChatContextValue } from "./ChatContext";
 
 export type InitialMessage =
-  | { type: "greeting" }
+  | { type: "greeting"; location: string | null }
   | { type: "user"; text: string };
 
 interface Props {
@@ -65,7 +64,7 @@ export const ChatProvider = ({
     sent.current = true;
     const text =
       initialMessage.type === "greeting"
-        ? buildGreetingPrompt(getLocationParam())
+        ? buildGreetingPrompt(initialMessage.location)
         : initialMessage.text;
     void sendMessage({ text });
   }, [sendMessage, initialMessage]);

--- a/web/src/app/chat/hooks/useThreadManager.ts
+++ b/web/src/app/chat/hooks/useThreadManager.ts
@@ -11,6 +11,7 @@ import {
 } from "~/app/chat/hooks/useThreads";
 import { useAdminUser } from "~/hooks/useAdminUser";
 import { threadRepository } from "~/lib/api/repository";
+import { getLocationParam } from "~/lib/location-param";
 import { getResourceId } from "~/lib/resource";
 import type { InitialMessage } from "../contexts/ChatProvider";
 
@@ -18,6 +19,9 @@ const storageKey = (resourceId: string) => `chat_threadId_${resourceId}`;
 
 export const useThreadManager = () => {
   const resourceId = useMemo(() => getResourceId() ?? "default", []);
+  // ?location= 付きアクセスは訪問履歴に関わらず歓迎挨拶の新規スレッドで始める
+  const location = useMemo(() => getLocationParam(), []);
+  const hasLocationGreeting = location !== null;
   const { data: adminUser, isLoading: isAdminLoading } = useAdminUser();
   const isAdmin = !!adminUser;
   const { isReady: isSessionReady, isFirstVisit } = useAnonymousSession();
@@ -50,8 +54,8 @@ export const useThreadManager = () => {
   );
 
   const handleNewThread = useCallback(
-    () => startThread({ type: "greeting" }),
-    [startThread],
+    () => startThread({ type: "greeting", location }),
+    [startThread, location],
   );
 
   const handleStartFromLanding = useCallback(
@@ -90,22 +94,21 @@ export const useThreadManager = () => {
   useEffect(() => {
     if (threadsLoaded && !hasInitialized.current) {
       hasInitialized.current = true;
-      if (threads.length > 0) {
+      if (!hasLocationGreeting && threads.length > 0) {
         const savedThreadId = localStorage.getItem(storageKey(resourceId));
         const thread =
           threads.find((t) => t.id === savedThreadId) ?? threads[0];
         setCurrentThreadId(thread.id);
       }
     }
-  }, [threadsLoaded, threads, resourceId]);
+  }, [threadsLoaded, threads, resourceId, hasLocationGreeting]);
 
   useEffect(() => {
     if (
       threadsLoaded &&
       hasInitialized.current &&
-      threads.length === 0 &&
       currentThreadId === null &&
-      !isFirstVisit
+      (hasLocationGreeting || (threads.length === 0 && !isFirstVisit))
     ) {
       handleNewThread();
     }
@@ -114,10 +117,12 @@ export const useThreadManager = () => {
     threads.length,
     currentThreadId,
     isFirstVisit,
+    hasLocationGreeting,
     handleNewThread,
   ]);
 
   const showLanding =
+    !hasLocationGreeting &&
     isFirstVisit &&
     threadsLoaded &&
     threads.length === 0 &&


### PR DESCRIPTION
## Summary
- Landing のクイックプロンプトを吹き出し（トーク）風に変更
- `?location=` 付きアクセス時、初回訪問でも Landing をスキップして歓迎挨拶から会話を始めるよう修正

## 主な変更内容

### 吹き出し化（feat）
クイックプロンプトのボタンを角丸バー（`rounded-full`）から `rounded-2xl` + 疑似要素のしっぽに変更。しっぽは隣に立つねっぷちゃん側（右）へ向け、ホバー時は枠線色も同期する。

### location 初回訪問の修正（fix）
develop の location 実装（#741）は `useThreadManager` を変更しておらず、`?location=` 付きでも以下の挙動になっていた:

| 状況 | これまで |
|------|------|
| 初回訪問 + `?location=` | Landing が表示され歓迎挨拶が発火しない |
| 再訪問 + 既存スレッドあり | 既存スレッドを開くだけ |

QR コードで来訪する人はほぼ全員が初回訪問のため、狙ったユースケースで location 歓迎挨拶がほぼ発火していなかった。

本 PR では `useThreadManager` を location 対応にし、location があれば訪問履歴に関わらず新規スレッドを作って歓迎挨拶から始める。あわせて URL の読み取りを `useThreadManager` に集約し、`ChatProvider` へは `InitialMessage` の `location` フィールドで明示的に渡す。

## Test plan
- [x] `pnpm lint`（変更ファイルはクリーン）
- [x] `pnpm --filter @nepp-chan/web test`（433 passed）
- [x] `pnpm --filter @nepp-chan/web build`
- [ ] `?location=天塩川温泉` 等で初回訪問時に歓迎挨拶から始まることを実機確認
- [ ] Landing のプロンプトが吹き出し表示になっていることを確認