### PR TITLE
fix(widget): intent 固定をやめてサーバーの intent 分類に委ねる

### DIFF
--- a/widget/src/WidgetChat.test.tsx
+++ b/widget/src/WidgetChat.test.tsx
@@ -228,6 +228,28 @@ describe("WidgetChat", () => {
     });
   });
 
+  it("intent を送らずサーバーの分類に委ねる", async () => {
+    let body: unknown;
+    server.use(
+      http.post(CHAT_URL, async ({ request }) => {
+        body = await request.json();
+        return buildChatStreamResponse("答えだよ");
+      }),
+    );
+    renderWidgetChat();
+    await waitForReady();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "音威子府駅ってどんなところ？" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("答えだよ")).toBeTruthy();
+    });
+
+    expect(body).not.toHaveProperty("intent");
+  });
+
   it("通信エラー時はエラーバブルを表示する", async () => {
     server.use(
       http.post(CHAT_URL, () => new HttpResponse("boom", { status: 500 })),

--- a/widget/src/WidgetChat.tsx
+++ b/widget/src/WidgetChat.tsx
@@ -72,7 +72,6 @@ export const WidgetChat = ({
           return {
             body: {
               message: messages[messages.length - 1],
-              intent: "casual",
             },
           };
         },


### PR DESCRIPTION
## 事象

widget のねっぷちゃんが、村の情報を尋ねても「調べてみるね〜✨」で止まって回答が返らないことがある。

## 原因

widget だけ `intent: "casual"` を固定送信していた。casual ティアは `gemini-flash-lite-latest` / thinkingLevel `low` で、`baseInstructions` の「ステップ0: 必ずテキストを先に出力する」に従ったあと、ステップ2の knowledgeAgent 委譲に進まずターンを終えてしまう。

サーバー側の SSE を dev 環境で直接確認したところ、`tool-input-start` も `data-tool-agent` も出ないまま `finish` していた。フロントの受信機構（`useChat` + `DefaultChatTransport`）は正常で、届いたものを描画しているだけだった。

## 検証（dev 環境・すべて widget の resourceId）

| 送信 intent | モデルティア | 結果 |
| --- | --- | --- |
| `casual`（修正前） | flash-lite / low | 8 回中 5 回でツール呼び出しゼロ・リアクション文だけで終了 |
| `thinking` | flash / high | 4 回中 4 回で委譲・完走 |
| 未指定（`classifyIntent`） | 同上（thinking に分類） | 委譲・完走 |

widget のツール制限（`widgetAgents` / `widgetTools`）は無関係で、intent を変えるだけで挙動が変わる。

## 変更

- `WidgetChat.tsx` — 送信ボディから `intent` を削除し、web / LINE と同じくサーバーの `classifyIntent` に委ねる
- `WidgetChat.test.tsx` — intent を送らないことを検証するテストを追加

LINE は元から `classifyIntent` を通しており、casual に落ちるのは雑談と非テキストメッセージだけなのでこの問題を踏まない。LP の `MiniChat` は API を呼ばない定型 Q&A なので対象外。

## トレードオフ

事実質問で初回トークンまでの遅延が伸びる。分類の LLM 呼び出しが 1 回増え、本体も flash-lite から flash + thinkingLevel high に上がるため。casual 固定はおそらくこの遅延を避けるためのものだったが、回答が返らない方が損失は大きいと判断した。

## 確認

- `pnpm --filter @nepp-chan/widget test` — 49 tests 全パス
- `pnpm lint`（Biome + astro check + tsc、249 files） — 0 errors / 0 warnings
- 実モデルでの最終確認は develop マージ後の dev 環境で行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxqgnVdJBan2i2WVesyrQo