### PR TITLE
feat(widget): 埋め込み元ページを GA で追えるようにする

### DIFF
--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -98,3 +98,4 @@ jobs:
           PUBLIC_GA_MEASUREMENT_ID: G-FMW4FP326K
           VITE_API_URL: https://api.nepp-chan.ai
           VITE_WEB_URL: https://web.nepp-chan.ai
+          VITE_GA_MEASUREMENT_ID: G-FMW4FP326K

--- a/widget/CLAUDE.md
+++ b/widget/CLAUDE.md
@@ -11,6 +11,7 @@
 - 匿名セッションのトークン/resourceId は localStorage（`nepp-chan-widget:session-token` / `nepp-chan-widget:resource-id`）に保存し、同じブラウザでの再訪問時は再利用する（90日有効）。
 - iframe は lp と同一 origin（`nepp-chan.ai/widget/`）配信。fetch の Origin は配信元になるため、ローダーを貼る host サイトのオリジンは API の CORS 許可リストに無関係。
 - iframe → loader の「閉じる」連携は `postMessage`。loader 側で `event.origin`（iframeSrc のオリジン）と `event.source`（iframe の contentWindow）を検証してから閉じる。
+- loader は iframe の src に `?host=<埋め込み元の origin + pathname>` を付ける。iframe は自ドメイン配信で `Referer` が使えないため、どのページに置かれた widget かはこのクエリでしか分からない。GA の `page_location` にそのまま乗るので、ページ別の利用状況はレポート上で切れる。host 側の URL に個人情報が乗りうるのでクエリ文字列とハッシュは落とす。値は自己申告なので認可には使えない。
 - ボタン設置 2500ms 後、`INITIAL_MESSAGE` の挨拶文を吹き出しティーザーとして表示する。localStorage（`nepp-chan-widget:teaser-dismissed-at`）に閉じた時刻を記録し、7 日以内は再表示しない。
 
 ## host への導入
@@ -24,6 +25,8 @@ host 側で CSP を設定している場合は `nepp-chan.ai` を `script-src` �
 ## 配信
 
 lp の Pages に同居配信する。`lp build` が widget をビルドして `lp/public/widget/` に出力し、Astro が `dist/widget/` へ配置する（専用サブドメインは設けない）。API URL / Web URL はビルド時に `VITE_API_URL` / `VITE_WEB_URL` で注入する（deploy ワークフローの LP ジョブで設定）。
+
+GA は `VITE_GA_MEASUREMENT_ID` を渡した本番ビルドでのみ有効（lp と同じ測定 ID）。host サイトから見るとサードパーティ Cookie になるため、ブロック環境では計測が漏れる。
 
 | 環境 | ローダー URL |
 | ---- | ------------ |

--- a/widget/env.d.ts
+++ b/widget/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_WEB_URL: string;
+  readonly VITE_GA_MEASUREMENT_ID?: string;
 }
 
 interface ImportMeta {

--- a/widget/src/analytics.test.ts
+++ b/widget/src/analytics.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initAnalytics } from "./analytics";
+
+const gtagScript = () =>
+  document.head.querySelector('script[src*="googletagmanager.com"]');
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const el of document.head.querySelectorAll("script")) el.remove();
+});
+
+describe("initAnalytics", () => {
+  it("本番かつ測定 ID があれば gtag を読み込む", () => {
+    vi.stubEnv("PROD", true);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST");
+
+    initAnalytics();
+
+    expect(gtagScript()?.getAttribute("src")).toContain("id=G-TEST");
+  });
+
+  it("測定 ID が無ければ読み込まない", () => {
+    vi.stubEnv("PROD", true);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "");
+
+    initAnalytics();
+
+    expect(gtagScript()).toBeNull();
+  });
+
+  it("開発中は読み込まない", () => {
+    vi.stubEnv("PROD", false);
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST");
+
+    initAnalytics();
+
+    expect(gtagScript()).toBeNull();
+  });
+});

--- a/widget/src/analytics.ts
+++ b/widget/src/analytics.ts
@@ -1,0 +1,23 @@
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+  }
+}
+
+export const initAnalytics = () => {
+  const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID;
+  if (!import.meta.env.PROD || !measurementId) return;
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer ?? [];
+  // gtag.js は配列ではなく arguments オブジェクトを積まれる前提で実装されている
+  function gtag(..._args: unknown[]) {
+    window.dataLayer?.push(arguments);
+  }
+  gtag("js", new Date());
+  gtag("config", measurementId);
+};

--- a/widget/src/iframe-entry.tsx
+++ b/widget/src/iframe-entry.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { initAnalytics } from "./analytics";
 import "./iframe.css";
 import { WidgetChat } from "./WidgetChat";
+
+initAnalytics();
 
 const root = document.getElementById("root");
 if (!root) throw new Error("#root が見つかりません");

--- a/widget/src/loader.test.ts
+++ b/widget/src/loader.test.ts
@@ -99,7 +99,32 @@ describe("mountWidget", () => {
     document.body.querySelector("button")?.click();
     const iframe = document.body.querySelector("iframe");
     expect(iframe).not.toBeNull();
-    expect(iframe?.getAttribute("src")).toBe(IFRAME_SRC);
+    expect(iframe?.getAttribute("src")).toContain(IFRAME_SRC);
+  });
+
+  it("iframe の src に埋め込み元ページを host として渡す", () => {
+    mount();
+    document.body.querySelector("button")?.click();
+    const src = document.body.querySelector("iframe")?.getAttribute("src");
+
+    expect(new URL(src as string).searchParams.get("host")).toBe(
+      `${location.origin}${location.pathname}`,
+    );
+  });
+
+  it("host にクエリ文字列やハッシュを含めない", () => {
+    const original = window.location.href;
+    window.history.replaceState({}, "", "/iju?utm_source=mail&name=taro#top");
+
+    mount();
+    document.body.querySelector("button")?.click();
+    const src = document.body.querySelector("iframe")?.getAttribute("src");
+
+    expect(new URL(src as string).searchParams.get("host")).toBe(
+      `${location.origin}/iju`,
+    );
+
+    window.history.replaceState({}, "", original);
   });
 
   it("初回クリック直後は閉じた状態のスタイルで挿入する", () => {

--- a/widget/src/loader.ts
+++ b/widget/src/loader.ts
@@ -30,6 +30,13 @@ type MountOptions = {
   doc?: Document;
 };
 
+// クエリ文字列とハッシュには host 側の個人情報が乗りうるので origin + pathname までに絞る
+const buildIframeSrc = (iframeSrc: string) => {
+  const url = new URL(iframeSrc);
+  url.searchParams.set("host", `${location.origin}${location.pathname}`);
+  return url.toString();
+};
+
 const applyPanelState = (iframe: HTMLIFrameElement, open: boolean) => {
   iframe.style.visibility = open ? "visible" : "hidden";
   iframe.style.opacity = open ? "1" : "0";
@@ -138,7 +145,7 @@ export const mountWidget = ({
 
     if (!iframe) {
       iframe = doc.createElement("iframe");
-      iframe.src = iframeSrc;
+      iframe.src = buildIframeSrc(iframeSrc);
       iframe.title = "ねっぷちゃん";
       iframe.style.cssText = `
         position: fixed;


### PR DESCRIPTION
## 背景

widget がどのページに置かれた状態で使われたかを知る手段がなかった。iframe は `nepp-chan.ai` 配信なので、サーバー側で `Origin` / `Referer` を見ても常に自分のドメインになる。host の情報は loader（host の DOM 上で動く vanilla JS）から明示的に運ぶしかない。

## 変更

- **`loader.ts`**: iframe の src に `?host=<origin + pathname>` を付ける
- **`analytics.ts`（新規）**: gtag を初期化。本番ビルドかつ `VITE_GA_MEASUREMENT_ID` があるときだけ動く（lp の `GoogleAnalytics.astro` と同じ条件）
- **`deploy-prd.yml`**: LP ジョブに `VITE_GA_MEASUREMENT_ID`（lp と同じ測定 ID）。dev は lp 同様 GA なし

集計コードは持たない。クエリ付き URL がそのまま GA の `page_location` になるので、「ページとスクリーン」レポートに

```
/widget/index.html?host=https%3A%2F%2Fotoineppu.jp%2Fiju
/widget/index.html?host=https%3A%2F%2Fotoineppu.jp%2F
```

のように並ぶ。

## 設計判断

**クエリ文字列とハッシュは落とす。** host 側の URL に個人情報が乗っている可能性があるため、`origin + pathname` までに絞る。

**値は自己申告。** iframe の URL は誰でも直接開けるので任意の host を名乗れる。分析用途に限り、認可の根拠には使えない。将来サイトごとの出し分けが必要になったら埋め込みキーの発行に切り替える。

**サードパーティ Cookie の制約。** host サイトから見ると iframe 内の GA はサードパーティ扱いになり、ブロック環境では計測が漏れる。取りこぼしのない数字が必要なら `thread.metadata` へのサーバー側記録に切り替える必要がある。傾向把握が目的なので今回は GA で足りると判断した。

## 確認

- widget 54 tests パス（loader の host 付与 2 ケース、GA 初期化 3 ケースを追加）
- `pnpm lint` exit 0
- ローカルは `PROD` でないため GA は起動しない。host クエリの付与はユニットテストで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxqgnVdJBan2i2WVesyrQo