### PR TITLE
feat(knowledge): curated 区分を新設し検証用ナレッジを追加

### DIFF
--- a/dataset/v5/src/curated/spots/otoineppu-tokyo.md
+++ b/dataset/v5/src/curated/spots/otoineppu-tokyo.md
@@ -1,0 +1,24 @@
+---
+title: 音威子府TOKYO（東京・四谷三丁目の音威子府そばの店）
+category: お店・スポット
+source_type: curated
+source_authority: 2
+verified_at: '2026-08-30'
+url: 'https://peraichi.com/landing_pages/view/otoineppu'
+---
+# 音威子府TOKYO
+
+> 営業時間・メニュー等の最新情報は、下記の公式サイト・SNS で確認してください。
+
+東京都新宿区舟町（四谷三丁目駅近くの杉大門通り）にある、音威子府そばを提供する蕎麦店。2019年10月に開店した、「音威子府」の名を冠する東京で初めての蕎麦店。店主が、お土産にもらった音威子府そばの黒さと味に魅了されたことがきっかけで開いた。
+
+音威子府そば（黒い蕎麦）と更科そば（白い蕎麦）の2種類を提供し、夜は日本酒と肴も楽しめる。
+
+村内の畠山製麺が2022年8月末に廃業し伝統の黒いそばが途絶えかけた際には、千葉県茂原市の「音威子府食堂」とともに約1年かけて麺を再開発し、2023年1月に新しい黒いそばを完成させた。音威子府そばの味を村の外で受け継ぐ存在。
+
+## 情報源
+
+- 公式サイト: https://peraichi.com/landing_pages/view/otoineppu
+- X: https://x.com/otoineppu_tokyo
+- Instagram: https://www.instagram.com/otoineppu.tokyo/
+- 紹介記事: 文春オンライン（2019-10）、お店の学校（2024-03）、北海道LOMO（2023-12）

--- a/dataset/v5/src/curated/spots/usagi.md
+++ b/dataset/v5/src/curated/spots/usagi.md
@@ -1,0 +1,17 @@
+---
+title: お食事処うさぎ（開業準備中の食事処）
+category: お店・スポット
+source_type: curated
+source_authority: 2
+verified_at: '2026-08-30'
+url: 'https://www.instagram.com/oshokujidokoro.usagi/'
+---
+# お食事処うさぎ
+
+> 開業準備中の店舗です。最新情報は公式 Instagram で確認してください。
+
+音威子府村に開業準備中の食事処。アスパラ農家が営む店で、自家栽培の旬の野菜が味わえる。昼はおといねっぷ蕎麦や定食など、夜は居酒屋として営業予定で、宴会の受付もある。2026年夏に一時的なオープンを行い、正式な営業開始に向けて準備を進めている。
+
+## 情報源
+
+- 公式 Instagram: https://www.instagram.com/oshokujidokoro.usagi/

--- a/knowledge/curated/spots/otoineppu-tokyo.md
+++ b/knowledge/curated/spots/otoineppu-tokyo.md
@@ -1,0 +1,24 @@
+---
+title: 音威子府TOKYO（東京・四谷三丁目の音威子府そばの店）
+category: お店・スポット
+source_type: curated
+source_authority: 2
+verified_at: '2026-08-30'
+url: 'https://peraichi.com/landing_pages/view/otoineppu'
+---
+# 音威子府TOKYO
+
+> 営業時間・メニュー等の最新情報は、下記の公式サイト・SNS で確認してください。
+
+東京都新宿区舟町（四谷三丁目駅近くの杉大門通り）にある、音威子府そばを提供する蕎麦店。2019年10月に開店した、「音威子府」の名を冠する東京で初めての蕎麦店。店主が、お土産にもらった音威子府そばの黒さと味に魅了されたことがきっかけで開いた。
+
+音威子府そば（黒い蕎麦）と更科そば（白い蕎麦）の2種類を提供し、夜は日本酒と肴も楽しめる。
+
+村内の畠山製麺が2022年8月末に廃業し伝統の黒いそばが途絶えかけた際には、千葉県茂原市の「音威子府食堂」とともに約1年かけて麺を再開発し、2023年1月に新しい黒いそばを完成させた。音威子府そばの味を村の外で受け継ぐ存在。
+
+## 情報源
+
+- 公式サイト: https://peraichi.com/landing_pages/view/otoineppu
+- X: https://x.com/otoineppu_tokyo
+- Instagram: https://www.instagram.com/otoineppu.tokyo/
+- 紹介記事: 文春オンライン（2019-10）、お店の学校（2024-03）、北海道LOMO（2023-12）

--- a/knowledge/curated/spots/usagi.md
+++ b/knowledge/curated/spots/usagi.md
@@ -1,0 +1,17 @@
+---
+title: お食事処うさぎ（開業準備中の食事処）
+category: お店・スポット
+source_type: curated
+source_authority: 2
+verified_at: '2026-08-30'
+url: 'https://www.instagram.com/oshokujidokoro.usagi/'
+---
+# お食事処うさぎ
+
+> 開業準備中の店舗です。最新情報は公式 Instagram で確認してください。
+
+音威子府村に開業準備中の食事処。アスパラ農家が営む店で、自家栽培の旬の野菜が味わえる。昼はおといねっぷ蕎麦や定食など、夜は居酒屋として営業予定で、宴会の受付もある。2026年夏に一時的なオープンを行い、正式な営業開始に向けて準備を進めている。
+
+## 情報源
+
+- 公式 Instagram: https://www.instagram.com/oshokujidokoro.usagi/


### PR DESCRIPTION
## 概要

公式サイトのミラー（villotoinep / otoko）とは別に、運営が編集・検証して作成するナレッジの置き場として `knowledge/curated/` を新設し、スポット2件を検証用に追加します。

## 変更内容

- `dataset/v5/src/curated/spots/` と `knowledge/curated/spots/`（ミラー）に md を2件追加
- 本文は「情報源の URL + 正確な概要」のみのミニマル構成
  - 営業時間・価格などの可変情報は書かず、冒頭で公式 SNS 等への確認を促す
  - 個人名は掲載しない
- frontmatter に `source_type: curated` / `source_authority: 2` / `verified_at`（人間レビュー日）を付与し、公式ミラー由来と区別

## 検証

- 記載内容は一次情報源（公式 SNS プロフィール・紹介記事）を直接確認して裏取り済み
- Vectorize へのアップロードはマージ後に別途実施