### PR TITLE
fix: GA 計測を本番デプロイのみに限定

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -62,7 +62,6 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PUBLIC_API_URL: https://dev-api.nepp-chan.ai
           PUBLIC_LP_URL: https://dev.nepp-chan.ai
-          PUBLIC_GA_MEASUREMENT_ID: G-FMW4FP326K
           PUBLIC_SENTRY_DSN: ${{ secrets.SENTRY_DSN_WEB }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT_WEB: ${{ secrets.SENTRY_PROJECT_WEB }}
@@ -92,4 +91,3 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PUBLIC_API_URL: https://dev-api.nepp-chan.ai
           PUBLIC_WEB_URL: https://dev-web.nepp-chan.ai
-          PUBLIC_GA_MEASUREMENT_ID: G-FMW4FP326K

--- a/lp/src/components/GoogleAnalytics.astro
+++ b/lp/src/components/GoogleAnalytics.astro
@@ -1,9 +1,10 @@
 ---
 const measurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+const enabled = import.meta.env.PROD && measurementId;
 ---
 
 {
-	measurementId && (
+	enabled && (
 		<>
 			<script
 				is:inline

--- a/web/src/components/GoogleAnalytics.astro
+++ b/web/src/components/GoogleAnalytics.astro
@@ -1,9 +1,10 @@
 ---
 const measurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+const enabled = import.meta.env.PROD && measurementId;
 ---
 
 {
-	measurementId && (
+	enabled && (
 		<>
 			<script
 				is:inline


### PR DESCRIPTION
## Summary

- Google Analytics の計測を**本番デプロイのみ**に限定する
- ローカル開発（`astro dev`）と dev デプロイ環境では計測しないようにする
- これまで dev デプロイ・ローカルのアクセスが本番 GA プロパティ（`G-FMW4FP326K`）に混入していた状態を解消する

## 背景

GA の発火条件が「測定ID が空でないか」だけで環境判定がなく、加えて `deploy-dev.yml` が本番と同じ測定ID をビルド時に注入していたため、dev デプロイ・ローカルのアクセスも本番プロパティに計上されていた。

`astro build` は dev デプロイ・本番デプロイのどちらも `MODE=production` で区別できないため、ローカルと dev デプロイを別レイヤーで抑止する。

## 主な変更内容

- **ローカル（`astro dev`）**: `web` / `lp` の `GoogleAnalytics.astro` に `import.meta.env.PROD` ガードを追加。dev サーバーでは測定ID が設定されていても発火しない。
- **dev デプロイ**: `.github/workflows/deploy-dev.yml` の web/lp ジョブから `PUBLIC_GA_MEASUREMENT_ID` の注入を削除。`.env.production` は gitignore で CI に存在しないため、dev ビルドでは ID が空になり描画されない。
- **本番デプロイ（`deploy-prd.yml`）**: 無変更。計測を継続。

| 環境 | 変更後 |
| --- | --- |
| localhost (`astro dev`) | 計測なし |
| dev デプロイ | 計測なし |
| 本番デプロイ | 計測あり |

## Test plan

- [x] `pnpm lint`（Biome + astro check + tsc）が通る
- [x] web/lp ビルド: 測定ID あり → gtag 出力あり、ID なし → 出力なし
- [x] web dev サーバーを測定ID 付きで起動しても gtag が出力されない（PROD ガード動作）
- [ ] dev デプロイ後、`https://dev-web.nepp-chan.ai` の view-source に gtag が無いこと
- [ ] 本番デプロイ後、`https://web.nepp-chan.ai` に gtag が在ること
