### PR TITLE
fix(deps): pnpm-lock.yaml の重複キーを除去

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5259,11 +5259,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.18:
-    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   needle@2.9.1:
     resolution: {integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==}
     engines: {node: '>= 4.4.x'}
@@ -5520,10 +5515,6 @@ packages:
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
-  postcss@8.5.26:
-    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -11770,8 +11761,6 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanoid@3.3.18: {}
-
   needle@2.9.1(supports-color@10.2.2):
     dependencies:
       debug: 3.2.7(supports-color@10.2.2)
@@ -12022,12 +12011,6 @@ snapshots:
   pluralize@8.0.0: {}
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.5.26:
-    dependencies:
-      nanoid: 3.3.18
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:


### PR DESCRIPTION
## 背景

Dependabot PR を順次マージしている途中で、残りの PR の rebase が次のコメントで止まった。

> Dependabot can't parse your pnpm-lock.yaml. Because of this, Dependabot cannot update this pull request.

`pnpm-lock.yaml` を重複キー禁止で厳格パースすると、`nanoid@3.3.18` と `postcss@8.5.26` が `packages:` / `snapshots:` の両セクションでそれぞれ同一内容のまま 2 回定義されていた。pnpm は last-wins で読めるので CI は緑のままだが、Dependabot の YAML パーサはこれを拒否するため rebase 不能になる。

## 変更

重複した 4 ブロック（17 行）を削除。内容が完全に同一であることを確認済みで、解決済みバージョンは 1 件も変わらない。

## 確認

- 重複キー禁止の厳格 YAML パース: OK
- `pnpm install --frozen-lockfile`: 成功（pnpm による lockfile の書き換えなし）
- 差分は `pnpm-lock.yaml` の削除 17 行のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UMCVn5CgL3skYkDe9HWJd