### PR TITLE
security: @mastra/deployer マルウェア依存を除去

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,11 @@
     "frontmatter:apply": "tsx scripts/apply-date-contact.ts",
     "openapi:generate": "pnpm --filter @nepp-chan/web openapi:generate"
   },
+  "pnpm": {
+    "overrides": {
+      "@mastra/deployer": "1.42.0"
+    }
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "glob": "^13.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@mastra/deployer': 1.42.0
+
 importers:
 
   .:
@@ -1985,8 +1988,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@mastra/deployer@1.42.1':
-    resolution: {integrity: sha512-ca9VUhCZ+jYxdgFmHEVk8Tmiu2AQJKkSbQuHaUCIy1uA5rLe4jBy3YiDkjmbQ6gWTznMG1fiyRSiXo1ydRH0RQ==}
+  '@mastra/deployer@1.42.0':
+    resolution: {integrity: sha512-iRpCf+gP4OCkGBYfHUKLzARi6+4gFBIK/yVngYveE5f/IuUhIPYRBL1SBoYVDx6r25L9yyLrw7jstAFDggRgHQ==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
       '@mastra/core': '>=1.34.0-0 <2.0.0-0'
@@ -3815,9 +3818,6 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  easy-day-js@1.11.22:
-    resolution: {integrity: sha512-JkJVZNSsFBmlAXKECNErDjK+swkGYMuEnCW1wLYlHMl3Mfx16725kJ99f3261B0Bk7gJIGEZZZ+4TPAXUkTmcw==}
-
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -4198,10 +4198,6 @@ packages:
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
@@ -7864,7 +7860,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/deployer@1.42.1(@hono/node-server@1.19.14(hono@4.12.25))(@mastra/core@1.42.0(ai@6.0.207(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)':
+  '@mastra/deployer@1.42.0(@hono/node-server@1.19.14(hono@4.12.25))(@mastra/core@1.42.0(ai@6.0.207(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
@@ -7881,7 +7877,6 @@ snapshots:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.62.0)
       '@sindresorhus/slugify': 2.2.1
       '@types/babel__traverse': 7.28.0
-      easy-day-js: 1.11.22
       empathic: 2.0.1
       esbuild: 0.27.7
       find-workspaces: 0.3.1
@@ -8789,7 +8784,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8805,7 +8800,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -9673,8 +9668,6 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  easy-day-js@1.11.22: {}
-
   ee-first@1.1.1: {}
 
   efrt@2.7.0: {}
@@ -9728,7 +9721,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-toolkit@1.46.1: {}
 
@@ -10074,7 +10067,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-node@4.4.1:
@@ -10113,7 +10106,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-port@7.2.0: {}
@@ -10195,10 +10188,6 @@ snapshots:
   has-tostringtag@1.0.2:
     dependencies:
       has-symbols: 1.1.0
-
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
 
   hasown@2.0.4:
     dependencies:
@@ -10704,7 +10693,7 @@ snapshots:
       '@clack/prompts': 1.5.1
       '@expo/devcert': 1.2.1
       '@mastra/core': 1.42.0(ai@6.0.207(zod@4.4.3))(express@5.2.1)(zod@4.4.3)
-      '@mastra/deployer': 1.42.1(@hono/node-server@1.19.14(hono@4.12.25))(@mastra/core@1.42.0(ai@6.0.207(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)
+      '@mastra/deployer': 1.42.0(@hono/node-server@1.19.14(hono@4.12.25))(@mastra/core@1.42.0(ai@6.0.207(zod@4.4.3))(express@5.2.1)(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)
       '@mastra/loggers': 1.1.2(@mastra/core@1.42.0(ai@6.0.207(zod@4.4.3))(express@5.2.1)(zod@4.4.3))
       archiver: 7.0.1
       commander: 14.0.3


### PR DESCRIPTION
## Summary

- `@mastra/deployer@1.42.1` は侵害された npm アカウントから公開された悪意あるバージョン
- typosquat パッケージ `easy-day-js` を依存に含み、`postinstall` で C2 サーバーに接続する RCE マルウェアを実行する
- pnpm overrides で `@mastra/deployer` を `1.42.0`（クリーン版）にピン止めし、lockfile から `easy-day-js` を排除

## 背景

- ref: https://github.com/mastra-ai/mastra/issues/18048
- `mastra@1.13.0` が `@mastra/deployer: ^1.42.0` を要求 → npm に残っている `1.42.1`（マルウェア版）に解決されてしまう
- マルウェア版はまだ npm から takedown されていないため、overrides によるピン止めが必要

## 対応後の残タスク

- [ ] CI/CD シークレットの全ローテーション（deploy-dev / deploy-prd の CI ランナーで postinstall が実行された可能性）
- [ ] Cloudflare Workers シークレットのローテーション
- [ ] ローカル開発マシンのクレデンシャルローテーション

🤖 Generated with [Claude Code](https://claude.com/claude-code)