### PR TITLE
fix(web): 期限切れ匿名セッションを自動再発行する

### DIFF
--- a/web/src/app/chat/hooks/useAnonymousSession.test.ts
+++ b/web/src/app/chat/hooks/useAnonymousSession.test.ts
@@ -8,6 +8,9 @@ import { useAnonymousSession } from "./useAnonymousSession";
 
 const API = "http://localhost:8787";
 
+const sessionToken = (expiresAt: number) =>
+  `header.${btoa(JSON.stringify({ exp: expiresAt }))}.signature`;
+
 beforeEach(() => {
   localStorage.clear();
 });
@@ -18,12 +21,45 @@ afterEach(() => {
 
 describe("useAnonymousSession", () => {
   it("既にトークンがあれば即 isReady=true・isFirstVisit=false", async () => {
-    setSessionToken("existing");
+    setSessionToken(sessionToken(Math.floor(Date.now() / 1000) + 60));
 
     const { result } = renderHook(() => useAnonymousSession());
 
     expect(result.current.isReady).toBe(true);
     expect(result.current.isFirstVisit).toBe(false);
+  });
+
+  it("期限切れトークンなら API から再取得する", async () => {
+    setSessionToken(sessionToken(Math.floor(Date.now() / 1000) - 1));
+    server.use(
+      http.post(`${API}/auth/anonymous-session`, () =>
+        HttpResponse.json({ token: "renewed-token", resourceId: "res-2" }),
+      ),
+    );
+
+    const { result } = renderHook(() => useAnonymousSession());
+
+    expect(result.current.isReady).toBe(false);
+    expect(result.current.isFirstVisit).toBe(true);
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(getSessionToken()).toBe("renewed-token");
+    expect(getResourceId()).toBe("res-2");
+  });
+
+  it("壊れたトークンなら API から再取得する", async () => {
+    setSessionToken("invalid-token");
+    server.use(
+      http.post(`${API}/auth/anonymous-session`, () =>
+        HttpResponse.json({ token: "renewed-token", resourceId: "res-3" }),
+      ),
+    );
+
+    const { result } = renderHook(() => useAnonymousSession());
+
+    expect(result.current.isReady).toBe(false);
+    await waitFor(() => expect(result.current.isReady).toBe(true));
+    expect(getSessionToken()).toBe("renewed-token");
+    expect(getResourceId()).toBe("res-3");
   });
 
   it("トークン無しなら API を叩いて取得・isFirstVisit=true", async () => {

--- a/web/src/app/chat/hooks/useAnonymousSession.ts
+++ b/web/src/app/chat/hooks/useAnonymousSession.ts
@@ -1,11 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 import { API_BASE } from "~/lib/api/client";
-import { getSessionToken, setSessionToken } from "~/lib/auth-token";
+import {
+  getSessionToken,
+  removeSessionToken,
+  setSessionToken,
+} from "~/lib/auth-token";
 import { setResourceId } from "~/lib/resource";
 
 type SessionState = {
   isReady: boolean;
-  /** マウント時に session token が未保存だった = この訪問が初回 */
   isFirstVisit: boolean;
 };
 
@@ -22,14 +25,33 @@ const acquireSessionToken = async (): Promise<{
   return res.json();
 };
 
+const isSessionTokenActive = (token: string) => {
+  try {
+    const payload = token.split(".")[1];
+    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+    const { exp } = JSON.parse(atob(padded)) as { exp?: unknown };
+    return typeof exp === "number" && exp > Date.now() / 1000;
+  } catch {
+    return false;
+  }
+};
+
 export const useAnonymousSession = (): SessionState => {
-  const initialHadToken = useRef(
-    typeof window !== "undefined" && !!getSessionToken(),
+  const initialToken = useRef(
+    typeof window !== "undefined" ? getSessionToken() : null,
   );
-  const [isReady, setIsReady] = useState(initialHadToken.current);
+  const initialHadActiveToken = useRef(
+    !!initialToken.current && isSessionTokenActive(initialToken.current),
+  );
+  const [isReady, setIsReady] = useState(initialHadActiveToken.current);
 
   useEffect(() => {
     if (isReady) return;
+
+    if (initialToken.current) {
+      removeSessionToken();
+    }
 
     acquireSessionToken()
       .then(({ token, resourceId }) => {
@@ -43,5 +65,5 @@ export const useAnonymousSession = (): SessionState => {
       });
   }, [isReady]);
 
-  return { isReady, isFirstVisit: !initialHadToken.current };
+  return { isReady, isFirstVisit: !initialHadActiveToken.current };
 };

--- a/web/src/app/chat/hooks/useThreadManager.ts
+++ b/web/src/app/chat/hooks/useThreadManager.ts
@@ -30,7 +30,8 @@ export const useThreadManager = () => {
   const [initialMessage, setInitialMessage] = useState<InitialMessage>();
   const hasInitialized = useRef(false);
 
-  const { data: threadsData, isSuccess: threadsLoaded } = useThreads();
+  const { data: threadsData, isSuccess: threadsLoaded } =
+    useThreads(isSessionReady);
   const threads = useMemo(() => threadsData?.threads ?? [], [threadsData]);
 
   const createThreadMutation = useCreateThread();

--- a/web/src/app/chat/hooks/useThreads.test.ts
+++ b/web/src/app/chat/hooks/useThreads.test.ts
@@ -1,6 +1,6 @@
 import { act, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setAuthToken } from "~/lib/auth-token";
 import { server } from "~/test/msw-server";
 import { renderHookWithQuery } from "~/test/query";
@@ -50,6 +50,16 @@ describe("useThreads", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.threads).toHaveLength(1);
+  });
+
+  it("無効なら threads を取得しない", () => {
+    const handler = vi.fn();
+    server.use(http.get(`${API}/threads`, handler));
+
+    const { result } = renderHookWithQuery(() => useThreads(false));
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 

--- a/web/src/app/chat/hooks/useThreads.ts
+++ b/web/src/app/chat/hooks/useThreads.ts
@@ -10,10 +10,11 @@ export const threadKeys = {
     [...threadKeys.all, "messages", threadId] as const,
 };
 
-export const useThreads = (page = 0, perPage = 20) =>
+export const useThreads = (enabled = true, page = 0, perPage = 20) =>
   useQuery({
     queryKey: threadKeys.list(),
     queryFn: () => threadRepository.fetchThreads(page, perPage),
+    enabled,
   });
 
 export const useThread = (threadId: string) =>


### PR DESCRIPTION
## Summary
- 期限切れまたは不正な匿名セッショントークンを検出し、新しいセッションを自動発行する
- 匿名セッションの準備が完了するまでスレッド取得を待機する
- location QRアクセス時に認証初期化の競合で挨拶が始まらない状態を防ぐ

## 主な変更内容
保存済みJWTの `exp` を起動時に確認し、利用できない場合は保存済みトークンを削除して `/auth/anonymous-session` から再取得します。新しい匿名セッションの取得前にスレッドAPIが実行されないよう、クエリの `enabled` をセッション準備状態と連動させました。

過去の匿名セッションとは別の `resourceId` が発行されるため、期限切れ前のスレッドは引き継ぎません。

Refs #842

## Test plan
- [x] 有効なトークンでは再発行しない
- [x] 期限切れトークンを自動再発行する
- [x] 不正なトークンを自動再発行する
- [x] セッション準備前はスレッドAPIを呼ばない
- [x] web全テスト（676件）
- [x] lint・型チェック