### PR TITLE
fix(server): 検索前の待機案内を最後まで再生する

### DIFF
--- a/server/src/services/voice/silence-cover.test.ts
+++ b/server/src/services/voice/silence-cover.test.ts
@@ -93,7 +93,7 @@ describe("createSilenceCover", () => {
       });
       cover.onToolCall();
       expect(sendText).toHaveBeenCalledWith("ちょっと待ってね", true, {
-        preemptible: true,
+        preemptible: false,
         interruptible: true,
       });
       expect(sendPlay).not.toHaveBeenCalled();
@@ -113,7 +113,7 @@ describe("createSilenceCover", () => {
       cover.onToolCall();
       vi.advanceTimersByTime(10_000);
       expect(sendText).toHaveBeenCalledWith("ちょっと待ってね", true, {
-        preemptible: true,
+        preemptible: false,
         interruptible: true,
       });
       expect(sendPlay).not.toHaveBeenCalled();
@@ -159,7 +159,7 @@ describe("createSilenceCover", () => {
       vi.advanceTimersByTime(10_000);
       expect(sendText).toHaveBeenCalledTimes(1);
       expect(sendText).toHaveBeenCalledWith("ちょっと待ってね", true, {
-        preemptible: true,
+        preemptible: false,
         interruptible: true,
       });
     });
@@ -176,7 +176,7 @@ describe("createSilenceCover", () => {
     vi.advanceTimersByTime(10_000);
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(sendText).toHaveBeenCalledWith("ちょっと待ってね", true, {
-      preemptible: true,
+      preemptible: false,
       interruptible: true,
     });
     expect(sendPlay).not.toHaveBeenCalled();

--- a/server/src/services/voice/silence-cover.ts
+++ b/server/src/services/voice/silence-cover.ts
@@ -89,7 +89,7 @@ export const createSilenceCover = ({
         waitingSpoken = true;
         clearFillerTimer();
         sendText("ちょっと待ってね", true, {
-          preemptible: true,
+          preemptible: false,
           interruptible: true,
         });
       }


### PR DESCRIPTION
## Summary
- 実検索前の「ちょっと待ってね」が本回答に置き換えられないようにする
- slot で即答できる場合は従来どおり待機案内を省略する

## 主な変更内容
ConversationRelayへ送る検索待機案内の `preemptible` を `false` に変更しました。ユーザーによる割り込みは引き続き可能です。

## Test plan
- [x] `pnpm --filter @nepp-chan/server test --run src/services/voice/silence-cover.test.ts src/mastra/tools/voice-answer-tool.test.ts src/services/voice/conversation.test.ts src/mastra/agents/nepp-chan-agent.test.ts`
- [x] 実検索時の待機案内が `preemptible: false` で送られることをテストで確認
- [x] slot ヒット時に検索開始コールバックが呼ばれない既存テストを確認