### PR TITLE
ダッシュボードの週次レポート表示順と今週の話題の集計を調整

### DIFF
--- a/web/src/app/dashboard/components/AnalyticsPanel.test.tsx
+++ b/web/src/app/dashboard/components/AnalyticsPanel.test.tsx
@@ -248,10 +248,10 @@ describe("AnalyticsPanel", () => {
     expect(askButtons).toHaveLength(3);
 
     await user.click(askButtons[0]);
-    expect(onAskMayor).toHaveBeenCalledWith("今週の週次レポート");
+    expect(onAskMayor).toHaveBeenCalledWith("直近30日の会話データ");
 
     await user.click(askButtons[2]);
-    expect(onAskMayor).toHaveBeenCalledWith("全期間の全体分析");
+    expect(onAskMayor).toHaveBeenCalledWith("今週の週次レポート");
   });
 
   it("週次レポートを選択すると詳細（ハイライト全文）を表示する", async () => {

--- a/web/src/app/dashboard/components/AnalyticsPanel.tsx
+++ b/web/src/app/dashboard/components/AnalyticsPanel.tsx
@@ -49,14 +49,6 @@ export const AnalyticsPanel = ({ onAskMayor, initialSection }: Props) => {
 
   return (
     <div className="space-y-6">
-      <TimeAxisHeading
-        title="今週のできごと"
-        description="週ごとのまとめ・毎週火曜に自動生成"
-        askContext="今週の週次レポート"
-        onAskMayor={onAskMayor}
-      />
-      <ReportsSection />
-
       <div id="analytics-conversation" className="space-y-6">
         <TimeAxisHeading
           title="最近の動き"
@@ -77,6 +69,14 @@ export const AnalyticsPanel = ({ onAskMayor, initialSection }: Props) => {
         <PersonaSection />
         <OntologySection />
       </div>
+
+      <TimeAxisHeading
+        title="今週のできごと"
+        description="週ごとのまとめ・毎週火曜に自動生成"
+        askContext="今週の週次レポート"
+        onAskMayor={onAskMayor}
+      />
+      <ReportsSection />
     </div>
   );
 };

--- a/web/src/app/dashboard/components/HomePanel.test.tsx
+++ b/web/src/app/dashboard/components/HomePanel.test.tsx
@@ -91,7 +91,7 @@ const useDefaultHandlers = () => {
       const params = new URL(request.url).searchParams;
       return HttpResponse.json({
         topics:
-          params.get("sentiments") === "positive"
+          params.get("sentiments") === "positive,neutral"
             ? positiveTopics
             : troubleTopics,
       });

--- a/web/src/app/dashboard/hooks/useHomeSummary.test.ts
+++ b/web/src/app/dashboard/hooks/useHomeSummary.test.ts
@@ -107,7 +107,7 @@ const useHandlers = ({
       topicCalls.push(params);
       return HttpResponse.json({
         topics:
-          params.get("sentiments") === "positive"
+          params.get("sentiments") === "positive,neutral"
             ? positiveTopics
             : troubleTopics,
       });
@@ -151,9 +151,9 @@ describe("useHomeSummary", () => {
 
     await waitFor(() => expect(topicCalls.length).toBeGreaterThanOrEqual(2));
     expect(topicCalls.every((c) => c.get("from") === "2026-07-28")).toBe(true);
-    expect(topicCalls.some((c) => c.get("sentiments") === "positive")).toBe(
-      true,
-    );
+    expect(
+      topicCalls.some((c) => c.get("sentiments") === "positive,neutral"),
+    ).toBe(true);
     expect(
       topicCalls.some((c) => c.get("sentiments") === "negative,request"),
     ).toBe(true);

--- a/web/src/app/dashboard/hooks/useHomeSummary.ts
+++ b/web/src/app/dashboard/hooks/useHomeSummary.ts
@@ -16,7 +16,7 @@ const PERIOD_DAYS = 7;
 const LIST_LIMIT = 5;
 const TOP_LIMIT = 4;
 const SPEAKER_LIMIT = 2;
-const POSITIVE_SENTS = ["positive"] as const;
+const TOPIC_SENTS = ["positive", "neutral"] as const;
 const TROUBLE_SENTS = ["negative", "request"] as const;
 
 type TopicAggregation = {
@@ -52,7 +52,7 @@ export const useHomeSummary = () => {
 
   const positiveTopics = usePersonaTopics({
     ...period,
-    sentiments: [...POSITIVE_SENTS],
+    sentiments: [...TOPIC_SENTS],
   });
   const troubleTopics = usePersonaTopics({
     ...period,


### PR DESCRIPTION
## Summary
- 「村の分析」の週次レポートセクションを時系列の最後（今週→直近→全期間 の逆）から、直近→全期間→週次レポートの順に並び替え
- ホームの「今週の話題」カードの集計対象に neutral センチメントを追加し、positive のみだった対象を拡大

## 主な変更内容
- `AnalyticsPanel.tsx`: 週次レポートのセクションを一番下に移動
- `useHomeSummary.ts`: 話題集計の sentiments フィルタを `["positive"]` から `["positive", "neutral"]` に変更（定数名も `POSITIVE_SENTS` → `TOPIC_SENTS` に変更）
- 上記に伴うテストの並び順・sentiments 期待値を更新

## Test plan
- [x] `pnpm test`（web、663件）が通ること
- [x] `pnpm lint`（Biome + astro check + tsc）が通ること