### PR TITLE
fix(server): Gemini の thinking 無効化指定を minimal に変更

### DIFF
--- a/server/src/lib/llm-models.test.ts
+++ b/server/src/lib/llm-models.test.ts
@@ -59,7 +59,7 @@ describe("resolveModelTier", () => {
   });
 
   describe("LINE プラットフォーム（非 Admin）", () => {
-    it("casual → プライマリ FLASH_LITE + thinking 無効 (thinkingBudget: 0)", () => {
+    it("casual → プライマリ FLASH_LITE + minimal", () => {
       const tier = resolveModelTier({
         intent: "casual",
         platform: "line",
@@ -67,7 +67,7 @@ describe("resolveModelTier", () => {
       });
       expect(tier.model[0].model).toBe(GEMINI_FLASH_LITE);
       expect(tier.model[0].providerOptions.google.thinkingConfig).toEqual({
-        thinkingBudget: 0,
+        thinkingLevel: "minimal",
       });
     });
 

--- a/server/src/lib/llm-models.ts
+++ b/server/src/lib/llm-models.ts
@@ -16,12 +16,9 @@ export const OPENAI_SCORER = "openai/gpt-4.1-nano";
 // 埋め込みモデル
 export const GEMINI_EMBEDDING = "gemini-embedding-001";
 
-type ThinkingLevel = "high" | "medium" | "low" | "none";
+// Gemini 3 系では thinking を完全に無効化できず、thinkingBudget: 0 は 400 になる。最小は minimal。
+type ThinkingLevel = "high" | "medium" | "low" | "minimal";
 
-/**
- * Gemini モデルと thinkingConfig を含む Agent 設定を返す。
- * "none" は AI SDK の thinkingLevel enum に存在しないため thinkingBudget: 0 で無効化する。
- */
 export const geminiModelWithThinking = ({
   model = GEMINI_FLASH_LITE,
   level = "low" as ThinkingLevel,
@@ -29,8 +26,7 @@ export const geminiModelWithThinking = ({
   model,
   providerOptions: {
     google: {
-      thinkingConfig:
-        level === "none" ? { thinkingBudget: 0 } : { thinkingLevel: level },
+      thinkingConfig: { thinkingLevel: level },
     },
   },
 });
@@ -86,7 +82,7 @@ const MODEL_TIERS: Record<Intent, Record<"web" | "line", AgentModelConfig>> = {
       model: geminiModelChain({
         primary: GEMINI_FLASH_LITE,
         fallback: GEMINI_FLASH,
-        level: "none",
+        level: "minimal",
       }),
       defaultOptions: { maxSteps: MAX_STEPS.casual },
     },

--- a/server/src/mastra/agents/intent-router-agent.ts
+++ b/server/src/mastra/agents/intent-router-agent.ts
@@ -5,7 +5,7 @@ const routerModelConfig = {
   model: GEMINI_FLASH_LITE,
   providerOptions: {
     google: {
-      thinkingConfig: { thinkingLevel: "none" as const },
+      thinkingConfig: { thinkingLevel: "minimal" as const },
     },
   },
   defaultOptions: { modelSettings: { temperature: 0 } },

--- a/server/src/mastra/agents/voice-summarizer-agent.ts
+++ b/server/src/mastra/agents/voice-summarizer-agent.ts
@@ -8,7 +8,7 @@ const summarizerModelConfig = {
   model: GEMINI_FLASH_LITE,
   providerOptions: {
     google: {
-      thinkingConfig: { thinkingBudget: 0 },
+      thinkingConfig: { thinkingLevel: "minimal" as const },
     },
   },
   defaultOptions: { modelSettings: { temperature: 0 } },


### PR DESCRIPTION
## 背景

本番の LINE 返信が `AI_APICallError: Request contains an invalid argument.` で失敗していた。

```
"message": "LINE reply failed"
"Error executing model gemini-flash-lite-latest"
```

## 原因

`gemini-flash-lite-latest` / `gemini-flash-latest` のエイリアス先が Gemini 3 系に更新され、thinking を無効化する指定が受け付けられなくなった。実 API で再現を確認した。

| thinkingConfig | gemini-flash-lite-latest |
| -------------- | ------------------------ |
| `{ thinkingBudget: 0 }` | 400 INVALID_ARGUMENT |
| `{ thinkingLevel: "none" }` | 400 INVALID_ARGUMENT |
| `{ thinkingLevel: "minimal" }` | 200 |
| `{ thinkingLevel: "low" }` | 200 |

バージョン固定の `gemini-2.5-flash-lite` では `thinkingBudget: 0` が今も 200 を返すため、切り替わったのは latest エイリアス。

影響範囲は無効化指定を使っていた 3 箇所。

- `llm-models.ts` の LINE casual ティア（`level: "none"` → `thinkingBudget: 0`）。フォールバックの `gemini-flash-latest` も同じ設定を引き継ぐため、リトライ含めて全滅していた
- `intent-router-agent`（`thinkingLevel: "none"`）。`generateReply` の冒頭で呼ばれるため LINE の全メッセージが影響を受ける
- `voice-summarizer-agent`（`thinkingBudget: 0`）

## 変更

Gemini 3 系は thinking を完全に無効化できないため、最小の `minimal` に切り替える。`ThinkingLevel` から `"none"` を削除し、`thinkingBudget` 分岐も不要になったので削除した。

## 検証

- `pnpm lint` グリーン
- `server` テスト 1249 件グリーン
- 実 API で `thinkingLevel: "minimal"` が `gemini-flash-lite-latest`・`gemini-flash-latest` 両方で 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sQbV1DbV4TkwrTVbPFhjz