### PR TITLE
perf(server): 音声会話のD1依存を応答経路から外す

### DIFF
--- a/server/src/lib/principal.test.ts
+++ b/server/src/lib/principal.test.ts
@@ -126,41 +126,41 @@ describe("toLineIds", () => {
 
 describe("toVoiceIds", () => {
   it("resourceId / threadId / hashedFrom をまとめて返す", async () => {
-    const ids = await toVoiceIds("client:abc123", SECRET);
+    const ids = await toVoiceIds("client:abc123", "CA123", SECRET);
     expect(ids.hashedFrom).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(ids.resourceId).toBe(`voice:${ids.hashedFrom}`);
-    expect(ids.threadId).toBe(`voice-thread:${ids.hashedFrom}`);
+    expect(ids.threadId).toMatch(/^voice-thread:[A-Za-z0-9_-]{43}$/);
   });
 
-  it("同じ発信元 / secret から同じ ID が再現される（会話継続性）", async () => {
-    const a = await toVoiceIds("+81901234567", SECRET);
-    const b = await toVoiceIds("+81901234567", SECRET);
+  it("同じ発信元 / callSid / secret から同じ ID が再現される", async () => {
+    const a = await toVoiceIds("+81901234567", "CA123", SECRET);
+    const b = await toVoiceIds("+81901234567", "CA123", SECRET);
     expect(a.resourceId).toBe(b.resourceId);
     expect(a.threadId).toBe(b.threadId);
   });
 
   it("異なる発信元は異なる resourceId になる", async () => {
-    const a = await toVoiceIds("client:aaa", SECRET);
-    const b = await toVoiceIds("client:bbb", SECRET);
+    const a = await toVoiceIds("client:aaa", "CA123", SECRET);
+    const b = await toVoiceIds("client:bbb", "CA123", SECRET);
     expect(a.resourceId).not.toBe(b.resourceId);
   });
 
-  it("resourceId と threadId は同じハッシュを共有する", async () => {
-    const ids = await toVoiceIds("client:abc123", SECRET);
-    expect(ids.resourceId.replace("voice:", "")).toBe(
-      ids.threadId.replace("voice-thread:", ""),
-    );
+  it("同じ発信元でも通話が異なれば threadId を分ける", async () => {
+    const a = await toVoiceIds("client:abc123", "CA123", SECRET);
+    const b = await toVoiceIds("client:abc123", "CA456", SECRET);
+    expect(a.resourceId).toBe(b.resourceId);
+    expect(a.threadId).not.toBe(b.threadId);
   });
 
   it("出力に平文の発信元を含まない", async () => {
-    const ids = await toVoiceIds("client:secret-caller", SECRET);
+    const ids = await toVoiceIds("client:secret-caller", "CA123", SECRET);
     expect(ids.hashedFrom).not.toContain("secret-caller");
     expect(ids.resourceId).not.toContain("secret-caller");
     expect(ids.threadId).not.toContain("secret-caller");
   });
 
   it("LINE と voice は同じ生入力でも名前空間が分かれる", async () => {
-    const voice = await toVoiceIds("U1234567890", SECRET);
+    const voice = await toVoiceIds("U1234567890", "CA123", SECRET);
     const line = await toLineIds({ type: "line", id: "U1234567890" }, SECRET);
     expect(voice.resourceId).not.toBe(line.resourceId);
   });

--- a/server/src/lib/principal.ts
+++ b/server/src/lib/principal.ts
@@ -44,15 +44,21 @@ export const toLineIds = async (p: LinePrincipal, secret: string) => {
   };
 };
 
-// 音声通話の発信元（softphone の client:… / PSTN の +81…）から
-// resourceId / threadId / hashedFrom をまとめて生成する。LINE と同様に
-// 平文の発信元が永続化されないよう HMAC でハッシュ化し、voice 名前空間を分ける。
-export const toVoiceIds = async (from: string, secret: string) => {
-  const hashedFrom = await hmacSha256(from, secret);
+// 発信元は resourceId、通話は threadId に対応させる。どちらも平文を
+// 永続化しないよう HMAC でハッシュ化し、voice 名前空間を分ける。
+export const toVoiceIds = async (
+  from: string,
+  callSid: string,
+  secret: string,
+) => {
+  const [hashedFrom, hashedCallSid] = await Promise.all([
+    hmacSha256(from, secret),
+    hmacSha256(callSid, secret),
+  ]);
   return {
     hashedFrom,
     resourceId: `voice:${hashedFrom}`,
-    threadId: `voice-thread:${hashedFrom}`,
+    threadId: `voice-thread:${hashedCallSid}`,
   };
 };
 

--- a/server/src/services/voice/call-bridge.test.ts
+++ b/server/src/services/voice/call-bridge.test.ts
@@ -1,21 +1,49 @@
 import { describe, expect, it, vi } from "vitest";
 import { CallBridge } from "./call-bridge";
 
-const { createVoiceTurnRunnerMock } = vi.hoisted(() => ({
-  createVoiceTurnRunnerMock: vi.fn(),
+const { createVoiceConversationMock } = vi.hoisted(() => ({
+  createVoiceConversationMock: vi.fn(),
 }));
 
 vi.mock("./conversation", () => ({
-  createVoiceTurnRunner: createVoiceTurnRunnerMock,
+  createVoiceConversation: createVoiceConversationMock,
 }));
 
 describe("CallBridge", () => {
+  it("WebSocket のメッセージ処理を waitUntil に登録する", async () => {
+    const waitUntil = vi.fn();
+    const bridge = new CallBridge(
+      { waitUntil } as unknown as DurableObjectState,
+      {} as CloudflareBindings,
+    );
+    const handleMessageEvent = Reflect.get(bridge, "handleMessageEvent") as (
+      ws: WebSocket,
+      event: MessageEvent,
+    ) => void;
+
+    handleMessageEvent.call(
+      bridge,
+      {} as WebSocket,
+      {
+        data: new ArrayBuffer(0),
+      } as MessageEvent,
+    );
+
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+    await waitUntil.mock.calls[0][0];
+  });
+
   it("ランナー初期化中に中断されたターンは発話も実行もしない", async () => {
-    let resolveRunner: ((runner: ReturnType<typeof vi.fn>) => void) | undefined;
     const turnRunner = vi.fn(async function* () {
       yield "回答";
     });
-    createVoiceTurnRunnerMock.mockReturnValue(
+    let resolveRunner:
+      | ((conversation: {
+          runTurn: typeof turnRunner;
+          persistTurn: () => Promise<void>;
+        }) => void)
+      | undefined;
+    createVoiceConversationMock.mockReturnValue(
       new Promise((resolve) => {
         resolveRunner = resolve;
       }),
@@ -39,10 +67,58 @@ describe("CallBridge", () => {
     await onMessage.call(bridge, ws, {
       data: JSON.stringify({ type: "interrupt" }),
     } as MessageEvent);
-    resolveRunner?.(turnRunner);
+    resolveRunner?.({ runTurn: turnRunner, persistTurn: vi.fn() });
     await prompt;
 
     expect(turnRunner).not.toHaveBeenCalled();
     expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it("完了トークンを送ってから D1 保存を待つ", async () => {
+    const order: string[] = [];
+    const runTurn = vi.fn(async function* () {
+      yield "回答";
+    });
+    const persistTurn = vi.fn(async () => {
+      order.push("persist");
+    });
+    createVoiceConversationMock.mockResolvedValue({ runTurn, persistTurn });
+
+    const bridge = new CallBridge(
+      {} as DurableObjectState,
+      {} as CloudflareBindings,
+    );
+    Reflect.set(bridge, "from", "client:tester");
+    Reflect.set(bridge, "callSid", "CA123");
+    const ws = {
+      send: vi.fn((raw: string) => {
+        const message = JSON.parse(raw) as {
+          type: string;
+          token?: string;
+          last?: boolean;
+        };
+        if (message.type === "text" && message.last && message.token === "") {
+          order.push("last");
+        }
+      }),
+    } as unknown as WebSocket;
+    const handlePrompt = Reflect.get(bridge, "handlePrompt") as (
+      ws: WebSocket,
+      text: string,
+    ) => Promise<void>;
+
+    await handlePrompt.call(bridge, ws, "質問");
+
+    expect(order).toEqual(["last", "persist"]);
+    expect(createVoiceConversationMock).toHaveBeenCalledWith({
+      env: expect.anything(),
+      from: "client:tester",
+      callSid: "CA123",
+    });
+    expect(persistTurn).toHaveBeenCalledWith({
+      turnIndex: 0,
+      userText: "質問",
+      assistantText: "回答",
+    });
   });
 });

--- a/server/src/services/voice/call-bridge.test.ts
+++ b/server/src/services/voice/call-bridge.test.ts
@@ -121,4 +121,41 @@ describe("CallBridge", () => {
       assistantText: "回答",
     });
   });
+
+  it("完了トークン送信後は D1 保存中でも active turn を解除する", async () => {
+    let resolvePersistence: (() => void) | undefined;
+    const runTurn = vi.fn(async function* () {
+      yield "回答";
+    });
+    const persistTurn = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePersistence = resolve;
+        }),
+    );
+    createVoiceConversationMock.mockResolvedValue({ runTurn, persistTurn });
+
+    const bridge = new CallBridge(
+      {} as DurableObjectState,
+      {} as CloudflareBindings,
+    );
+    Reflect.set(bridge, "from", "client:tester");
+    Reflect.set(bridge, "callSid", "CA123");
+    const handlePrompt = Reflect.get(bridge, "handlePrompt") as (
+      ws: WebSocket,
+      text: string,
+    ) => Promise<void>;
+
+    const prompt = handlePrompt.call(
+      bridge,
+      { send: vi.fn() } as unknown as WebSocket,
+      "質問",
+    );
+    await vi.waitFor(() => expect(persistTurn).toHaveBeenCalledOnce());
+
+    expect(Reflect.get(bridge, "currentTurn")).toBeNull();
+
+    resolvePersistence?.();
+    await prompt;
+  });
 });

--- a/server/src/services/voice/call-bridge.test.ts
+++ b/server/src/services/voice/call-bridge.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "~/lib/logger";
 import { CallBridge } from "./call-bridge";
 
 const { createVoiceConversationMock } = vi.hoisted(() => ({
@@ -10,6 +11,10 @@ vi.mock("./conversation", () => ({
 }));
 
 describe("CallBridge", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("WebSocket のメッセージ処理を waitUntil に登録する", async () => {
     const waitUntil = vi.fn();
     const bridge = new CallBridge(
@@ -157,5 +162,70 @@ describe("CallBridge", () => {
 
     resolvePersistence?.();
     await prompt;
+  });
+
+  it("assistantText が空のターンは D1 へ保存しない", async () => {
+    const runTurn = vi.fn(async function* () {
+      // ツール呼び出しのみで終わり、text-delta を1つも yield しないケース
+    });
+    const persistTurn = vi.fn();
+    createVoiceConversationMock.mockResolvedValue({ runTurn, persistTurn });
+
+    const bridge = new CallBridge(
+      {} as DurableObjectState,
+      {} as CloudflareBindings,
+    );
+    Reflect.set(bridge, "from", "client:tester");
+    Reflect.set(bridge, "callSid", "CA123");
+    const handlePrompt = Reflect.get(bridge, "handlePrompt") as (
+      ws: WebSocket,
+      text: string,
+    ) => Promise<void>;
+
+    await handlePrompt.call(
+      bridge,
+      { send: vi.fn() } as unknown as WebSocket,
+      "質問",
+    );
+
+    expect(persistTurn).not.toHaveBeenCalled();
+  });
+
+  it("turnEndMs は D1 保存待ち時間を含まず、persistenceMs に分離して計測する", async () => {
+    vi.useFakeTimers();
+    const runTurn = vi.fn(async function* () {
+      yield "回答";
+    });
+    const persistTurn = vi.fn(
+      () => new Promise<void>((resolve) => setTimeout(resolve, 500)),
+    );
+    createVoiceConversationMock.mockResolvedValue({ runTurn, persistTurn });
+    const infoSpy = vi.spyOn(logger, "info");
+
+    const bridge = new CallBridge(
+      {} as DurableObjectState,
+      {} as CloudflareBindings,
+    );
+    Reflect.set(bridge, "from", "client:tester");
+    Reflect.set(bridge, "callSid", "CA123");
+    const handlePrompt = Reflect.get(bridge, "handlePrompt") as (
+      ws: WebSocket,
+      text: string,
+    ) => Promise<void>;
+
+    const prompt = handlePrompt.call(
+      bridge,
+      { send: vi.fn() } as unknown as WebSocket,
+      "質問",
+    );
+    await vi.advanceTimersByTimeAsync(500);
+    await prompt;
+
+    const timingCall = infoSpy.mock.calls.find(
+      ([message]) => message === "[Voice] turn timing",
+    );
+    const timing = timingCall?.[1] as Record<string, number>;
+    expect(timing.turnEndMs).toBeLessThan(500);
+    expect(timing.persistenceMs).toBeGreaterThanOrEqual(500);
   });
 });

--- a/server/src/services/voice/call-bridge.ts
+++ b/server/src/services/voice/call-bridge.ts
@@ -228,6 +228,7 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
       }
       if (!controller.signal.aborted) {
         send("", true);
+        if (this.currentTurn === controller) this.currentTurn = null;
         if (endRequested && this.config.endCallEnabled) {
           this.scheduleEndCall(ws, assistantChars);
         }

--- a/server/src/services/voice/call-bridge.ts
+++ b/server/src/services/voice/call-bridge.ts
@@ -6,7 +6,7 @@ import {
   type BridgeConfig,
   parseBridgeConfig,
 } from "./bridge-config";
-import { createVoiceTurnRunner } from "./conversation";
+import { createVoiceConversation } from "./conversation";
 import {
   createVoiceFindingsSlot,
   type VoiceFindingsSlot,
@@ -36,6 +36,7 @@ export const handleRelayUpgrade = (
 
 export class CallBridge extends DurableObject<CloudflareBindings> {
   private from = "";
+  private callSid = "";
   private verified = false;
   private socket: WebSocket | null = null;
   private currentTurn: AbortController | null = null;
@@ -47,19 +48,17 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
   private findingsSlot: VoiceFindingsSlot = createVoiceFindingsSlot();
   private config: BridgeConfig = BRIDGE_CONFIG_DEFAULTS;
   private pendingEndTimer: ReturnType<typeof setTimeout> | null = null;
-  private turnRunnerPromise: ReturnType<typeof createVoiceTurnRunner> | null =
-    null;
+  private conversationPromise: ReturnType<
+    typeof createVoiceConversation
+  > | null = null;
+  private turnIndex = 0;
 
   async fetch() {
     const { 0: client, 1: server } = new WebSocketPair();
     this.socket = server;
     server.accept();
     server.addEventListener("message", (event) => {
-      this.onMessage(server, event).catch((e) =>
-        logger.error("[CallBridge] onMessage failed", {
-          error: e instanceof Error ? e.message : String(e),
-        }),
-      );
+      this.handleMessageEvent(server, event);
     });
     server.addEventListener("close", () => {
       this.currentTurn?.abort();
@@ -67,6 +66,15 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
     });
     await this.ctx.storage.setAlarm(Date.now() + SETUP_TIMEOUT_MS);
     return new Response(null, { status: 101, webSocket: client });
+  }
+
+  private handleMessageEvent(ws: WebSocket, event: MessageEvent) {
+    const task = this.onMessage(ws, event).catch((e) =>
+      logger.error("[CallBridge] onMessage failed", {
+        error: e instanceof Error ? e.message : String(e),
+      }),
+    );
+    this.ctx.waitUntil(task);
   }
 
   async alarm() {
@@ -100,6 +108,7 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
       }
       this.verified = true;
       this.from = msg.from;
+      this.callSid = msg.callSid;
       this.config = parseBridgeConfig(msg.customParameters);
     } else if (msg.type === "prompt") {
       if (!this.verified) return;
@@ -168,11 +177,12 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
     this.currentTurn = controller;
 
     const t0 = Date.now();
-    this.turnRunnerPromise ??= createVoiceTurnRunner({
+    this.conversationPromise ??= createVoiceConversation({
       env: this.env,
       from: this.from,
+      callSid: this.callSid,
     });
-    const turnRunner = await this.turnRunnerPromise;
+    const conversation = await this.conversationPromise;
     if (controller.signal.aborted || this.currentTurn !== controller) {
       if (this.currentTurn === controller) this.currentTurn = null;
       return;
@@ -181,6 +191,7 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
     let firstSendMs: number | null = null;
     let tokenCount = 0;
     let assistantChars = 0;
+    let assistantText = "";
     let endRequested = false;
 
     const send = (token: string, last = false, options?: TextTokenOptions) =>
@@ -198,7 +209,7 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
     cover.start();
 
     try {
-      for await (const delta of turnRunner({
+      for await (const delta of conversation.runTurn({
         text,
         signal: controller.signal,
         onToolCall: cover.onToolCall,
@@ -211,6 +222,7 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
         if (firstSendMs === null) firstSendMs = Date.now() - t0;
         tokenCount++;
         assistantChars += delta.length;
+        assistantText += delta;
         cover.onToken();
         send(delta);
       }
@@ -218,6 +230,19 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
         send("", true);
         if (endRequested && this.config.endCallEnabled) {
           this.scheduleEndCall(ws, assistantChars);
+        }
+        const turnIndex = this.turnIndex++;
+        try {
+          await conversation.persistTurn({
+            turnIndex,
+            userText: text,
+            assistantText,
+          });
+        } catch (e) {
+          logger.error("[Voice] turn persistence failed", {
+            error: e instanceof Error ? e.message : String(e),
+            turnIndex,
+          });
         }
       }
     } catch (e) {

--- a/server/src/services/voice/call-bridge.ts
+++ b/server/src/services/voice/call-bridge.ts
@@ -193,6 +193,8 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
     let assistantChars = 0;
     let assistantText = "";
     let endRequested = false;
+    let responseEndMs: number | null = null;
+    let persistenceMs: number | null = null;
 
     const send = (token: string, last = false, options?: TextTokenOptions) =>
       ws.send(serializeRelayMessage(textTokenMessage(token, last, options)));
@@ -228,22 +230,27 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
       }
       if (!controller.signal.aborted) {
         send("", true);
+        responseEndMs = Date.now() - t0;
         if (this.currentTurn === controller) this.currentTurn = null;
         if (endRequested && this.config.endCallEnabled) {
           this.scheduleEndCall(ws, assistantChars);
         }
-        const turnIndex = this.turnIndex++;
-        try {
-          await conversation.persistTurn({
-            turnIndex,
-            userText: text,
-            assistantText,
-          });
-        } catch (e) {
-          logger.error("[Voice] turn persistence failed", {
-            error: e instanceof Error ? e.message : String(e),
-            turnIndex,
-          });
+        if (assistantText) {
+          const turnIndex = this.turnIndex++;
+          const persistStart = Date.now();
+          try {
+            await conversation.persistTurn({
+              turnIndex,
+              userText: text,
+              assistantText,
+            });
+          } catch (e) {
+            logger.error("[Voice] turn persistence failed", {
+              error: e instanceof Error ? e.message : String(e),
+              turnIndex,
+            });
+          }
+          persistenceMs = Date.now() - persistStart;
         }
       }
     } catch (e) {
@@ -257,11 +264,12 @@ export class CallBridge extends DurableObject<CloudflareBindings> {
       cover.dispose();
       if (this.currentTurn === controller) this.currentTurn = null;
       const timing: Record<string, number | boolean> = {
-        turnEndMs: Date.now() - t0,
+        turnEndMs: responseEndMs ?? Date.now() - t0,
         tokenCount,
         aborted: controller.signal.aborted,
       };
       if (firstSendMs !== null) timing.firstSendMs = firstSendMs;
+      if (persistenceMs !== null) timing.persistenceMs = persistenceMs;
       logger.info("[Voice] turn timing", timing);
     }
   }

--- a/server/src/services/voice/conversation.test.ts
+++ b/server/src/services/voice/conversation.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { logger } from "~/lib/logger";
-import { toVoiceIds } from "~/lib/principal";
-import { createVoiceTurnRunner } from "./conversation";
+import { createNeppChanAgent } from "~/mastra/agents/nepp-chan-agent";
+import { createVoiceConversation } from "./conversation";
 
 type FakeChunk =
   | { type: "text-delta"; payload: { text: string } }
@@ -21,10 +21,16 @@ async function* fakeFullStream(chunks: FakeChunk[]) {
   for (const chunk of chunks) yield chunk;
 }
 
-const { streamMock } = vi.hoisted(() => ({ streamMock: vi.fn() }));
+const { getMemoryStoreMock, saveMessagesMock, saveThreadMock, streamMock } =
+  vi.hoisted(() => ({
+    getMemoryStoreMock: vi.fn(),
+    saveMessagesMock: vi.fn(),
+    saveThreadMock: vi.fn(),
+    streamMock: vi.fn(),
+  }));
 
 vi.mock("~/lib/storage", () => ({
-  getStorage: vi.fn().mockResolvedValue({}),
+  getStorage: vi.fn().mockResolvedValue({ getStore: getMemoryStoreMock }),
 }));
 vi.mock("~/mastra/agents/nepp-chan-agent", () => ({
   createNeppChanAgent: vi.fn(() => ({})),
@@ -37,7 +43,7 @@ vi.mock("@mastra/core/mastra", () => ({
   },
 }));
 
-describe("createVoiceTurnRunner / runTurn", () => {
+describe("createVoiceConversation", () => {
   const env = {
     DB: {},
     RESOURCE_ID_HASH_SECRET: "test-secret",
@@ -45,29 +51,113 @@ describe("createVoiceTurnRunner / runTurn", () => {
 
   beforeEach(() => {
     streamMock.mockReset();
+    getMemoryStoreMock.mockReset();
+    getMemoryStoreMock.mockResolvedValue({
+      saveMessages: saveMessagesMock,
+      saveThread: saveThreadMock,
+    });
+    saveMessagesMock.mockReset();
+    saveThreadMock.mockReset();
   });
 
-  it("toVoiceIds 由来の memory を渡して text-delta を順に yield する", async () => {
+  it("Mastra Memory を使わず、通話内の履歴を明示して text-delta を返す", async () => {
     streamMock.mockResolvedValue({
       fullStream: fakeFullStream([textDelta("こん"), textDelta("にちは")]),
     });
 
-    const runTurn = await createVoiceTurnRunner({
+    const conversation = await createVoiceConversation({
       env,
       from: "client:tester",
+      callSid: "CA123",
     });
     const out: string[] = [];
-    for await (const d of runTurn({ text: "やあ" })) {
+    for await (const d of conversation.runTurn({ text: "やあ" })) {
       out.push(d);
     }
 
     expect(out).toEqual(["こん", "にちは"]);
-    const ids = await toVoiceIds("client:tester", "test-secret");
     expect(streamMock).toHaveBeenCalledWith(
-      "やあ",
-      expect.objectContaining({
-        memory: { resource: ids.resourceId, thread: ids.threadId },
+      [{ role: "user", content: "やあ" }],
+      expect.not.objectContaining({ memory: expect.anything() }),
+    );
+    expect(createNeppChanAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ withMemory: false }),
+    );
+
+    streamMock.mockResolvedValue({
+      fullStream: fakeFullStream([textDelta("元気だよ")]),
+    });
+    for await (const _ of conversation.runTurn({ text: "元気？" })) {
+      // drain
+    }
+    expect(streamMock).toHaveBeenLastCalledWith(
+      [
+        { role: "user", content: "やあ" },
+        { role: "assistant", content: "こんにちは" },
+        { role: "user", content: "元気？" },
+      ],
+      expect.anything(),
+    );
+  });
+
+  it("応答完了後に同じ ID でスレッドと1ターンを upsert する", async () => {
+    const conversation = await createVoiceConversation({
+      env,
+      from: "client:tester",
+      callSid: "CA123",
+    });
+
+    await conversation.persistTurn({
+      turnIndex: 0,
+      userText: "やあ",
+      assistantText: "こんにちは",
+    });
+
+    expect(saveThreadMock).toHaveBeenCalledWith({
+      thread: expect.objectContaining({
+        id: expect.stringMatching(/^voice-thread:/),
+        resourceId: expect.stringMatching(/^voice:/),
       }),
+    });
+    expect(saveMessagesMock).toHaveBeenCalledWith({
+      messages: [
+        expect.objectContaining({
+          id: expect.stringContaining(":turn:0:user"),
+          role: "user",
+        }),
+        expect.objectContaining({
+          id: expect.stringContaining(":turn:0:assistant"),
+          role: "assistant",
+        }),
+      ],
+    });
+    const [userMessage, assistantMessage] =
+      saveMessagesMock.mock.calls[0][0].messages;
+    expect(userMessage.createdAt.getTime()).toBeLessThan(
+      assistantMessage.createdAt.getTime(),
+    );
+  });
+
+  it("D1 保存が一度失敗した場合は同じ ID で一度だけ再試行する", async () => {
+    saveMessagesMock
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({ messages: [] });
+    const conversation = await createVoiceConversation({
+      env,
+      from: "client:tester",
+      callSid: "CA123",
+    });
+
+    await conversation.persistTurn({
+      turnIndex: 0,
+      userText: "やあ",
+      assistantText: "こんにちは",
+    });
+
+    expect(saveThreadMock).toHaveBeenCalledTimes(2);
+    expect(saveMessagesMock).toHaveBeenCalledTimes(2);
+    expect(saveMessagesMock.mock.calls[0]).toEqual(
+      saveMessagesMock.mock.calls[1],
     );
   });
 
@@ -80,7 +170,11 @@ describe("createVoiceTurnRunner / runTurn", () => {
       ]),
     });
 
-    const runTurn = await createVoiceTurnRunner({ env, from: "client:tester" });
+    const { runTurn } = await createVoiceConversation({
+      env,
+      from: "client:tester",
+      callSid: "CA123",
+    });
     const out: string[] = [];
     for await (const d of runTurn({ text: "おはよう" })) {
       out.push(d);
@@ -99,7 +193,11 @@ describe("createVoiceTurnRunner / runTurn", () => {
       ]),
     });
 
-    const runTurn = await createVoiceTurnRunner({ env, from: "client:x" });
+    const { runTurn } = await createVoiceConversation({
+      env,
+      from: "client:x",
+      callSid: "CA123",
+    });
     const out: string[] = [];
     for await (const d of runTurn({ text: "観光スポット教えて" })) {
       out.push(d);
@@ -114,9 +212,10 @@ describe("createVoiceTurnRunner / runTurn", () => {
     });
     const infoSpy = vi.spyOn(logger, "info");
 
-    const runTurn = await createVoiceTurnRunner({
+    const { runTurn } = await createVoiceConversation({
       env,
       from: "client:tester",
+      callSid: "CA123",
     });
     for await (const _ of runTurn({ text: "やあ" })) {
       // drain
@@ -143,7 +242,11 @@ describe("createVoiceTurnRunner / runTurn", () => {
     });
     const controller = new AbortController();
 
-    const runTurn = await createVoiceTurnRunner({ env, from: "client:x" });
+    const { runTurn } = await createVoiceConversation({
+      env,
+      from: "client:x",
+      callSid: "CA123",
+    });
     const out: string[] = [];
     for await (const d of runTurn({ text: "hi", signal: controller.signal })) {
       out.push(d);
@@ -152,7 +255,7 @@ describe("createVoiceTurnRunner / runTurn", () => {
 
     expect(out).toEqual(["a"]);
     expect(streamMock).toHaveBeenCalledWith(
-      "hi",
+      [{ role: "user", content: "hi" }],
       expect.objectContaining({ abortSignal: controller.signal }),
     );
     const { requestContext } = streamMock.mock.calls[0][1];

--- a/server/src/services/voice/conversation.test.ts
+++ b/server/src/services/voice/conversation.test.ts
@@ -117,6 +117,7 @@ describe("createVoiceConversation", () => {
       thread: expect.objectContaining({
         id: expect.stringMatching(/^voice-thread:/),
         resourceId: expect.stringMatching(/^voice:/),
+        title: "音声通話",
       }),
     });
     expect(saveMessagesMock).toHaveBeenCalledWith({
@@ -135,6 +136,32 @@ describe("createVoiceConversation", () => {
       saveMessagesMock.mock.calls[0][0].messages;
     expect(userMessage.createdAt.getTime()).toBeLessThan(
       assistantMessage.createdAt.getTime(),
+    );
+  });
+
+  it("読み上げ可能な応答が空なら、そのターンを履歴へ追加しない", async () => {
+    streamMock.mockResolvedValueOnce({
+      fullStream: fakeFullStream([textDelta("🌸")]),
+    });
+    const conversation = await createVoiceConversation({
+      env,
+      from: "client:tester",
+      callSid: "CA123",
+    });
+    for await (const _ of conversation.runTurn({ text: "最初の質問" })) {
+      // drain
+    }
+
+    streamMock.mockResolvedValueOnce({
+      fullStream: fakeFullStream([textDelta("回答")]),
+    });
+    for await (const _ of conversation.runTurn({ text: "次の質問" })) {
+      // drain
+    }
+
+    expect(streamMock).toHaveBeenLastCalledWith(
+      [{ role: "user", content: "次の質問" }],
+      expect.anything(),
     );
   });
 

--- a/server/src/services/voice/conversation.ts
+++ b/server/src/services/voice/conversation.ts
@@ -24,6 +24,7 @@ type PersistTurnParams = {
 };
 
 const MAX_HISTORY_MESSAGES = 20;
+const VOICE_THREAD_TITLE = "音声通話";
 
 const textContent = (text: string) => ({
   format: 2 as const,
@@ -108,7 +109,7 @@ export const createVoiceConversation = async ({
           yield clean;
         }
       }
-      if (!signal?.aborted) {
+      if (!signal?.aborted && assistantText) {
         const assistantMessage: ModelMessage = {
           role: "assistant",
           content: assistantText,
@@ -136,6 +137,7 @@ export const createVoiceConversation = async ({
     const thread = {
       id: threadId,
       resourceId,
+      title: VOICE_THREAD_TITLE,
       createdAt,
       updatedAt: now,
     };

--- a/server/src/services/voice/conversation.ts
+++ b/server/src/services/voice/conversation.ts
@@ -1,4 +1,5 @@
 import { Mastra } from "@mastra/core/mastra";
+import type { ModelMessage } from "ai";
 import { voiceModelConfig } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
 import { toVoiceIds } from "~/lib/principal";
@@ -16,28 +17,46 @@ type RunTurnParams = {
   findingsSlot?: VoiceFindingsSlot;
 };
 
-// 通話（DO インスタンス）ごとに1回だけ生成する。agent/Mastra 構築と
-// toVoiceIds の HMAC はターンごとに変わらないため、通話中は使い回す。
-export const createVoiceTurnRunner = async ({
+type PersistTurnParams = {
+  turnIndex: number;
+  userText: string;
+  assistantText: string;
+};
+
+const MAX_HISTORY_MESSAGES = 20;
+
+const textContent = (text: string) => ({
+  format: 2 as const,
+  parts: [{ type: "text" as const, text }],
+});
+
+// 通話（DO インスタンス）ごとに1回だけ生成し、会話履歴をメモリ上で保持する。
+// D1 は応答完了後の persistTurn でのみ触る。
+export const createVoiceConversation = async ({
   env,
   from,
+  callSid,
 }: {
   env: CloudflareBindings;
   from: string;
+  callSid: string;
 }) => {
   const { resourceId, threadId } = await toVoiceIds(
     from,
+    callSid,
     env.RESOURCE_ID_HASH_SECRET,
   );
-  const storage = await getStorage(env.DB);
+  const createdAt = new Date();
+  let history: ModelMessage[] = [];
   const neppChanAgent = createNeppChanAgent({
     platform: "voice",
     modelConfig: voiceModelConfig,
+    withMemory: false,
   });
-  const mastra = new Mastra({ agents: { neppChanAgent }, storage });
+  const mastra = new Mastra({ agents: { neppChanAgent } });
   const agent = mastra.getAgent("neppChanAgent");
 
-  return async function* runTurn({
+  const runTurn = async function* ({
     text,
     signal,
     onToolCall,
@@ -46,7 +65,6 @@ export const createVoiceTurnRunner = async ({
   }: RunTurnParams) {
     const start = Date.now();
     const requestContext = createRequestContext({
-      storage,
       db: env.DB,
       env,
       voiceFindings: findingsSlot,
@@ -54,15 +72,16 @@ export const createVoiceTurnRunner = async ({
       voiceTurnSignal: signal,
       voiceEndCall: onEndCall,
     });
+    const input: ModelMessage[] = [...history, { role: "user", content: text }];
 
-    const result = await agent.stream(text, {
+    const result = await agent.stream(input, {
       requestContext,
-      memory: { resource: resourceId, thread: threadId },
       abortSignal: signal,
     });
     const streamReadyMs = Date.now() - start;
 
     let firstTokenMs: number | null = null;
+    let assistantText = "";
     try {
       for await (const chunk of result.fullStream) {
         if (signal?.aborted) return;
@@ -84,7 +103,17 @@ export const createVoiceTurnRunner = async ({
         if (chunk.type !== "text-delta") continue;
         if (firstTokenMs === null) firstTokenMs = Date.now() - start;
         const clean = sanitizeForSpeech(chunk.payload.text);
-        if (clean) yield clean;
+        if (clean) {
+          assistantText += clean;
+          yield clean;
+        }
+      }
+      if (!signal?.aborted) {
+        const assistantMessage: ModelMessage = {
+          role: "assistant",
+          content: assistantText,
+        };
+        history = [...input, assistantMessage].slice(-MAX_HISTORY_MESSAGES);
       }
     } finally {
       const timing: Record<string, number> = { streamReadyMs };
@@ -92,4 +121,57 @@ export const createVoiceTurnRunner = async ({
       logger.info("[Voice] llm timing", timing);
     }
   };
+
+  const persistTurn = async ({
+    turnIndex,
+    userText,
+    assistantText,
+  }: PersistTurnParams) => {
+    const storage = await getStorage(env.DB);
+    const memoryStore = await storage.getStore("memory");
+    if (!memoryStore) throw new Error("Memory storage is unavailable");
+
+    const now = new Date();
+    const assistantCreatedAt = new Date(now.getTime() + 1);
+    const thread = {
+      id: threadId,
+      resourceId,
+      createdAt,
+      updatedAt: now,
+    };
+    const messages = [
+      {
+        id: `${threadId}:turn:${turnIndex}:user`,
+        role: "user" as const,
+        createdAt: now,
+        threadId,
+        resourceId,
+        content: textContent(userText),
+      },
+      {
+        id: `${threadId}:turn:${turnIndex}:assistant`,
+        role: "assistant" as const,
+        createdAt: assistantCreatedAt,
+        threadId,
+        resourceId,
+        content: textContent(assistantText),
+      },
+    ];
+    const save = async () => {
+      await memoryStore.saveThread({ thread });
+      await memoryStore.saveMessages({ messages });
+    };
+
+    try {
+      await save();
+    } catch (error) {
+      logger.warn("[Voice] retrying turn persistence", {
+        error: error instanceof Error ? error.message : String(error),
+        turnIndex,
+      });
+      await save();
+    }
+  };
+
+  return { runTurn, persistTurn };
 };


### PR DESCRIPTION
## Summary
- 通話中の会話履歴をDurable Objectのメモリで保持
- 電話番号単位のresourceIdと通話単位のthreadIdに分離
- 音声応答の送信後にD1へ会話ターンを直接保存

## 主な変更内容
Mastra Memoryによる応答前のD1初期化・履歴取得を廃止し、直近20メッセージをモデルへ明示的に渡します。保存はTwilioへの完了トークン送信後にawaitし、決定的IDによるupsertと1回の再試行を行います。WebSocketメッセージ処理はctx.waitUntil()で保護します。

D1スレッドには必須titleを設定し、読み上げ可能な応答が空のターンは通話内履歴へ追加しません。また、完了トークン送信後はD1保存を待ちながらactive turnを解除し、次の発話への相槌を妨げないようにします。

## Working Memoryについて
音声通話では、応答前のD1アクセスをなくして速度を比較するため、MastraのWorking Memoryを無効化しています。

そのため、同じ通話内の会話履歴は維持されますが、電話番号に紐づく名前・好みなどを通話間で読み書きする機能は現在動作しません。会話ログ自体はD1へ保存され、事後のペルソナ抽出は引き続き可能です。

速度改善との比較結果によっては、Working Memoryの再有効化、または初回応答を妨げない先読み方式を別途検討します。

## Test plan
- [x] serverテスト 1225件
- [x] TypeScript型チェック
- [x] Biomeチェック
- [x] git diff --check
