### PR TITLE
fix(server): Mastra 未登録 Agent の generate が workerd でクラッシュする問題を回避

### DIFF
--- a/server/src/lib/classify-intent.test.ts
+++ b/server/src/lib/classify-intent.test.ts
@@ -4,10 +4,10 @@ const { generateMock } = vi.hoisted(() => ({
   generateMock: vi.fn(),
 }));
 
-vi.mock("~/mastra/agents/intent-router-agent", () => ({
-  intentRouterAgent: {
-    generate: generateMock,
-  },
+vi.mock("~/mastra/core-mastra", () => ({
+  getCoreMastra: () => ({
+    getAgent: () => ({ generate: generateMock }),
+  }),
 }));
 
 const { classifyIntent } = await import("./classify-intent");

--- a/server/src/lib/classify-intent.ts
+++ b/server/src/lib/classify-intent.ts
@@ -1,19 +1,15 @@
 import { z } from "zod";
 import type { Intent } from "~/lib/llm-models";
-import { intentRouterAgent } from "~/mastra/agents/intent-router-agent";
+import { getCoreMastra } from "~/mastra/core-mastra";
 
 const intentSchema = z.object({
   intent: z.enum(["casual", "thinking"]),
 });
 
-/**
- * ユーザーメッセージの意図を軽量モデル（intent-router-agent）で分類する。
- * 分類結果は resolveModelTier と組み合わせてメインエージェントのモデルティアを決定する。
- * 分類失敗時は "thinking" にフォールバックする。
- */
 export const classifyIntent = async (message: string): Promise<Intent> => {
   try {
-    const result = await intentRouterAgent.generate(message, {
+    const agent = getCoreMastra().getAgent("intentRouterAgent");
+    const result = await agent.generate(message, {
       structuredOutput: { schema: intentSchema },
     });
     return result.object?.intent ?? "thinking";

--- a/server/src/lib/image-converter.test.ts
+++ b/server/src/lib/image-converter.test.ts
@@ -4,10 +4,10 @@ const { generateMock } = vi.hoisted(() => ({
   generateMock: vi.fn(),
 }));
 
-vi.mock("~/mastra/agents/converter-agent", () => ({
-  converterAgent: {
-    generate: generateMock,
-  },
+vi.mock("~/mastra/core-mastra", () => ({
+  getCoreMastra: () => ({
+    getAgent: () => ({ generate: generateMock }),
+  }),
 }));
 
 const { convertToMarkdown, isSupportedMimeType } = await import(

--- a/server/src/lib/image-converter.ts
+++ b/server/src/lib/image-converter.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { converterAgent } from "~/mastra/agents/converter-agent";
+import { getCoreMastra } from "~/mastra/core-mastra";
 
 const SUPPORTED_MIME_TYPES = [
   "image/png",
@@ -26,7 +26,8 @@ export const convertToMarkdown = async (
 
   const base64Data = Buffer.from(fileData).toString("base64");
 
-  const result = await converterAgent.generate([
+  const agent = getCoreMastra().getAgent("converterAgent");
+  const result = await agent.generate([
     {
       role: "user",
       content: [

--- a/server/src/mastra/agents/knowledge-reranker-agent.ts
+++ b/server/src/mastra/agents/knowledge-reranker-agent.ts
@@ -1,0 +1,20 @@
+import { Agent } from "@mastra/core/agent";
+import { GEMINI_FLASH } from "~/lib/llm-models";
+
+// instructions は @mastra/core の MastraAgentRelevanceScorer 内部実装と同等
+// （挙動パリティのため英語のまま。日本語ナレッジ向けの調整は必要になってから）
+export const knowledgeRerankerAgent = new Agent({
+  id: "knowledge-reranker",
+  name: "Knowledge Reranker",
+  model: GEMINI_FLASH,
+  instructions: `You are a specialized agent for evaluating the relevance of text to queries.
+Your task is to rate how well a text passage answers a given query.
+Output only a number between 0 and 1, where:
+1.0 = Perfectly relevant, directly answers the query
+0.0 = Completely irrelevant
+Consider:
+- Direct relevance to the question
+- Completeness of information
+- Quality and specificity
+Always return just the number, no explanation.`,
+});

--- a/server/src/mastra/core-mastra.test.ts
+++ b/server/src/mastra/core-mastra.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getCoreMastra } from "./core-mastra";
+
+describe("getCoreMastra", () => {
+  it("同一インスタンスを返し、全 Agent が登録されている", () => {
+    const mastra = getCoreMastra();
+    expect(getCoreMastra()).toBe(mastra);
+
+    const agents = [
+      mastra.getAgent("intentRouterAgent"),
+      mastra.getAgent("converterAgent"),
+      mastra.getAgent("knowledgeRerankerAgent"),
+    ];
+    for (const agent of agents) {
+      expect(agent.getMastraInstance()).toBe(mastra);
+    }
+  });
+});

--- a/server/src/mastra/core-mastra.ts
+++ b/server/src/mastra/core-mastra.ts
@@ -1,0 +1,22 @@
+import { Mastra } from "@mastra/core/mastra";
+import { converterAgent } from "~/mastra/agents/converter-agent";
+import { intentRouterAgent } from "~/mastra/agents/intent-router-agent";
+import { knowledgeRerankerAgent } from "~/mastra/agents/knowledge-reranker-agent";
+
+// FIXME: mastra-ai/mastra#19462 の回避。未登録 Agent の generate() が ephemeral Mastra 経由で
+// Scheduler の setInterval(...).unref() を呼び workerd でクラッシュするため、workers: false の
+// Mastra に事前登録して回避している。upstream 修正後はこのファイルごと削除し、
+// 呼び出し元は Agent を直接 import する形に戻す。
+const createCoreMastra = () =>
+  new Mastra({
+    logger: false,
+    workers: false,
+    agents: { intentRouterAgent, converterAgent, knowledgeRerankerAgent },
+  });
+
+let mastra: ReturnType<typeof createCoreMastra> | undefined;
+
+export const getCoreMastra = () => {
+  mastra ??= createCoreMastra();
+  return mastra;
+};

--- a/server/src/services/knowledge/search.test.ts
+++ b/server/src/services/knowledge/search.test.ts
@@ -6,16 +6,7 @@ vi.mock("@ai-sdk/google", () => ({
   })),
 }));
 
-vi.mock("@mastra/core/llm", () => ({
-  ModelRouterLanguageModel: vi.fn(function (modelId: string) {
-    return { modelId };
-  }),
-}));
-
 vi.mock("@mastra/rag", () => ({
-  MastraAgentRelevanceScorer: vi.fn(function (id: string, model: unknown) {
-    return { id, model };
-  }),
   rerankWithScorer: vi.fn(),
 }));
 
@@ -27,10 +18,20 @@ vi.mock("~/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+const { rerankerGenerateMock } = vi.hoisted(() => ({
+  rerankerGenerateMock: vi.fn(),
+}));
+
+vi.mock("~/mastra/core-mastra", () => ({
+  getCoreMastra: () => ({
+    getAgent: () => ({ generate: rerankerGenerateMock }),
+  }),
+}));
+
 const { embed } = await import("ai");
 const { rerankWithScorer } = await import("@mastra/rag");
 const { logger } = await import("~/lib/logger");
-const { searchKnowledge } = await import("./search");
+const { knowledgeRerankScorer, searchKnowledge } = await import("./search");
 
 const buildVectorize = () =>
   ({
@@ -43,6 +44,23 @@ beforeEach(() => {
   vi.mocked(embed).mockReset();
   vi.mocked(rerankWithScorer).mockReset();
   vi.mocked(logger.error).mockReset();
+  rerankerGenerateMock.mockReset();
+});
+
+describe("knowledgeRerankScorer", () => {
+  it("query と text をプロンプトに含めて generate し、数値スコアを返す", async () => {
+    rerankerGenerateMock.mockResolvedValueOnce({ text: "0.85" });
+
+    const score = await knowledgeRerankScorer.getRelevanceScore(
+      "観光名所",
+      "音威子府村の観光スポット一覧",
+    );
+
+    expect(score).toBe(0.85);
+    const prompt = rerankerGenerateMock.mock.calls[0]?.[0] as string;
+    expect(prompt).toContain("観光名所");
+    expect(prompt).toContain("音威子府村の観光スポット一覧");
+  });
 });
 
 describe("searchKnowledge", () => {

--- a/server/src/services/knowledge/search.ts
+++ b/server/src/services/knowledge/search.ts
@@ -1,15 +1,28 @@
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
-import { ModelRouterLanguageModel } from "@mastra/core/llm";
-import { MastraAgentRelevanceScorer, rerankWithScorer } from "@mastra/rag";
+import type { RelevanceScoreProvider } from "@mastra/core/relevance";
+import { createSimilarityPrompt } from "@mastra/core/relevance";
+import { rerankWithScorer } from "@mastra/rag";
 import { embed } from "ai";
-import { GEMINI_EMBEDDING, GEMINI_FLASH } from "~/lib/llm-models";
+import { GEMINI_EMBEDDING } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
+import { getCoreMastra } from "~/mastra/core-mastra";
 
 const EMBEDDING_DIMENSIONS = 1536;
 
 const SEARCH_TOP_K = 10;
 
 const RERANK_TOP_K = 5;
+
+// FIXME: mastra-ai/mastra#19462 の回避。MastraAgentRelevanceScorer は内部で未登録 Agent を
+// 生成し workerd でクラッシュするため公開インターフェースを自前実装している。
+// upstream 修正後は MastraAgentRelevanceScorer（シングルトン化）に戻す。
+export const knowledgeRerankScorer: RelevanceScoreProvider = {
+  getRelevanceScore: async (query, text) => {
+    const agent = getCoreMastra().getAgent("knowledgeRerankerAgent");
+    const result = await agent.generate(createSimilarityPrompt(query, text));
+    return Number.parseFloat(result.text);
+  },
+};
 
 export type KnowledgeResult = {
   content: string;
@@ -78,15 +91,10 @@ export const searchKnowledge = async (
       };
     });
 
-    const rerankModel = new ModelRouterLanguageModel(GEMINI_FLASH);
-    const scorer = new MastraAgentRelevanceScorer(
-      "knowledge-reranker",
-      rerankModel,
-    );
     const rerankedResults = await rerankWithScorer({
       results: queryResults,
       query,
-      scorer,
+      scorer: knowledgeRerankScorer,
       options: {
         topK: RERANK_TOP_K,
         weights: {


### PR DESCRIPTION
## Summary

- `@mastra/core` 1.49.0 の Scheduler がガードなしで `setInterval(...).unref()` を呼ぶため、Mastra 未登録 Agent の `generate()` が ephemeral Mastra 経由で workerd 上クラッシュする（[mastra-ai/mastra#19462](https://github.com/mastra-ai/mastra/issues/19462) として報告済み）
- 影響範囲: intent 分類（全チャネルで常に thinking ティア固定に劣化）、管理画面の画像/PDF 変換（500 エラー）、ナレッジ検索の rerank（RAG 全滅、dev 環境で実証済み）。本番は 7/10 の Mastra バンプ未デプロイのため無傷
- 対応: `workers: false` の共有 Mastra へ事前登録する `getCoreMastra()` を導入し、Agent はここ経由で取得する。リランカーは `MastraAgentRelevanceScorer` が内部で未登録 Agent を都度生成する設計のため、公開インターフェース `RelevanceScoreProvider` を自前実装に置き換え
- upstream 修正後に削除する前提の一時対応。復帰手順は各 FIXME コメントに記載

## Test plan

- [x] server 単体テスト 1039 件パス
- [x] tsc / biome クリーン
- [ ] wrangler dev で chat リクエスト → intent 分類が casual/thinking を返し `unref` エラーが出ないこと
- [ ] ナレッジ検索（RAG）が結果を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)