### PR TITLE
fix(server): embedding テキストに strip されたヘッダー情報を復元

### DIFF
--- a/server/src/services/knowledge/embedding.test.ts
+++ b/server/src/services/knowledge/embedding.test.ts
@@ -131,6 +131,60 @@ describe("processKnowledgeFile", () => {
     expect(upsertArg[1].metadata.subsection).toBe("Sub");
   });
 
+  it("strip されたヘッダー情報を embedding テキストの先頭にプレフィックスとして復元する", async () => {
+    const bodyA = "a".repeat(100);
+    const bodyB = "b".repeat(100);
+    setChunks(
+      [bodyA, bodyB],
+      [
+        { title: "広報おといねっぷ 2023年6月号", section: "診療所" },
+        {
+          title: "広報おといねっぷ 2023年6月号",
+          section: "診療所",
+          subsection: "整形外科",
+        },
+      ],
+    );
+    vi.mocked(embedMany).mockResolvedValueOnce({
+      embeddings: [fakeEmbedding(), fakeEmbedding()],
+    } as never);
+
+    const vectorize = buildVectorize();
+    await processKnowledgeFile("kouhou.md", "x", vectorize, "key");
+
+    const call = vi.mocked(embedMany).mock.calls[0]?.[0] as {
+      values: string[];
+    };
+    expect(call.values[0]).toBe(
+      `広報おといねっぷ 2023年6月号 > 診療所\n\n${bodyA}`,
+    );
+    expect(call.values[1]).toBe(
+      `広報おといねっぷ 2023年6月号 > 診療所 > 整形外科\n\n${bodyB}`,
+    );
+
+    const upsertArg = vi.mocked(vectorize.upsert).mock.calls[0]?.[0] as Array<{
+      metadata: Record<string, unknown>;
+    }>;
+    expect(upsertArg[0].metadata.content).toBe(call.values[0]);
+    expect(upsertArg[1].metadata.content).toBe(call.values[1]);
+  });
+
+  it("ヘッダーメタデータがないチャンクはプレフィックスなしで元テキストを使う", async () => {
+    const body = "c".repeat(100);
+    setChunks([body], [{}]);
+    vi.mocked(embedMany).mockResolvedValueOnce({
+      embeddings: [fakeEmbedding()],
+    } as never);
+
+    const vectorize = buildVectorize();
+    await processKnowledgeFile("plain.md", "x", vectorize, "key");
+
+    const call = vi.mocked(embedMany).mock.calls[0]?.[0] as {
+      values: string[];
+    };
+    expect(call.values[0]).toBe(body);
+  });
+
   it("metadata から undefined を除外して upsert する", async () => {
     setChunks(["a".repeat(100)], [{ title: undefined, section: "S1" }]);
     vi.mocked(embedMany).mockResolvedValueOnce({

--- a/server/src/services/knowledge/embedding.ts
+++ b/server/src/services/knowledge/embedding.ts
@@ -75,8 +75,16 @@ const chunkDocument = async (
     .filter(({ text }) => text.length >= MIN_CHUNK_LENGTH)
     .map(({ i }) => i);
 
-  const texts = filteredIndices.map((i) => allTexts[i]);
-  const metadata: ChunkMetadata[] = filteredIndices.map((i) => {
+  const texts = filteredIndices.map((i) => {
+    const chunkMeta = chunkMetadataList[i] as
+      | Record<string, unknown>
+      | undefined;
+    const prefix = [chunkMeta?.title, chunkMeta?.section, chunkMeta?.subsection]
+      .filter((v): v is string => typeof v === "string")
+      .join(" > ");
+    return prefix ? `${prefix}\n\n${allTexts[i]}` : allTexts[i];
+  });
+  const metadata: ChunkMetadata[] = filteredIndices.map((i, idx) => {
     const chunkMeta = chunkMetadataList[i] as
       | Record<string, unknown>
       | undefined;
@@ -86,7 +94,7 @@ const chunkDocument = async (
       title: chunkMeta?.title as string | undefined,
       section: chunkMeta?.section as string | undefined,
       subsection: chunkMeta?.subsection as string | undefined,
-      content: allTexts[i],
+      content: texts[idx],
     };
   });
 


### PR DESCRIPTION
## Summary

- Mastra の markdown chunking（`stripHeaders: true`）が見出しを embedding テキストから除去するため、年度情報がヘッダーにしかないチャンクで年度を区別できない問題を修正
- strip された見出し情報（title/section/subsection）を `Title > Section > Subsection` 形式で embedding テキストの先頭にプレフィックスとして復元
- search.ts / knowledge-agent.ts の変更なし

## Background

広報のように `# 広報おといねっぷ 2023年6月号` という見出しに年度が含まれるファイルで、chunking 後のテキストから年度情報が消失する。
結果、2020年〜2023年の「7月の整形外科」チャンクが embedding 空間でほぼ同位置になり、検索時に正しい年度が選べない。

## Test plan

- [ ] `pnpm test --run` で server 全テスト通過
- [ ] マージ後: Vectorize 再構築が必要（全チャンクの embedding が変わるため）
- [ ] 再構築後、広報系の年度依存クエリ（例:「7月の整形外科は？」）で正しい年度が返ることを確認