### PR TITLE
ウィジェットに設置サイトの文脈を持たせる

### DIFF
--- a/server/src/__tests__/helpers/test-db.ts
+++ b/server/src/__tests__/helpers/test-db.ts
@@ -177,6 +177,15 @@ export const createTestDb = async () => {
       created_at TEXT NOT NULL
     );
 
+    -- ウィジェット設置サイト allowlist
+    CREATE TABLE IF NOT EXISTS widget_sites (
+      id TEXT PRIMARY KEY,
+      host TEXT NOT NULL UNIQUE,
+      instructions TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT
+    );
+
     -- Mastra 管理テーブル（read-only スキーマ。テストのフィクスチャ生成用に最低限のカラムを定義）
     CREATE TABLE IF NOT EXISTS mastra_threads (
       id TEXT PRIMARY KEY,

--- a/server/src/__tests__/helpers/test-db.ts
+++ b/server/src/__tests__/helpers/test-db.ts
@@ -177,7 +177,6 @@ export const createTestDb = async () => {
       created_at TEXT NOT NULL
     );
 
-    -- ウィジェット設置サイト allowlist
     CREATE TABLE IF NOT EXISTS widget_sites (
       id TEXT PRIMARY KEY,
       host TEXT NOT NULL UNIQUE,

--- a/server/src/db/migrations/0024_widget_sites.sql
+++ b/server/src/db/migrations/0024_widget_sites.sql
@@ -1,4 +1,3 @@
--- 埋め込みウィジェットの設置サイト allowlist
 CREATE TABLE IF NOT EXISTS widget_sites (
   id TEXT PRIMARY KEY,
   host TEXT NOT NULL UNIQUE,

--- a/server/src/db/migrations/0024_widget_sites.sql
+++ b/server/src/db/migrations/0024_widget_sites.sql
@@ -1,0 +1,17 @@
+-- 埋め込みウィジェットの設置サイト allowlist
+CREATE TABLE IF NOT EXISTS widget_sites (
+  id TEXT PRIMARY KEY,
+  host TEXT NOT NULL UNIQUE,
+  instructions TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT
+);
+
+INSERT OR IGNORE INTO widget_sites (id, host, instructions, created_at) VALUES (
+  '018f2c1a-0000-7000-8000-000000000001',
+  'vill.otoineppu.hokkaido.jp',
+  'ユーザーは音威子府村の公式ホームページ（https://www.vill.otoineppu.hokkaido.jp）を見ながら話しかけている。
+- 行政手続き・窓口案内の質問を優先して受け止める（担当窓口・受付時間・必要な持ち物など）
+- 答えるときは該当する公式ホームページのページ URL を添える',
+  '2026-08-12T00:00:00.000Z'
+);

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -232,3 +232,16 @@ export const dataRetentionLogs = sqliteTable("data_retention_logs", {
 
 export type DataRetentionLog = typeof dataRetentionLogs.$inferSelect;
 export type NewDataRetentionLog = typeof dataRetentionLogs.$inferInsert;
+
+// 埋め込みウィジェットの設置サイト allowlist
+export const widgetSites = sqliteTable("widget_sites", {
+  id: text("id").primaryKey(),
+  // 保存も照合も normalizeSiteHost を通した形に揃える
+  host: text("host").notNull().unique(),
+  instructions: text("instructions").notNull(),
+  createdAt: text("created_at").notNull(),
+  updatedAt: text("updated_at"),
+});
+
+export type WidgetSite = typeof widgetSites.$inferSelect;
+export type NewWidgetSite = typeof widgetSites.$inferInsert;

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -233,10 +233,8 @@ export const dataRetentionLogs = sqliteTable("data_retention_logs", {
 export type DataRetentionLog = typeof dataRetentionLogs.$inferSelect;
 export type NewDataRetentionLog = typeof dataRetentionLogs.$inferInsert;
 
-// 埋め込みウィジェットの設置サイト allowlist
 export const widgetSites = sqliteTable("widget_sites", {
   id: text("id").primaryKey(),
-  // 保存も照合も normalizeSiteHost を通した形に揃える
   host: text("host").notNull().unique(),
   instructions: text("instructions").notNull(),
   createdAt: text("created_at").notNull(),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,6 +29,7 @@ import {
   threadsRoutes,
   twilioVoiceRoutes,
   userAdminRoutes,
+  widgetSiteAdminRoutes,
 } from "~/routes";
 import type { LineEventMessage } from "~/schemas/line-schema";
 import { CallBridge, handleRelayUpgrade } from "~/services/voice/call-bridge";
@@ -54,6 +55,7 @@ app.route("/admin/emergency", emergencyAdminRoutes);
 app.route("/admin/invitations", invitationRoutes);
 app.route("/admin/users", userAdminRoutes);
 app.route("/admin/polls", pollAdminRoutes);
+app.route("/admin/widget-sites", widgetSiteAdminRoutes);
 app.route("/polls", pollRoutes);
 app.route("/auth", authRoutes);
 app.route("/line", lineRoutes);

--- a/server/src/lib/widget-site.test.ts
+++ b/server/src/lib/widget-site.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSiteHost } from "./widget-site";
+
+describe("normalizeSiteHost", () => {
+  it("www. を落とす", () => {
+    expect(normalizeSiteHost("www.vill.otoineppu.hokkaido.jp")).toBe(
+      "vill.otoineppu.hokkaido.jp",
+    );
+  });
+
+  it("大文字と前後の空白を吸収する", () => {
+    expect(normalizeSiteHost("  WWW.Vill.Otoineppu.Hokkaido.JP ")).toBe(
+      "vill.otoineppu.hokkaido.jp",
+    );
+  });
+
+  it("先頭以外の www. は落とさない", () => {
+    expect(normalizeSiteHost("example.www.jp")).toBe("example.www.jp");
+  });
+});

--- a/server/src/lib/widget-site.ts
+++ b/server/src/lib/widget-site.ts
@@ -1,0 +1,6 @@
+// 保存も照合もこの形に揃える（widget から来る host は表記ゆれがあり、完全一致で引くため）
+export const normalizeSiteHost = (host: string) =>
+  host
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, "");

--- a/server/src/lib/widget-site.ts
+++ b/server/src/lib/widget-site.ts
@@ -1,4 +1,3 @@
-// 保存も照合もこの形に揃える（widget から来る host は表記ゆれがあり、完全一致で引くため）
 export const normalizeSiteHost = (host: string) =>
   host
     .trim()

--- a/server/src/mastra/agents/nepp-chan-agent.test.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.test.ts
@@ -48,6 +48,22 @@ describe("createNeppChanAgent", () => {
       expect(ins).not.toContain("管理者機能");
     });
 
+    it("siteInstructions を設置サイトの文脈として見出しごと差し込む", async () => {
+      const ins = await instructionsOf(
+        build({
+          platform: "widget",
+          siteInstructions: "行政手続きの案内を優先する",
+        }),
+      );
+      expect(ins).toContain("## 設置サイトの文脈");
+      expect(ins).toContain("行政手続きの案内を優先する");
+    });
+
+    it("siteInstructions なしの widget では設置サイトの指示を含まない", async () => {
+      const ins = await instructionsOf(build({ platform: "widget" }));
+      expect(ins).not.toContain("設置サイトの文脈");
+    });
+
     it("常に現在の日時セクションを含む", async () => {
       const ins = await instructionsOf(build());
       expect(ins).toContain("現在の日時");

--- a/server/src/mastra/agents/nepp-chan-agent.ts
+++ b/server/src/mastra/agents/nepp-chan-agent.ts
@@ -307,6 +307,7 @@ export const neppChanMemoryOptions = {
 type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
   isAdmin?: boolean;
   platform?: Platform;
+  siteInstructions?: string;
   modelConfig: AgentModelConfig;
   withMemory?: boolean;
 };
@@ -314,6 +315,7 @@ type Props = Omit<AgentConfig, "id" | "name" | "instructions" | "model"> & {
 export const createNeppChanAgent = ({
   isAdmin = false,
   platform = "web",
+  siteInstructions,
   modelConfig,
   withMemory = true,
   ...agentOptions
@@ -333,6 +335,7 @@ export const createNeppChanAgent = ({
       baseInstructions(platform),
       platform === "line" ? lineInstructions : "",
       platform === "voice" ? voiceInstructions : "",
+      siteInstructions ? `## 設置サイトの文脈\n${siteInstructions}` : "",
       `## 現在の日時\n${getCurrentDateInfo()}`,
       isAdmin ? adminInstructions : "",
     ]

--- a/server/src/repository/widget-site-repository.test.ts
+++ b/server/src/repository/widget-site-repository.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return { ...actual, createDb: () => testDbHolder.db };
+});
+
+const { widgetSiteRepository } = await import("./widget-site-repository");
+
+const fakeD1 = {} as D1Database;
+
+const create = (over: Partial<{ id: string; host: string }> = {}) =>
+  widgetSiteRepository.create(fakeD1, {
+    id: over.id ?? "ws-1",
+    host: over.host ?? "vill.otoineppu.hokkaido.jp",
+    instructions: "行政手続きを優先して案内する",
+    createdAt: "2026-08-12T00:00:00.000Z",
+  });
+
+describe("widgetSiteRepository", () => {
+  beforeEach(async () => {
+    testDbHolder.db = await createTestDb();
+  });
+
+  it("host で設置サイトを引ける", async () => {
+    await create();
+
+    const site = await widgetSiteRepository.findByHost(
+      fakeD1,
+      "vill.otoineppu.hokkaido.jp",
+    );
+
+    expect(site?.instructions).toBe("行政手続きを優先して案内する");
+  });
+
+  it("www 付き・大文字のホストでも同じ行に解決する", async () => {
+    await create();
+
+    const site = await widgetSiteRepository.findByHost(
+      fakeD1,
+      "WWW.Vill.Otoineppu.Hokkaido.JP",
+    );
+
+    expect(site?.host).toBe("vill.otoineppu.hokkaido.jp");
+  });
+
+  it("未登録の host は null を返す", async () => {
+    await create();
+
+    expect(
+      await widgetSiteRepository.findByHost(fakeD1, "evil.example.com"),
+    ).toBeNull();
+  });
+
+  it("登録時に host を正規化して保存し、作成した行を返す", async () => {
+    const created = await widgetSiteRepository.create(fakeD1, {
+      id: "ws-2",
+      host: "  WWW.Example.COM ",
+      instructions: "案内文",
+      createdAt: "2026-08-12T00:00:00.000Z",
+    });
+
+    expect(created.host).toBe("example.com");
+    expect(
+      (await widgetSiteRepository.findByHost(fakeD1, "example.com"))?.id,
+    ).toBe("ws-2");
+  });
+
+  it("id で引ける", async () => {
+    await create();
+
+    expect((await widgetSiteRepository.findById(fakeD1, "ws-1"))?.host).toBe(
+      "vill.otoineppu.hokkaido.jp",
+    );
+    expect(await widgetSiteRepository.findById(fakeD1, "missing")).toBeNull();
+  });
+
+  it("一覧を取得できる", async () => {
+    await create();
+    await create({ id: "ws-2", host: "example.com" });
+
+    expect(await widgetSiteRepository.list(fakeD1)).toHaveLength(2);
+  });
+
+  it("更新すると instructions と updatedAt が変わり、更新後の行を返す", async () => {
+    await create();
+
+    const updated = await widgetSiteRepository.update(fakeD1, "ws-1", {
+      instructions: "書き換えた案内文",
+    });
+
+    expect(updated.instructions).toBe("書き換えた案内文");
+    expect(updated.updatedAt).not.toBeNull();
+  });
+
+  it("更新でも host を正規化する", async () => {
+    await create();
+
+    await widgetSiteRepository.update(fakeD1, "ws-1", {
+      host: "WWW.Example.COM",
+    });
+
+    expect(
+      await widgetSiteRepository.findByHost(fakeD1, "example.com"),
+    ).not.toBeNull();
+  });
+
+  it("削除すると引けなくなる", async () => {
+    await create();
+
+    await widgetSiteRepository.delete(fakeD1, "ws-1");
+
+    expect(
+      await widgetSiteRepository.findByHost(
+        fakeD1,
+        "vill.otoineppu.hokkaido.jp",
+      ),
+    ).toBeNull();
+  });
+});

--- a/server/src/repository/widget-site-repository.ts
+++ b/server/src/repository/widget-site-repository.ts
@@ -1,0 +1,76 @@
+import { eq } from "drizzle-orm";
+import {
+  createDb,
+  type NewWidgetSite,
+  type WidgetSite,
+  widgetSites,
+} from "~/db";
+import { normalizeSiteHost } from "~/lib/widget-site";
+
+type CreateInput = Omit<NewWidgetSite, "id" | "updatedAt"> & { id: string };
+
+export const widgetSiteRepository = {
+  async findByHost(d1: D1Database, host: string) {
+    const db = createDb(d1);
+    const result = await db
+      .select()
+      .from(widgetSites)
+      .where(eq(widgetSites.host, normalizeSiteHost(host)))
+      .get();
+    return result ?? null;
+  },
+
+  async findById(d1: D1Database, id: string) {
+    const db = createDb(d1);
+    const result = await db
+      .select()
+      .from(widgetSites)
+      .where(eq(widgetSites.id, id))
+      .get();
+    return result ?? null;
+  },
+
+  async list(d1: D1Database) {
+    const db = createDb(d1);
+    return await db.select().from(widgetSites).all();
+  },
+
+  async create(d1: D1Database, input: CreateInput) {
+    const db = createDb(d1);
+    return await db
+      .insert(widgetSites)
+      .values({
+        id: input.id,
+        host: normalizeSiteHost(input.host),
+        instructions: input.instructions,
+        createdAt: input.createdAt,
+      })
+      .returning()
+      .get();
+  },
+
+  async update(
+    d1: D1Database,
+    id: string,
+    input: Partial<Pick<WidgetSite, "host" | "instructions">>,
+  ) {
+    const db = createDb(d1);
+    return await db
+      .update(widgetSites)
+      .set({
+        ...input,
+        ...(input.host && { host: normalizeSiteHost(input.host) }),
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(widgetSites.id, id))
+      .returning()
+      .get();
+  },
+
+  async delete(d1: D1Database, id: string) {
+    const db = createDb(d1);
+    await db.delete(widgetSites).where(eq(widgetSites.id, id));
+  },
+};
+
+export type { WidgetSite };

--- a/server/src/routes/admin/index.ts
+++ b/server/src/routes/admin/index.ts
@@ -7,3 +7,4 @@ export { knowledgeAdminRoutes } from "./knowledge";
 export { personaAdminRoutes } from "./persona";
 export { pollAdminRoutes } from "./poll";
 export { userAdminRoutes } from "./users";
+export { widgetSiteAdminRoutes } from "./widget-sites";

--- a/server/src/routes/admin/widget-sites.test.ts
+++ b/server/src/routes/admin/widget-sites.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/repository/admin-session-repository", () => ({
+  adminSessionRepository: { findValid: vi.fn() },
+}));
+
+vi.mock("~/repository/admin-user-repository", () => ({
+  adminUserRepository: { findById: vi.fn() },
+}));
+
+vi.mock("~/repository/widget-site-repository", () => ({
+  widgetSiteRepository: {
+    findByHost: vi.fn(),
+    findById: vi.fn(),
+    list: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock("~/services/auth/anonymous-session", () => ({
+  verifyAnonymousToken: vi.fn(),
+}));
+
+const { adminSessionRepository } = await import(
+  "~/repository/admin-session-repository"
+);
+const { adminUserRepository } = await import(
+  "~/repository/admin-user-repository"
+);
+const { widgetSiteRepository } = await import(
+  "~/repository/widget-site-repository"
+);
+const { widgetSiteAdminRoutes: rawRoutes } = await import("./widget-sites");
+
+import { withResolvePrincipal } from "~/__tests__/helpers/test-app";
+
+const routes = await withResolvePrincipal(rawRoutes);
+
+const TOKEN = "a".repeat(64);
+const superAdminUser = {
+  id: "u-super",
+  username: "super01",
+  name: "スーパー管理者",
+  role: "super_admin" as "admin" | "staff" | "super_admin",
+  passwordHash: "hash",
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: null,
+};
+
+const mockEnv = {
+  DB: {} as D1Database,
+  JWT_SECRET: "test-secret-32-chars-long-enough",
+} as unknown as CloudflareBindings;
+
+const site = {
+  id: "ws-1",
+  host: "vill.otoineppu.hokkaido.jp",
+  instructions: "行政手続きの案内を優先する",
+  createdAt: "2026-08-12T00:00:00.000Z",
+  updatedAt: null,
+};
+
+const useAuth = (user = superAdminUser) => {
+  vi.mocked(adminSessionRepository.findValid).mockResolvedValue({
+    token: TOKEN,
+    userId: user.id,
+    expiresAt: new Date(Date.now() + 86400000).toISOString(),
+    createdAt: "2025-01-01T00:00:00Z",
+  });
+  vi.mocked(adminUserRepository.findById).mockImplementation(async (_d1, id) =>
+    id === user.id ? user : null,
+  );
+};
+
+const authed = (path: string, method: string, body?: unknown) =>
+  new Request(`http://localhost${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+
+describe("widgetSiteAdminRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("認可", () => {
+    it("認証なしは 401", async () => {
+      const res = await routes.request(
+        new Request("http://localhost/"),
+        undefined,
+        mockEnv,
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it.each(["staff", "admin"] as const)("%s ロールは 403", async (role) => {
+      useAuth({ ...superAdminUser, role });
+
+      const res = await routes.request(authed("/", "GET"), undefined, mockEnv);
+
+      expect(res.status).toBe(403);
+      expect(widgetSiteRepository.list).not.toHaveBeenCalled();
+    });
+  });
+
+  it("一覧を返す", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.list).mockResolvedValue([site]);
+
+    const res = await routes.request(authed("/", "GET"), undefined, mockEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ sites: [site] });
+  });
+
+  it("新しい設置サイトを登録する", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findByHost).mockResolvedValue(null);
+    vi.mocked(widgetSiteRepository.create).mockResolvedValue(site);
+
+    const res = await routes.request(
+      authed("/", "POST", {
+        host: "www.vill.otoineppu.hokkaido.jp",
+        instructions: "行政手続きの案内を優先する",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual(site);
+    expect(widgetSiteRepository.create).toHaveBeenCalledWith(
+      mockEnv.DB,
+      expect.objectContaining({
+        host: "www.vill.otoineppu.hokkaido.jp",
+        instructions: "行政手続きの案内を優先する",
+      }),
+    );
+  });
+
+  it("登録済みドメインの再登録は 409", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findByHost).mockResolvedValue(site);
+
+    const res = await routes.request(
+      authed("/", "POST", {
+        host: "vill.otoineppu.hokkaido.jp",
+        instructions: "案内文",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(409);
+    expect(widgetSiteRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("host が空なら 400", async () => {
+    useAuth();
+
+    const res = await routes.request(
+      authed("/", "POST", { host: "", instructions: "案内文" }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("設置サイトを更新する", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findById).mockResolvedValue(site);
+    vi.mocked(widgetSiteRepository.findByHost).mockResolvedValue(site);
+    vi.mocked(widgetSiteRepository.update).mockResolvedValue({
+      ...site,
+      instructions: "書き換えた案内文",
+    });
+
+    const res = await routes.request(
+      authed("/ws-1", "PUT", {
+        host: "vill.otoineppu.hokkaido.jp",
+        instructions: "書き換えた案内文",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ...site,
+      instructions: "書き換えた案内文",
+    });
+    expect(widgetSiteRepository.update).toHaveBeenCalledWith(
+      mockEnv.DB,
+      "ws-1",
+      {
+        host: "vill.otoineppu.hokkaido.jp",
+        instructions: "書き換えた案内文",
+      },
+    );
+  });
+
+  it("他サイトが使っているドメインへの更新は 409", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findById).mockResolvedValue(site);
+    vi.mocked(widgetSiteRepository.findByHost).mockResolvedValue({
+      ...site,
+      id: "ws-2",
+    });
+
+    const res = await routes.request(
+      authed("/ws-1", "PUT", {
+        host: "example.com",
+        instructions: "案内文",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(409);
+    expect(widgetSiteRepository.update).not.toHaveBeenCalled();
+  });
+
+  it("存在しない id の更新は 404", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findById).mockResolvedValue(null);
+
+    const res = await routes.request(
+      authed("/missing", "PUT", {
+        host: "example.com",
+        instructions: "案内文",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("設置サイトを削除する", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findById).mockResolvedValue(site);
+
+    const res = await routes.request(
+      authed("/ws-1", "DELETE"),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(200);
+    expect(widgetSiteRepository.delete).toHaveBeenCalledWith(
+      mockEnv.DB,
+      "ws-1",
+    );
+  });
+
+  it("存在しない id の削除は 404", async () => {
+    useAuth();
+    vi.mocked(widgetSiteRepository.findById).mockResolvedValue(null);
+
+    const res = await routes.request(
+      authed("/missing", "DELETE"),
+      undefined,
+      mockEnv,
+    );
+
+    expect(res.status).toBe(404);
+    expect(widgetSiteRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/routes/admin/widget-sites.ts
+++ b/server/src/routes/admin/widget-sites.ts
@@ -1,0 +1,171 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { HTTPException } from "hono/http-exception";
+import { errorResponse } from "~/lib/openapi-errors";
+import type { PrincipalVariables } from "~/lib/principal";
+import { requireRole } from "~/middleware/require-role";
+import { widgetSiteRepository } from "~/repository/widget-site-repository";
+import {
+  widgetSiteInputSchema,
+  widgetSiteSchema,
+} from "~/schemas/widget-site-schema";
+
+export const widgetSiteAdminRoutes = new OpenAPIHono<{
+  Bindings: CloudflareBindings;
+  Variables: Partial<PrincipalVariables>;
+}>();
+
+widgetSiteAdminRoutes.use("*", requireRole("super_admin"));
+
+const listRoute = createRoute({
+  method: "get",
+  path: "/",
+  tags: ["Admin - Widget Sites"],
+  summary: "ウィジェット設置サイト一覧",
+  description:
+    "ウィジェットを設置できるサイトと、そのサイト向けの指示の一覧を返します。スーパー管理者のみ実行できます。",
+  responses: {
+    200: {
+      description: "一覧取得成功",
+      content: {
+        "application/json": {
+          schema: z.object({ sites: z.array(widgetSiteSchema) }),
+        },
+      },
+    },
+    401: errorResponse(401),
+    403: errorResponse(403),
+  },
+});
+
+widgetSiteAdminRoutes.openapi(listRoute, async (c) => {
+  const sites = await widgetSiteRepository.list(c.env.DB);
+  return c.json({ sites }, 200);
+});
+
+const createSiteRoute = createRoute({
+  method: "post",
+  path: "/",
+  tags: ["Admin - Widget Sites"],
+  summary: "ウィジェット設置サイト登録",
+  description:
+    "ウィジェットの設置を許可するサイトを登録します。スーパー管理者のみ実行できます。",
+  request: {
+    body: {
+      content: { "application/json": { schema: widgetSiteInputSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    201: {
+      description: "登録成功",
+      content: { "application/json": { schema: widgetSiteSchema } },
+    },
+    400: errorResponse(400),
+    401: errorResponse(401),
+    403: errorResponse(403),
+    409: errorResponse(409),
+  },
+});
+
+widgetSiteAdminRoutes.openapi(createSiteRoute, async (c) => {
+  const { host, instructions } = c.req.valid("json");
+
+  if (await widgetSiteRepository.findByHost(c.env.DB, host)) {
+    throw new HTTPException(409, {
+      message: "このドメインはすでに登録されています",
+    });
+  }
+
+  const site = await widgetSiteRepository.create(c.env.DB, {
+    id: crypto.randomUUID(),
+    host,
+    instructions,
+    createdAt: new Date().toISOString(),
+  });
+
+  return c.json(site, 201);
+});
+
+const updateSiteRoute = createRoute({
+  method: "put",
+  path: "/{id}",
+  tags: ["Admin - Widget Sites"],
+  summary: "ウィジェット設置サイト更新",
+  description:
+    "設置サイトのドメインと指示を更新します。スーパー管理者のみ実行できます。",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: { "application/json": { schema: widgetSiteInputSchema } },
+      required: true,
+    },
+  },
+  responses: {
+    200: {
+      description: "更新成功",
+      content: { "application/json": { schema: widgetSiteSchema } },
+    },
+    400: errorResponse(400),
+    401: errorResponse(401),
+    403: errorResponse(403),
+    404: errorResponse(404),
+    409: errorResponse(409),
+  },
+});
+
+widgetSiteAdminRoutes.openapi(updateSiteRoute, async (c) => {
+  const { id } = c.req.valid("param");
+  const { host, instructions } = c.req.valid("json");
+
+  if (!(await widgetSiteRepository.findById(c.env.DB, id))) {
+    throw new HTTPException(404, { message: "設置サイトが見つかりません" });
+  }
+
+  const duplicated = await widgetSiteRepository.findByHost(c.env.DB, host);
+  if (duplicated && duplicated.id !== id) {
+    throw new HTTPException(409, {
+      message: "このドメインはすでに登録されています",
+    });
+  }
+
+  const updated = await widgetSiteRepository.update(c.env.DB, id, {
+    host,
+    instructions,
+  });
+
+  return c.json(updated, 200);
+});
+
+const deleteSiteRoute = createRoute({
+  method: "delete",
+  path: "/{id}",
+  tags: ["Admin - Widget Sites"],
+  summary: "ウィジェット設置サイト削除",
+  description: "設置サイトの登録を削除します。スーパー管理者のみ実行できます。",
+  request: {
+    params: z.object({ id: z.string() }),
+  },
+  responses: {
+    200: {
+      description: "削除成功",
+      content: {
+        "application/json": { schema: z.object({ message: z.string() }) },
+      },
+    },
+    401: errorResponse(401),
+    403: errorResponse(403),
+    404: errorResponse(404),
+  },
+});
+
+widgetSiteAdminRoutes.openapi(deleteSiteRoute, async (c) => {
+  const { id } = c.req.valid("param");
+
+  if (!(await widgetSiteRepository.findById(c.env.DB, id))) {
+    throw new HTTPException(404, { message: "設置サイトが見つかりません" });
+  }
+
+  await widgetSiteRepository.delete(c.env.DB, id);
+
+  return c.json({ message: "設置サイトを削除しました" }, 200);
+});

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -8,6 +8,7 @@ export {
   personaAdminRoutes,
   pollAdminRoutes,
   userAdminRoutes,
+  widgetSiteAdminRoutes,
 } from "./admin";
 export { authRoutes } from "./auth";
 export { broadcastMediaRoutes } from "./broadcast-media";

--- a/server/src/routes/threads/chat.test.ts
+++ b/server/src/routes/threads/chat.test.ts
@@ -5,11 +5,17 @@ const {
   mockClassifyIntent,
   mockGetThreadById,
   mockRecordLlmUsage,
+  mockFindWidgetSiteByHost,
 } = vi.hoisted(() => ({
   mockHandleChatStream: vi.fn(),
   mockClassifyIntent: vi.fn(),
   mockGetThreadById: vi.fn(),
   mockRecordLlmUsage: vi.fn(),
+  mockFindWidgetSiteByHost: vi.fn(),
+}));
+
+vi.mock("~/repository/widget-site-repository", () => ({
+  widgetSiteRepository: { findByHost: mockFindWidgetSiteByHost },
 }));
 
 vi.mock("@mastra/ai-sdk", () => ({
@@ -141,6 +147,7 @@ describe("chatRoutes: POST /:threadId/chat", () => {
     vi.clearAllMocks();
     mockHandleChatStream.mockResolvedValue(buildStubStream());
     mockClassifyIntent.mockResolvedValue("casual");
+    mockFindWidgetSiteByHost.mockResolvedValue(null);
   });
 
   it("認証なしは 401", async () => {
@@ -308,6 +315,81 @@ describe("chatRoutes: POST /:threadId/chat", () => {
 
     expect(mockCreateNeppChanAgent).toHaveBeenCalledWith(
       expect.objectContaining({ platform: "widget" }),
+    );
+  });
+
+  it("widget で登録済みの siteHost なら設置サイトの instructions を渡す", async () => {
+    useAnonAuth(WIDGET_RES_ID);
+    mockGetThreadById.mockResolvedValue({
+      ...ownThread,
+      resourceId: WIDGET_RES_ID,
+    });
+    mockFindWidgetSiteByHost.mockResolvedValue({
+      id: "ws-1",
+      host: "vill.otoineppu.hokkaido.jp",
+      instructions: "行政手続きの案内を優先する",
+      createdAt: "2026-08-12T00:00:00.000Z",
+      updatedAt: null,
+    });
+
+    await routes.request(
+      buildReq("/thread-1/chat", {
+        ...validBody,
+        siteHost: "www.vill.otoineppu.hokkaido.jp",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(mockFindWidgetSiteByHost).toHaveBeenCalledWith(
+      mockEnv.DB,
+      "www.vill.otoineppu.hokkaido.jp",
+    );
+    expect(mockCreateNeppChanAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteInstructions: "行政手続きの案内を優先する",
+      }),
+    );
+  });
+
+  it("widget でも未登録の siteHost なら instructions を渡さない", async () => {
+    useAnonAuth(WIDGET_RES_ID);
+    mockGetThreadById.mockResolvedValue({
+      ...ownThread,
+      resourceId: WIDGET_RES_ID,
+    });
+    mockFindWidgetSiteByHost.mockResolvedValue(null);
+
+    await routes.request(
+      buildReq("/thread-1/chat", {
+        ...validBody,
+        siteHost: "evil.example.com",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(mockCreateNeppChanAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ siteInstructions: undefined }),
+    );
+  });
+
+  it("web の resourceId では siteHost が来ても設置サイトを引かない", async () => {
+    useAnonAuth();
+    mockGetThreadById.mockResolvedValue(ownThread);
+
+    await routes.request(
+      buildReq("/thread-1/chat", {
+        ...validBody,
+        siteHost: "www.vill.otoineppu.hokkaido.jp",
+      }),
+      undefined,
+      mockEnv,
+    );
+
+    expect(mockFindWidgetSiteByHost).not.toHaveBeenCalled();
+    expect(mockCreateNeppChanAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ siteInstructions: undefined }),
     );
   });
 

--- a/server/src/routes/threads/chat.ts
+++ b/server/src/routes/threads/chat.ts
@@ -12,6 +12,7 @@ import { createRequestContext } from "~/mastra/request-context";
 import { requireAuth } from "~/middleware/auth";
 import type { ThreadVariables } from "~/middleware/require-thread-access";
 import { requireThreadAccess } from "~/middleware/require-thread-access";
+import { widgetSiteRepository } from "~/repository/widget-site-repository";
 import { recordLlmUsage } from "~/services/analytics/llm-usage";
 
 export const chatRoutes = new OpenAPIHono<{
@@ -27,6 +28,7 @@ const ChatSendRequestSchema = z.object({
     createdAt: z.coerce.date().optional(),
   }),
   intent: z.enum(["casual", "thinking"]).optional(),
+  siteHost: z.string().max(255).optional(),
 });
 
 const chatRoute = createRoute({
@@ -64,7 +66,7 @@ const chatRoute = createRoute({
 
 chatRoutes.openapi(chatRoute, async (c) => {
   const { threadId } = c.req.valid("param");
-  const { message, intent: fixedIntent } = c.req.valid("json");
+  const { message, intent: fixedIntent, siteHost } = c.req.valid("json");
   const thread = c.get("thread");
   const principal = c.get("principal");
 
@@ -79,6 +81,10 @@ chatRoutes.openapi(chatRoute, async (c) => {
   // widget 由来の resourceId は widget- prefix を持つ（server/src/lib/principal.ts の
   // line:/admin: と同じ、resourceId prefix でチャネルを区別する規約）
   const platform = thread.resourceId.startsWith("widget-") ? "widget" : "web";
+  const site =
+    platform === "widget" && siteHost
+      ? await widgetSiteRepository.findByHost(c.env.DB, siteHost)
+      : null;
 
   const storage = await getStorage(c.env.DB);
 
@@ -98,6 +104,7 @@ chatRoutes.openapi(chatRoute, async (c) => {
     isAdmin: enableAdminAgents,
     modelConfig,
     platform,
+    siteInstructions: site?.instructions,
   });
   const mastra = new Mastra({
     agents: { neppChanAgent },

--- a/server/src/schemas/widget-site-schema.ts
+++ b/server/src/schemas/widget-site-schema.ts
@@ -1,0 +1,22 @@
+import { z } from "@hono/zod-openapi";
+
+export const widgetSiteSchema = z.object({
+  id: z.string(),
+  host: z.string(),
+  instructions: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string().nullable(),
+});
+
+export const widgetSiteInputSchema = z.object({
+  host: z
+    .string()
+    .min(1)
+    .max(255)
+    .describe("設置サイトのホスト名（例: www.vill.otoineppu.hokkaido.jp）"),
+  instructions: z
+    .string()
+    .min(1)
+    .max(4000)
+    .describe("このサイトで開かれたときにねっぷちゃんへ渡す指示"),
+});

--- a/shared/src/api/repository/widget-site-repository.test.ts
+++ b/shared/src/api/repository/widget-site-repository.test.ts
@@ -1,0 +1,136 @@
+import { HttpResponse, http } from "msw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  TEST_API_BASE as API,
+  setTestAuthToken,
+  testApiClient,
+} from "../../test/api-client";
+import { server } from "../../test/msw-server";
+import { createWidgetSiteRepository } from "./widget-site-repository";
+
+const repo = createWidgetSiteRepository(testApiClient);
+
+const site = {
+  id: "ws-1",
+  host: "vill.otoineppu.hokkaido.jp",
+  instructions: "行政手続きの案内を優先する",
+  createdAt: "2026-08-12T00:00:00.000Z",
+  updatedAt: null,
+};
+
+beforeEach(() => {
+  setTestAuthToken("admin-token");
+});
+
+afterEach(() => {
+  setTestAuthToken(null);
+});
+
+describe("widget-site-repository", () => {
+  it("fetchWidgetSites", async () => {
+    server.use(
+      http.get(`${API}/admin/widget-sites`, () =>
+        HttpResponse.json({ sites: [site] }),
+      ),
+    );
+
+    const result = await repo.fetchWidgetSites();
+    expect(result?.sites).toEqual([site]);
+  });
+
+  it("createWidgetSite: host + instructions を送る", async () => {
+    server.use(
+      http.post(`${API}/admin/widget-sites`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          host: "example.com",
+          instructions: "案内文",
+        });
+        return HttpResponse.json(site, { status: 201 });
+      }),
+    );
+
+    const result = await repo.createWidgetSite({
+      host: "example.com",
+      instructions: "案内文",
+    });
+    expect(result?.id).toBe("ws-1");
+  });
+
+  it("updateWidgetSite: PUT", async () => {
+    server.use(
+      http.put(`${API}/admin/widget-sites/ws-1`, async ({ request }) => {
+        expect(await request.json()).toEqual({
+          host: "example.com",
+          instructions: "書き換えた案内文",
+        });
+        return HttpResponse.json(site);
+      }),
+    );
+
+    const result = await repo.updateWidgetSite("ws-1", {
+      host: "example.com",
+      instructions: "書き換えた案内文",
+    });
+    expect(result?.host).toBe("vill.otoineppu.hokkaido.jp");
+  });
+
+  it("deleteWidgetSite: DELETE", async () => {
+    let called = false;
+    server.use(
+      http.delete(`${API}/admin/widget-sites/ws-1`, () => {
+        called = true;
+        return HttpResponse.json({ message: "ok" });
+      }),
+    );
+
+    await repo.deleteWidgetSite("ws-1");
+    expect(called).toBe(true);
+  });
+
+  it("失敗系: fetchWidgetSites 403 は throw", async () => {
+    server.use(
+      http.get(`${API}/admin/widget-sites`, () =>
+        HttpResponse.json({ error: { message: "forbidden" } }, { status: 403 }),
+      ),
+    );
+
+    await expect(repo.fetchWidgetSites()).rejects.toBeDefined();
+  });
+
+  it("失敗系: createWidgetSite 409 は throw", async () => {
+    server.use(
+      http.post(`${API}/admin/widget-sites`, () =>
+        HttpResponse.json({ error: { message: "duplicate" } }, { status: 409 }),
+      ),
+    );
+
+    await expect(
+      repo.createWidgetSite({ host: "example.com", instructions: "案内文" }),
+    ).rejects.toBeDefined();
+  });
+
+  it("失敗系: updateWidgetSite 404 は throw", async () => {
+    server.use(
+      http.put(`${API}/admin/widget-sites/missing`, () =>
+        HttpResponse.json({ error: { message: "not found" } }, { status: 404 }),
+      ),
+    );
+
+    await expect(
+      repo.updateWidgetSite("missing", {
+        host: "example.com",
+        instructions: "案内文",
+      }),
+    ).rejects.toBeDefined();
+  });
+
+  it("失敗系: deleteWidgetSite 5xx は throw", async () => {
+    server.use(
+      http.delete(`${API}/admin/widget-sites/x`, () =>
+        HttpResponse.json({ error: { message: "x" } }, { status: 500 }),
+      ),
+    );
+
+    await expect(repo.deleteWidgetSite("x")).rejects.toBeDefined();
+  });
+});

--- a/shared/src/api/repository/widget-site-repository.ts
+++ b/shared/src/api/repository/widget-site-repository.ts
@@ -1,0 +1,41 @@
+import type { ApiClient } from "../create-client";
+import type { paths } from "../types";
+
+type WidgetSiteInput = NonNullable<
+  paths["/admin/widget-sites"]["post"]["requestBody"]
+>["content"]["application/json"];
+
+export const createWidgetSiteRepository = (client: ApiClient) => ({
+  fetchWidgetSites: async () => {
+    const { data, error } = await client.GET("/admin/widget-sites");
+    if (error) throw error;
+    return data;
+  },
+
+  createWidgetSite: async (body: WidgetSiteInput) => {
+    const { data, error } = await client.POST("/admin/widget-sites", { body });
+    if (error) throw error;
+    return data;
+  },
+
+  updateWidgetSite: async (id: string, body: WidgetSiteInput) => {
+    const { data, error } = await client.PUT("/admin/widget-sites/{id}", {
+      params: { path: { id } },
+      body,
+    });
+    if (error) throw error;
+    return data;
+  },
+
+  deleteWidgetSite: async (id: string) => {
+    const { data, error } = await client.DELETE("/admin/widget-sites/{id}", {
+      params: { path: { id } },
+    });
+    if (error) throw error;
+    return data;
+  },
+});
+
+export type WidgetSiteRepository = ReturnType<
+  typeof createWidgetSiteRepository
+>;

--- a/shared/src/api/types.d.ts
+++ b/shared/src/api/types.d.ts
@@ -428,6 +428,7 @@ export interface paths {
                         };
                         /** @enum {string} */
                         intent?: "casual" | "thinking";
+                        siteHost?: string;
                     };
                 };
             };
@@ -4369,6 +4370,370 @@ export interface paths {
             };
         };
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/widget-sites": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * ウィジェット設置サイト一覧
+         * @description ウィジェットを設置できるサイトと、そのサイト向けの指示の一覧を返します。スーパー管理者のみ実行できます。
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 一覧取得成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            sites: {
+                                id: string;
+                                host: string;
+                                instructions: string;
+                                createdAt: string;
+                                updatedAt: string | null;
+                            }[];
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 権限エラー */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * ウィジェット設置サイト登録
+         * @description ウィジェットの設置を許可するサイトを登録します。スーパー管理者のみ実行できます。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 設置サイトのホスト名（例: www.vill.otoineppu.hokkaido.jp） */
+                        host: string;
+                        /** @description このサイトで開かれたときにねっぷちゃんへ渡す指示 */
+                        instructions: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description 登録成功 */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            host: string;
+                            instructions: string;
+                            createdAt: string;
+                            updatedAt: string | null;
+                        };
+                    };
+                };
+                /** @description リクエストエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 権限エラー */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが競合しています */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/widget-sites/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * ウィジェット設置サイト更新
+         * @description 設置サイトのドメインと指示を更新します。スーパー管理者のみ実行できます。
+         */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        /** @description 設置サイトのホスト名（例: www.vill.otoineppu.hokkaido.jp） */
+                        host: string;
+                        /** @description このサイトで開かれたときにねっぷちゃんへ渡す指示 */
+                        instructions: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description 更新成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            id: string;
+                            host: string;
+                            instructions: string;
+                            createdAt: string;
+                            updatedAt: string | null;
+                        };
+                    };
+                };
+                /** @description リクエストエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 権限エラー */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが競合しています */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        /**
+         * ウィジェット設置サイト削除
+         * @description 設置サイトの登録を削除します。スーパー管理者のみ実行できます。
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description 削除成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            message: string;
+                        };
+                    };
+                };
+                /** @description 認証エラー */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description 権限エラー */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+                /** @description リソースが見つかりません */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            error: {
+                                code: number;
+                                message: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
         options?: never;
         head?: never;
         patch?: never;

--- a/web/src/app/dashboard/App.tsx
+++ b/web/src/app/dashboard/App.tsx
@@ -7,6 +7,7 @@ import {
   ChatBubbleLeftIcon,
   ChatBubbleLeftRightIcon,
   EnvelopeIcon,
+  GlobeAltIcon,
   HandThumbUpIcon,
   HomeIcon,
   MegaphoneIcon,
@@ -31,6 +32,7 @@ import { PollPanel } from "~/app/dashboard/components/PollPanel";
 import { UsagePanel } from "~/app/dashboard/components/UsagePanel";
 import { VoicesPanel } from "~/app/dashboard/components/VoicesPanel";
 import type { VoiceFilter } from "~/app/dashboard/components/voices/helpers";
+import { WidgetSitesPanel } from "~/app/dashboard/components/WidgetSitesPanel";
 import { useAuth } from "~/app/dashboard/contexts/AuthContext";
 import { useRole } from "~/app/dashboard/hooks/useRole";
 import type { AdminUser } from "~/lib/api/auth";
@@ -44,6 +46,7 @@ export type Tab =
   | "knowledge"
   | "feedback"
   | "invitations"
+  | "widget-sites"
   | "usage";
 
 type AdminRole = AdminUser["role"];
@@ -111,6 +114,13 @@ const tabs: {
     id: "invitations",
     label: "招待管理",
     icon: <EnvelopeIcon className="w-5 h-5" aria-hidden="true" />,
+    group: "system",
+    minRole: "super_admin",
+  },
+  {
+    id: "widget-sites",
+    label: "設置サイト",
+    icon: <GlobeAltIcon className="w-5 h-5" aria-hidden="true" />,
     group: "system",
     minRole: "super_admin",
   },
@@ -326,6 +336,7 @@ export const App = () => {
             {activeTab === "knowledge" && <KnowledgePanel />}
             {activeTab === "feedback" && <FeedbackPanel />}
             {activeTab === "invitations" && <InvitationsPanel />}
+            {activeTab === "widget-sites" && <WidgetSitesPanel />}
             {activeTab === "usage" && <UsagePanel />}
           </div>
         </div>

--- a/web/src/app/dashboard/components/WidgetSitesPanel.test.tsx
+++ b/web/src/app/dashboard/components/WidgetSitesPanel.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setAuthToken } from "~/lib/auth-token";
+import { server } from "~/test/msw-server";
+import { renderWithQuery } from "~/test/query";
+import { WidgetSitesPanel } from "./WidgetSitesPanel";
+
+const API = "http://localhost:8787";
+
+const site = {
+  id: "ws-1",
+  host: "vill.otoineppu.hokkaido.jp",
+  instructions: "行政手続きの案内を優先する",
+  createdAt: "2026-08-12T00:00:00.000Z",
+  updatedAt: null,
+};
+
+const useSites = (sites = [site]) => {
+  server.use(
+    http.get(`${API}/admin/widget-sites`, () => HttpResponse.json({ sites })),
+  );
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  setAuthToken("admin-token");
+});
+
+describe("WidgetSitesPanel", () => {
+  it("登録済みの設置サイトを一覧表示する", async () => {
+    useSites();
+    renderWithQuery(<WidgetSitesPanel />);
+
+    expect(
+      await screen.findByText("vill.otoineppu.hokkaido.jp"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("行政手続きの案内を優先する")).toBeInTheDocument();
+  });
+
+  it("未登録なら空の案内を出す", async () => {
+    useSites([]);
+    renderWithQuery(<WidgetSitesPanel />);
+
+    expect(
+      await screen.findByText("まだ設置サイトが登録されていません。"),
+    ).toBeInTheDocument();
+  });
+
+  it("ドメインと指示が埋まるまで追加ボタンを押せない", async () => {
+    useSites([]);
+    renderWithQuery(<WidgetSitesPanel />);
+
+    const submit = screen.getByRole("button", { name: "追加" });
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("www.vill.otoineppu.hokkaido.jp"),
+      {
+        target: { value: "example.com" },
+      },
+    );
+    expect(submit).toBeDisabled();
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "行政手続き・窓口案内の質問を優先して受け止める",
+      ),
+      { target: { value: "案内文" } },
+    );
+    expect(submit).toBeEnabled();
+  });
+
+  it("フォーム送信で設置サイトを登録する", async () => {
+    useSites([]);
+    let body: unknown;
+    server.use(
+      http.post(`${API}/admin/widget-sites`, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json(site, { status: 201 });
+      }),
+    );
+    renderWithQuery(<WidgetSitesPanel />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText("www.vill.otoineppu.hokkaido.jp"),
+      {
+        target: { value: " Example.com " },
+      },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "行政手続き・窓口案内の質問を優先して受け止める",
+      ),
+      { target: { value: "案内文" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    await waitFor(() => {
+      expect(body).toEqual({ host: "Example.com", instructions: "案内文" });
+    });
+  });
+
+  it("編集ボタンでフォームに既存の値が入り更新できる", async () => {
+    useSites();
+    let body: unknown;
+    server.use(
+      http.put(`${API}/admin/widget-sites/ws-1`, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json(site);
+      }),
+    );
+    renderWithQuery(<WidgetSitesPanel />);
+
+    fireEvent.click(
+      await screen.findByLabelText("vill.otoineppu.hokkaido.jp を編集"),
+    );
+
+    expect(screen.getByText("設置サイトを編集")).toBeInTheDocument();
+    const instructions = screen.getByDisplayValue("行政手続きの案内を優先する");
+    fireEvent.change(instructions, { target: { value: "書き換えた案内文" } });
+    fireEvent.click(screen.getByRole("button", { name: "更新" }));
+
+    await waitFor(() => {
+      expect(body).toEqual({
+        host: "vill.otoineppu.hokkaido.jp",
+        instructions: "書き換えた案内文",
+      });
+    });
+  });
+
+  it("キャンセルで編集モードを抜ける", async () => {
+    useSites();
+    renderWithQuery(<WidgetSitesPanel />);
+
+    fireEvent.click(
+      await screen.findByLabelText("vill.otoineppu.hokkaido.jp を編集"),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(screen.getByText("設置サイトを追加")).toBeInTheDocument();
+  });
+
+  it("確認ダイアログを承認したときだけ削除する", async () => {
+    useSites();
+    let deleted = false;
+    server.use(
+      http.delete(`${API}/admin/widget-sites/ws-1`, () => {
+        deleted = true;
+        return HttpResponse.json({ message: "削除しました" });
+      }),
+    );
+    const confirmSpy = vi
+      .spyOn(window, "confirm")
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    renderWithQuery(<WidgetSitesPanel />);
+
+    const deleteButton = await screen.findByLabelText(
+      "vill.otoineppu.hokkaido.jp を削除",
+    );
+    fireEvent.click(deleteButton);
+    expect(deleted).toBe(false);
+
+    fireEvent.click(deleteButton);
+    await waitFor(() => {
+      expect(deleted).toBe(true);
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it("登録が失敗したらエラーメッセージを出す", async () => {
+    useSites([]);
+    server.use(
+      http.post(`${API}/admin/widget-sites`, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 409,
+              message: "このドメインはすでに登録されています",
+            },
+          },
+          { status: 409 },
+        ),
+      ),
+    );
+    renderWithQuery(<WidgetSitesPanel />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText("www.vill.otoineppu.hokkaido.jp"),
+      {
+        target: { value: "example.com" },
+      },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "行政手続き・窓口案内の質問を優先して受け止める",
+      ),
+      { target: { value: "案内文" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "追加" }));
+
+    expect(
+      await screen.findByText("このドメインはすでに登録されています"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/app/dashboard/components/WidgetSitesPanel.tsx
+++ b/web/src/app/dashboard/components/WidgetSitesPanel.tsx
@@ -1,0 +1,168 @@
+import { PencilSquareIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { Button } from "@nepp-chan/shared/ui/Button";
+import { type SubmitEvent, useState } from "react";
+import {
+  useCreateWidgetSite,
+  useDeleteWidgetSite,
+  useUpdateWidgetSite,
+  useWidgetSites,
+} from "~/app/dashboard/hooks/useWidgetSites";
+import { confirmDialog } from "~/lib/dialog";
+
+const errorMessage = (err: unknown) =>
+  err instanceof Error ? err.message : "エラーが発生しました";
+
+export const WidgetSitesPanel = () => {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [host, setHost] = useState("");
+  const [instructions, setInstructions] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const { data, isLoading } = useWidgetSites();
+  const createMutation = useCreateWidgetSite();
+  const updateMutation = useUpdateWidgetSite();
+  const deleteMutation = useDeleteWidgetSite();
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  const resetForm = () => {
+    setEditingId(null);
+    setHost("");
+    setInstructions("");
+  };
+
+  const handleSubmit = (e: SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!host.trim() || !instructions.trim()) return;
+    setError(null);
+
+    const body = { host: host.trim(), instructions: instructions.trim() };
+    const handlers = {
+      onSuccess: () => resetForm(),
+      onError: (err: unknown) => setError(errorMessage(err)),
+    };
+
+    if (editingId) {
+      updateMutation.mutate({ id: editingId, data: body }, handlers);
+      return;
+    }
+    createMutation.mutate(body, handlers);
+  };
+
+  const handleDelete = (id: string, host: string) => {
+    if (!confirmDialog(`${host} の設定を削除しますか？`)) return;
+    setError(null);
+    deleteMutation.mutate(id, {
+      onSuccess: () => {
+        if (editingId === id) resetForm();
+      },
+      onError: (err) => setError(errorMessage(err)),
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-xl border border-stone-200 p-4"
+      >
+        <h3 className="font-medium text-stone-900 mb-2">
+          {editingId ? "設置サイトを編集" : "設置サイトを追加"}
+        </h3>
+        <p className="text-sm text-stone-500 mb-4">
+          ここに登録したドメインでウィジェットが開かれたときだけ、ねっぷちゃんに追加の指示が渡ります。
+        </p>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">
+            {error}
+          </div>
+        )}
+
+        <label className="block mb-4">
+          <span className="block text-sm text-stone-600 mb-1">ドメイン</span>
+          <input
+            type="text"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            placeholder="www.vill.otoineppu.hokkaido.jp"
+            className="w-full px-3 py-2 border border-stone-300 rounded focus:outline-none focus:ring-2 focus:ring-teal-500"
+          />
+        </label>
+
+        <label className="block mb-4">
+          <span className="block text-sm text-stone-600 mb-1">
+            このサイト向けの指示
+          </span>
+          <textarea
+            value={instructions}
+            onChange={(e) => setInstructions(e.target.value)}
+            rows={6}
+            placeholder="行政手続き・窓口案内の質問を優先して受け止める"
+            className="w-full px-3 py-2 border border-stone-300 rounded focus:outline-none focus:ring-2 focus:ring-teal-500"
+          />
+        </label>
+
+        <div className="flex gap-2">
+          <Button
+            type="submit"
+            disabled={isPending || !host.trim() || !instructions.trim()}
+          >
+            {editingId ? "更新" : "追加"}
+          </Button>
+          {editingId && (
+            <Button type="button" variant="outline" onClick={resetForm}>
+              キャンセル
+            </Button>
+          )}
+        </div>
+      </form>
+
+      <div className="bg-white rounded-xl border border-stone-200">
+        {isLoading && <p className="p-4 text-stone-500">読み込み中...</p>}
+        {!isLoading && data?.sites.length === 0 && (
+          <p className="p-4 text-stone-500">
+            まだ設置サイトが登録されていません。
+          </p>
+        )}
+        <ul className="divide-y divide-stone-200">
+          {data?.sites.map((site) => (
+            <li key={site.id} className="p-4 flex gap-4">
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-stone-900 break-all">
+                  {site.host}
+                </p>
+                <p className="mt-1 text-sm text-stone-600 whitespace-pre-wrap">
+                  {site.instructions}
+                </p>
+              </div>
+              <div className="flex items-start gap-1">
+                <button
+                  type="button"
+                  aria-label={`${site.host} を編集`}
+                  onClick={() => {
+                    setEditingId(site.id);
+                    setHost(site.host);
+                    setInstructions(site.instructions);
+                    setError(null);
+                  }}
+                  className="p-2 text-stone-500 hover:text-teal-700"
+                >
+                  <PencilSquareIcon className="w-4 h-4" aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  aria-label={`${site.host} を削除`}
+                  onClick={() => handleDelete(site.id, site.host)}
+                  className="p-2 text-stone-500 hover:text-red-700"
+                >
+                  <TrashIcon className="w-4 h-4" aria-hidden="true" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/web/src/app/dashboard/hooks/keys.ts
+++ b/web/src/app/dashboard/hooks/keys.ts
@@ -26,4 +26,5 @@ export const dashboardKeys = {
   polls: ["dashboard", "polls"] as const,
   pollResults: (id: string) => ["dashboard", "poll", "results", id] as const,
   invitations: ["dashboard", "invitations"] as const,
+  widgetSites: ["dashboard", "widget-sites"] as const,
 };

--- a/web/src/app/dashboard/hooks/useWidgetSites.ts
+++ b/web/src/app/dashboard/hooks/useWidgetSites.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { widgetSiteRepository } from "~/lib/api/repository";
+import { dashboardKeys } from "./keys";
+
+export const useWidgetSites = () =>
+  useQuery({
+    queryKey: dashboardKeys.widgetSites,
+    queryFn: widgetSiteRepository.fetchWidgetSites,
+  });
+
+export const useCreateWidgetSite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: widgetSiteRepository.createWidgetSite,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.widgetSites }),
+  });
+};
+
+export const useUpdateWidgetSite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      data,
+    }: {
+      id: string;
+      data: Parameters<typeof widgetSiteRepository.updateWidgetSite>[1];
+    }) => widgetSiteRepository.updateWidgetSite(id, data),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.widgetSites }),
+  });
+};
+
+export const useDeleteWidgetSite = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: widgetSiteRepository.deleteWidgetSite,
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.widgetSites }),
+  });
+};

--- a/web/src/lib/api/repository.ts
+++ b/web/src/lib/api/repository.ts
@@ -8,6 +8,7 @@ import { createKnowledgeRepository } from "@nepp-chan/shared/api/repository/know
 import { createPersonaRepository } from "@nepp-chan/shared/api/repository/persona-repository";
 import { createPollRepository } from "@nepp-chan/shared/api/repository/poll-repository";
 import { createThreadRepository } from "@nepp-chan/shared/api/repository/thread-repository";
+import { createWidgetSiteRepository } from "@nepp-chan/shared/api/repository/widget-site-repository";
 
 import { API_BASE, client } from "./client";
 
@@ -25,3 +26,4 @@ export const knowledgeRepository = createKnowledgeRepository(client, API_BASE);
 export const personaRepository = createPersonaRepository(client);
 export const pollRepository = createPollRepository(client);
 export const threadRepository = createThreadRepository(client);
+export const widgetSiteRepository = createWidgetSiteRepository(client);

--- a/widget/CLAUDE.md
+++ b/widget/CLAUDE.md
@@ -12,6 +12,7 @@
 - iframe は lp と同一 origin（`nepp-chan.ai/widget/`）配信。fetch の Origin は配信元になるため、ローダーを貼る host サイトのオリジンは API の CORS 許可リストに無関係。
 - iframe → loader の「閉じる」連携は `postMessage`。loader 側で `event.origin`（iframeSrc のオリジン）と `event.source`（iframe の contentWindow）を検証してから閉じる。
 - loader は iframe の src に `?host=<埋め込み元の origin + pathname>` を付ける。iframe は自ドメイン配信で `Referer` が使えないため、どのページに置かれた widget かはこのクエリでしか分からない。GA の `page_location` にそのまま乗るので、ページ別の利用状況はレポート上で切れる。host 側の URL に個人情報が乗りうるのでクエリ文字列とハッシュは落とす。値は自己申告なので認可には使えない。
+- iframe は上記 `host` クエリからホスト名だけを取り出し、チャット送信時に `siteHost` として API に渡す。サーバーは `widget_sites` テーブル（管理画面の「設置サイト」タブで super_admin が編集）に完全一致で登録があるときだけ、その行の instructions をねっぷちゃんに足す。`siteHost` は host 側の自己申告で偽装できるため、instructions に入るのは管理画面で登録されたテキストだけにしてある。パスは渡さない（閲覧ページ自体が機微になりうるうえ、会話に混ざると Mastra memory やペルソナ抽出に流入するため）。
 - ボタン設置 2500ms 後、`INITIAL_MESSAGE` の挨拶文を吹き出しティーザーとして表示する。localStorage（`nepp-chan-widget:teaser-dismissed-at`）に閉じた時刻を記録し、7 日以内は再表示しない。
 
 ## host への導入

--- a/widget/CLAUDE.md
+++ b/widget/CLAUDE.md
@@ -49,6 +49,7 @@ pnpm --filter @nepp-chan/widget test   # WidgetChat / loader の単体テスト
 - `src/WidgetChat.tsx` — フローティングウィジェット専用のチャット UI（フルハイト・連続会話・ヘッダーに閉じるボタン）。マウント時に匿名セッション取得 → スレッド作成の順で bootstrap し、`@ai-sdk/react` の `DefaultChatTransport` で `/threads/{threadId}/chat` を叩く
 - `src/anonymous-session.ts` — `acquireAnonymousSession`。匿名 JWT の取得・localStorage 読み書き
 - `src/thread.ts` — `createThread`。`POST /threads` で新規スレッドを作成
+- `src/site-host.ts` — `resolveSiteHost`。loader が付ける `host` クエリからホスト名だけを取り出す
 - `src/iframe-entry.tsx` — iframe 中身。`WidgetChat` をマウント
 - `src/iframe.css` — Tailwind + shared スタイルを iframe に読み込む
 - `src/messages.ts` — `CLOSE_MESSAGE_TYPE`（loader と iframe で共有する postMessage の type）

--- a/widget/src/WidgetChat.test.tsx
+++ b/widget/src/WidgetChat.test.tsx
@@ -250,6 +250,56 @@ describe("WidgetChat", () => {
     expect(body).not.toHaveProperty("intent");
   });
 
+  it("設置サイトのホストを body に載せて送る", async () => {
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.post(CHAT_URL, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return buildChatStreamResponse("答えだよ");
+      }),
+    );
+    render(
+      <WidgetChat
+        apiUrl={API_URL}
+        webUrl={WEB_URL}
+        siteHost="www.vill.otoineppu.hokkaido.jp"
+      />,
+    );
+    await waitForReady();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "移住の補助金はある？" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("答えだよ")).toBeTruthy();
+    });
+
+    expect(body.siteHost).toBe("www.vill.otoineppu.hokkaido.jp");
+  });
+
+  it("設置サイトのホストが無ければ siteHost を送らない", async () => {
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.post(CHAT_URL, async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return buildChatStreamResponse("答えだよ");
+      }),
+    );
+    renderWidgetChat();
+    await waitForReady();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "移住の補助金はある？" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("答えだよ")).toBeTruthy();
+    });
+
+    expect(body).not.toHaveProperty("siteHost");
+  });
+
   it("生成中は送信ボタンが停止ボタンに変わる", async () => {
     const deferred = buildDeferredChatStreamResponse();
     server.use(http.post(CHAT_URL, () => deferred.response));

--- a/widget/src/WidgetChat.tsx
+++ b/widget/src/WidgetChat.tsx
@@ -24,6 +24,7 @@ type Props = {
   apiUrl: string;
   webUrl: string;
   iconSrc?: string;
+  siteHost?: string;
 };
 
 const closeWidget = () => {
@@ -63,6 +64,7 @@ export const WidgetChat = ({
   apiUrl,
   webUrl,
   iconSrc = "/mascot/icon.png",
+  siteHost,
 }: Props) => {
   const [token, setToken] = useState<string | null>(null);
   const [threadId, setThreadId] = useState<string | null>(null);
@@ -93,11 +95,12 @@ export const WidgetChat = ({
           return {
             body: {
               message: messages[messages.length - 1],
+              ...(siteHost && { siteHost }),
             },
           };
         },
       }),
-    [apiUrl, threadId, token],
+    [apiUrl, threadId, token, siteHost],
   );
 
   const { messages, sendMessage, status, error, stop } = useChat({

--- a/widget/src/iframe-entry.tsx
+++ b/widget/src/iframe-entry.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { initAnalytics } from "./analytics";
+import { resolveSiteHost } from "./site-host";
 import "./iframe.css";
 import { WidgetChat } from "./WidgetChat";
 
@@ -14,6 +15,7 @@ createRoot(root).render(
     <WidgetChat
       apiUrl={import.meta.env.VITE_API_URL}
       webUrl={import.meta.env.VITE_WEB_URL}
+      siteHost={resolveSiteHost(location.search)}
     />
   </StrictMode>,
 );

--- a/widget/src/site-host.test.ts
+++ b/widget/src/site-host.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSiteHost } from "./site-host";
+
+describe("resolveSiteHost", () => {
+  it("loader が渡す host クエリからホスト名だけを取り出す", () => {
+    expect(
+      resolveSiteHost("?host=https://www.vill.otoineppu.hokkaido.jp/kurashi/"),
+    ).toBe("www.vill.otoineppu.hokkaido.jp");
+  });
+
+  it("host クエリが無ければ未指定にする", () => {
+    expect(resolveSiteHost("")).toBeUndefined();
+  });
+
+  it("URL として解釈できない host は未指定にする", () => {
+    expect(resolveSiteHost("?host=not-a-url")).toBeUndefined();
+  });
+});

--- a/widget/src/site-host.ts
+++ b/widget/src/site-host.ts
@@ -1,0 +1,9 @@
+export const resolveSiteHost = (search: string) => {
+  const host = new URLSearchParams(search).get("host");
+  if (!host) return undefined;
+  try {
+    return new URL(host).hostname;
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
## Summary

- 外部サイトに埋め込んだねっぷちゃんが「どのサイトに設置されているか」を文脈として持てるようにする
- 役場ホームページで開かれたときは、行政手続き・窓口案内を優先し、公式ページの URL を添えて答える
- 許可ドメインとサイトごとの指示は、スーパー管理者が管理画面の「設置サイト」タブで編集できる

## 主な変更内容

### 文脈が届くまでの流れ

1. loader は既に GA 用に iframe の src へ `?host=<origin + pathname>` を付けている
2. iframe 側の `resolveSiteHost` がそこからホスト名だけを取り出す
3. `WidgetChat` がチャット送信ごとに body の `siteHost` として送る
4. `chat` ルートが `widget_sites` を完全一致で引き、見つかれば instructions を `## 設置サイトの文脈` として system prompt に差し込む

### 安全側に倒した点

`siteHost` はクライアント由来で偽装できるため、照合キーとしてのみ使い、プロンプトに入るのは管理画面で登録されたテキストだけにしている。偽装しても「一致しない」方向にしか倒れない。

パスは送っていない。役場ホームページは閲覧ページ自体が機微になりうるうえ、会話に混ざると `mastra_messages`（30 日保管）やペルソナ抽出に流入する。instructions はリクエストごとに組み立てるだけなので保存されない。

ホスト名は `normalizeSiteHost` で小文字化と先頭 `www.` の除去だけを行い、完全一致で照合する。サフィックス一致にしないため `evil-vill.otoineppu.hokkaido.jp` のような詐称は通らない。

### データと管理

`widget_sites` テーブルを追加し、役場ホームページの初期行はマイグレーションで投入する。このリポジトリで DML を含むマイグレーションは初めてで、デプロイ直後から動かすためのブートストラップという位置づけ。以降の編集は管理画面から行う。

管理 API は `requireRole("super_admin")` をサブアプリ入口に効かせている。

## Test plan

- [ ] dev にデプロイ後、役場ホームページ相当のドメインからウィジェットを開き、窓口案内の質問で公式ページの URL が返ることを確認する
- [ ] 未登録ドメインに設置した場合、これまでと同じ応答になることを確認する
- [ ] スーパー管理者以外のロールで「設置サイト」タブが見えないこと、API が 403 を返すことを確認する
- [ ] 管理画面からドメインと指示を追加・編集・削除し、チャットの応答に反映されることを確認する