### PR TITLE
fix(web): softphoneの発信音とwelcomeGreetingの重なりを解消

### DIFF
--- a/server/src/services/voice/twilio-token.test.ts
+++ b/server/src/services/voice/twilio-token.test.ts
@@ -103,7 +103,10 @@ describe("createRelayToken / verifyRelayToken（hono/jwt ベース）", () => {
       nowSeconds: Math.floor(Date.now() / 1000),
       ttlSeconds: 300,
     });
-    const tampered = `${token.slice(0, -1)}${token.endsWith("a") ? "b" : "a"}`;
+    const [header, payload, sig] = token.split(".");
+    const tampered = `${header}.${payload}.${
+      sig.startsWith("a") ? "b" : "a"
+    }${sig.slice(1)}`;
     expect(await verifyRelayToken(tampered, SECRET)).toBeNull();
   });
 

--- a/web/src/app/call-dev/useCallDevice.test.ts
+++ b/web/src/app/call-dev/useCallDevice.test.ts
@@ -2,15 +2,23 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useCallDevice } from "./useCallDevice";
 
-const { connect, destroy, disconnectAll, deviceOn, callOn, fetchCallToken } =
-  vi.hoisted(() => ({
-    connect: vi.fn(),
-    destroy: vi.fn(),
-    disconnectAll: vi.fn(),
-    deviceOn: vi.fn(),
-    callOn: vi.fn(),
-    fetchCallToken: vi.fn(),
-  }));
+const {
+  connect,
+  destroy,
+  disconnectAll,
+  deviceOn,
+  callOn,
+  audioOutgoing,
+  fetchCallToken,
+} = vi.hoisted(() => ({
+  connect: vi.fn(),
+  destroy: vi.fn(),
+  disconnectAll: vi.fn(),
+  deviceOn: vi.fn(),
+  callOn: vi.fn(),
+  audioOutgoing: vi.fn(),
+  fetchCallToken: vi.fn(),
+}));
 
 vi.mock("./api", () => ({ fetchCallToken }));
 vi.mock("@twilio/voice-sdk", () => ({
@@ -19,6 +27,7 @@ vi.mock("@twilio/voice-sdk", () => ({
     destroy = destroy;
     disconnectAll = disconnectAll;
     on = deviceOn;
+    audio = { outgoing: audioOutgoing };
   },
 }));
 
@@ -50,6 +59,18 @@ describe("useCallDevice", () => {
 
     expect(connect).not.toHaveBeenCalled();
     expect(result.current.status).toBe("idle");
+  });
+
+  it("発信音を無効化してから発信する", async () => {
+    fetchCallToken.mockResolvedValue({ token: "token", identity: "dev-1" });
+    const { result } = renderHook(() => useCallDevice());
+
+    await act(() => result.current.startCall());
+
+    expect(audioOutgoing).toHaveBeenCalledWith(false);
+    expect(audioOutgoing.mock.invocationCallOrder[0]).toBeLessThan(
+      connect.mock.invocationCallOrder[0],
+    );
   });
 
   it("アンマウント時に Device を破棄する", async () => {

--- a/web/src/app/call-dev/useCallDevice.ts
+++ b/web/src/app/call-dev/useCallDevice.ts
@@ -26,6 +26,8 @@ export const useCallDevice = () => {
         const { token } = await fetchCallToken();
         if (!isCurrentAttempt()) return;
         const device = new Device(token, { logLevel: "error" });
+        // ローカルの発信音が welcomeGreeting の頭とかぶるため鳴らさない
+        device.audio?.outgoing(false);
         // トークン期限切れ等は Call ではなく Device が 'error' を emit する。
         device.on("error", (e: { message?: string }) => {
           if (!isCurrentAttempt()) return;


### PR DESCRIPTION
## 概要

/call-dev の softphone で発信すると、Voice SDK がローカルで鳴らす発信音（outgoing sound）と ConversationRelay の welcomeGreeting の頭が重なって聞こえる問題を解消する。

## 変更内容

- Device 生成直後に `device.audio?.outgoing(false)` で発信音を無効化
- 接続中の状態は UI の connecting 表示で判別できるため、音による通知は不要

## 補足

本番想定の実電話（PSTN）では呼出音を網側が制御するためこの重なりは起きない。/call-dev の検証体験のみの修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXKY8KtYBsythFDstwQxmx