### PR TITLE
refactor(server): SQL を repository に集約する

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -62,6 +62,15 @@ const route = createRoute({
 app.openapi(route, async (c) => { ... });
 ```
 
+### データアクセス
+
+SQL を書けるのは `repository/` だけ。`services/` と `routes/` は repository のメソッドを呼ぶ。
+
+- どの repository に置くかは、結合したテーブル数ではなく **返す行・変更する行がどのテーブルのものか** で決める。JOIN の相手は問わない
+- 主テーブルが無い横断処理（ユーザーデータ一括削除・保管期間削除など）は service に置き、service が各 repository を順に呼ぶ
+- repository のメソッド名は意図で名付ける（`deleteCreatedBefore` など）。`SQL` 断片を引数で受け取ると SQL が service に戻るので禁止
+- 単純な CRUD は routes → repository の直呼びでよい。転送するだけの service は挟まない
+
 ### エラーハンドリング
 
 ```typescript

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -11,6 +11,7 @@ Cloudflare Workers で動作するバックエンド API。Hono + Mastra AI フ�
 | ツール           | `mastra/tools/*-tool.ts`               |
 | DB スキーマ      | `db/schema.ts`                         |
 | ビジネスロジック | `services/`                            |
+| SQL・データアクセス | `repository/`                       |
 | 型定義           | 各ファイル内、または `schemas/`        |
 
 ## ディレクトリ構成
@@ -68,7 +69,7 @@ SQL を書けるのは `repository/` だけ。`services/` と `routes/` は repo
 
 - どの repository に置くかは、結合したテーブル数ではなく **返す行・変更する行がどのテーブルのものか** で決める。JOIN の相手は問わない
 - 主テーブルが無い横断処理（ユーザーデータ一括削除・保管期間削除など）は service に置き、service が各 repository を順に呼ぶ
-- repository のメソッド名は意図で名付ける（`deleteCreatedBefore` など）。`SQL` 断片を引数で受け取ると SQL が service に戻るので禁止
+- repository のメソッド名は意図で名付ける（`deleteCreatedBefore` など）。service / routes から `SQL` 断片を受け取る API にしない
 - 単純な CRUD は routes → repository の直呼びでよい。転送するだけの service は挟まない
 
 ### エラーハンドリング

--- a/server/src/repository/data-retention-log-repository.test.ts
+++ b/server/src/repository/data-retention-log-repository.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+import { dataRetentionLogs } from "~/db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+const { dataRetentionLogRepository } = await import(
+  "./data-retention-log-repository"
+);
+
+const d1 = {} as D1Database;
+
+const log = (id: string, executedAt: string) => ({
+  id,
+  executedAt,
+  targetTable: "llm_usage",
+  deletedCount: 3,
+  createdAt: executedAt,
+});
+
+describe("dataRetentionLogRepository", () => {
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    testDbHolder.db = db;
+  });
+
+  it("記録した実行ログを取得できる", async () => {
+    await dataRetentionLogRepository.create(
+      d1,
+      log("l-1", "2026-06-01T00:00:00.000Z"),
+    );
+
+    const rows = await db.select().from(dataRetentionLogs).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.deletedCount).toBe(3);
+  });
+
+  it("実行時刻が期限より前のログを削除する", async () => {
+    await db
+      .insert(dataRetentionLogs)
+      .values(log("l-old", "2026-01-01T00:00:00.000Z"));
+    await db
+      .insert(dataRetentionLogs)
+      .values(log("l-new", "2026-06-01T00:00:00.000Z"));
+
+    const deleted = await dataRetentionLogRepository.deleteExecutedBefore(
+      d1,
+      "2026-03-01T00:00:00.000Z",
+    );
+
+    expect(deleted).toBe(1);
+    const remaining = await db.select().from(dataRetentionLogs).all();
+    expect(remaining.map((r) => r.id)).toEqual(["l-new"]);
+  });
+});

--- a/server/src/repository/data-retention-log-repository.ts
+++ b/server/src/repository/data-retention-log-repository.ts
@@ -1,0 +1,22 @@
+import { sql } from "drizzle-orm";
+
+import { createDb, dataRetentionLogs, type NewDataRetentionLog } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
+
+export const dataRetentionLogRepository = {
+  async create(d1: D1Database, input: NewDataRetentionLog) {
+    const db = createDb(d1);
+
+    await db.insert(dataRetentionLogs).values(input);
+  },
+
+  async deleteExecutedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      dataRetentionLogs,
+      sql`datetime(${dataRetentionLogs.executedAt}) < datetime(${cutoff})`,
+    );
+  },
+};

--- a/server/src/repository/delete-with-count.test.ts
+++ b/server/src/repository/delete-with-count.test.ts
@@ -1,0 +1,49 @@
+import { sql } from "drizzle-orm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+import { type DbClient, dataRetentionLogs } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
+
+const log = (id: string, executedAt: string) => ({
+  id,
+  executedAt,
+  targetTable: "llm_usage",
+  deletedCount: 0,
+  createdAt: executedAt,
+});
+
+describe("deleteWithCount", () => {
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  it("条件に一致した行を削除して件数を返す", async () => {
+    await db.insert(dataRetentionLogs).values(log("l-1", "2026-06-01"));
+    await db.insert(dataRetentionLogs).values(log("l-2", "2026-06-02"));
+
+    const deleted = await deleteWithCount(
+      db as unknown as DbClient,
+      dataRetentionLogs,
+      sql`${dataRetentionLogs.executedAt} = '2026-06-01'`,
+    );
+
+    expect(deleted).toBe(1);
+    expect(await db.select().from(dataRetentionLogs).all()).toHaveLength(1);
+  });
+
+  it("一致する行が無ければ DELETE を発行しない", async () => {
+    const spy = vi.spyOn(db, "delete");
+
+    const deleted = await deleteWithCount(
+      db as unknown as DbClient,
+      dataRetentionLogs,
+      sql`${dataRetentionLogs.executedAt} = '2026-06-01'`,
+    );
+
+    expect(deleted).toBe(0);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/repository/delete-with-count.test.ts
+++ b/server/src/repository/delete-with-count.test.ts
@@ -2,8 +2,24 @@ import { sql } from "drizzle-orm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
-import { type DbClient, dataRetentionLogs } from "~/db";
-import { deleteWithCount } from "./delete-with-count";
+import { dataRetentionLogs } from "~/db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+const { createDb } = await import("~/db");
+const { deleteWithCount } = await import("./delete-with-count");
+
+const fakeD1 = {} as D1Database;
 
 const log = (id: string, executedAt: string) => ({
   id,
@@ -13,11 +29,15 @@ const log = (id: string, executedAt: string) => ({
   createdAt: executedAt,
 });
 
+const executedOn = (executedAt: string) =>
+  sql`${dataRetentionLogs.executedAt} = ${executedAt}`;
+
 describe("deleteWithCount", () => {
   let db: TestDb;
 
   beforeEach(async () => {
     db = await createTestDb();
+    testDbHolder.db = db;
   });
 
   it("条件に一致した行を削除して件数を返す", async () => {
@@ -25,22 +45,23 @@ describe("deleteWithCount", () => {
     await db.insert(dataRetentionLogs).values(log("l-2", "2026-06-02"));
 
     const deleted = await deleteWithCount(
-      db as unknown as DbClient,
+      createDb(fakeD1),
       dataRetentionLogs,
-      sql`${dataRetentionLogs.executedAt} = '2026-06-01'`,
+      executedOn("2026-06-01"),
     );
 
     expect(deleted).toBe(1);
-    expect(await db.select().from(dataRetentionLogs).all()).toHaveLength(1);
+    const remaining = await db.select().from(dataRetentionLogs).all();
+    expect(remaining.map((r) => r.id)).toEqual(["l-2"]);
   });
 
   it("一致する行が無ければ DELETE を発行しない", async () => {
     const spy = vi.spyOn(db, "delete");
 
     const deleted = await deleteWithCount(
-      db as unknown as DbClient,
+      createDb(fakeD1),
       dataRetentionLogs,
-      sql`${dataRetentionLogs.executedAt} = '2026-06-01'`,
+      executedOn("2026-06-01"),
     );
 
     expect(deleted).toBe(0);

--- a/server/src/repository/delete-with-count.ts
+++ b/server/src/repository/delete-with-count.ts
@@ -1,0 +1,25 @@
+import type { SQL } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import type { SQLiteTable } from "drizzle-orm/sqlite-core";
+
+import type { DbClient } from "~/db";
+
+// 削除件数は D1 のドライバ差を避けて COUNT で取る。
+// 0 件のときに DELETE を撃たないのは Cron の空振りで書き込みを発生させないため
+export const deleteWithCount = async (
+  db: DbClient,
+  table: SQLiteTable,
+  where: SQL,
+) => {
+  const row = await db
+    .select({ c: sql<number>`COUNT(*)` })
+    .from(table)
+    .where(where)
+    .get();
+
+  const count = Number(row?.c ?? 0);
+  if (count > 0) {
+    await db.delete(table).where(where);
+  }
+  return count;
+};

--- a/server/src/repository/delete-with-count.ts
+++ b/server/src/repository/delete-with-count.ts
@@ -4,6 +4,7 @@ import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 
 import type { DbClient } from "~/db";
 
+// DELETE の戻り値は D1 が meta.changes、libsql が rowsAffected で形が違う
 export const deleteWithCount = async (
   db: DbClient,
   table: SQLiteTable,

--- a/server/src/repository/delete-with-count.ts
+++ b/server/src/repository/delete-with-count.ts
@@ -4,8 +4,6 @@ import type { SQLiteTable } from "drizzle-orm/sqlite-core";
 
 import type { DbClient } from "~/db";
 
-// 削除件数は D1 のドライバ差を避けて COUNT で取る。
-// 0 件のときに DELETE を撃たないのは Cron の空振りで書き込みを発生させないため
 export const deleteWithCount = async (
   db: DbClient,
   table: SQLiteTable,

--- a/server/src/repository/feedback-repository.test.ts
+++ b/server/src/repository/feedback-repository.test.ts
@@ -298,4 +298,25 @@ describe("feedbackRepository", () => {
       expect(found?.resolvedAt).toBeNull();
     });
   });
+
+  describe("deleteCreatedBefore", () => {
+    it("期限より前のフィードバックを削除する", async () => {
+      await feedbackRepository.create(
+        fakeD1,
+        baseInput({ id: "f-old", createdAt: "2029-01-01T00:00:00Z" }),
+      );
+      await feedbackRepository.create(
+        fakeD1,
+        baseInput({ id: "f-new", createdAt: "2031-01-01T00:00:00Z" }),
+      );
+
+      const deleted = await feedbackRepository.deleteCreatedBefore(
+        fakeD1,
+        "2030-01-01T00:00:00Z",
+      );
+
+      expect(deleted).toBe(1);
+      expect(await feedbackRepository.findById(fakeD1, "f-old")).toBeNull();
+    });
+  });
 });

--- a/server/src/repository/feedback-repository.test.ts
+++ b/server/src/repository/feedback-repository.test.ts
@@ -244,10 +244,10 @@ describe("feedbackRepository", () => {
       expect(await feedbackRepository.findById(fakeD1, "f-3")).not.toBeNull();
     });
 
-    it("該当が無くてもエラーにならない", async () => {
+    it("該当が無ければ 0 件を返す", async () => {
       await expect(
         feedbackRepository.deleteByThreadId(fakeD1, "ghost"),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe(0);
     });
   });
 

--- a/server/src/repository/feedback-repository.ts
+++ b/server/src/repository/feedback-repository.ts
@@ -6,6 +6,7 @@ import {
   messageFeedback,
   type NewMessageFeedback,
 } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 type CreateInput = Omit<NewMessageFeedback, "id"> & { id: string };
 
@@ -154,6 +155,16 @@ export const feedbackRepository = {
       .get();
 
     return result?.count ?? 0;
+  },
+
+  async deleteCreatedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      messageFeedback,
+      sql`datetime(${messageFeedback.createdAt}) < datetime(${cutoff})`,
+    );
   },
 
   async deleteByThreadId(d1: D1Database, threadId: string) {

--- a/server/src/repository/feedback-repository.ts
+++ b/server/src/repository/feedback-repository.ts
@@ -170,9 +170,11 @@ export const feedbackRepository = {
   async deleteByThreadId(d1: D1Database, threadId: string) {
     const db = createDb(d1);
 
-    await db
-      .delete(messageFeedback)
-      .where(eq(messageFeedback.threadId, threadId));
+    return deleteWithCount(
+      db,
+      messageFeedback,
+      eq(messageFeedback.threadId, threadId),
+    );
   },
 
   async delete(d1: D1Database, id: string) {

--- a/server/src/repository/llm-usage-repository.test.ts
+++ b/server/src/repository/llm-usage-repository.test.ts
@@ -222,4 +222,19 @@ describe("llmUsageRepository", () => {
       expect(rows.map((r) => Number(r.turnIndex))).toEqual([1, 2]);
     });
   });
+
+  describe("deleteCreatedBefore", () => {
+    it("期限より前の行を削除する", async () => {
+      await insert(db, { createdAt: "2026-01-01T00:00:00.000Z" });
+      await insert(db, { createdAt: "2026-06-01T00:00:00.000Z" });
+
+      const deleted = await llmUsageRepository.deleteCreatedBefore(
+        d1,
+        "2026-03-01T00:00:00.000Z",
+      );
+
+      expect(deleted).toBe(1);
+      expect(await db.select().from(llmUsage).all()).toHaveLength(1);
+    });
+  });
 });

--- a/server/src/repository/llm-usage-repository.test.ts
+++ b/server/src/repository/llm-usage-repository.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+import { llmUsage, type NewLlmUsage } from "~/db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+const { llmUsageRepository } = await import("./llm-usage-repository");
+
+const d1 = {} as D1Database;
+
+let seq = 0;
+
+const usageRow = (overrides: Partial<NewLlmUsage> = {}): NewLlmUsage => ({
+  id: `usage-${++seq}`,
+  model: "gpt-5-mini",
+  source: "chat",
+  inputTokens: 100,
+  outputTokens: 200,
+  reasoningTokens: 0,
+  cachedInputTokens: 0,
+  totalTokens: 300,
+  costUsd: 0.001,
+  createdAt: "2026-06-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const insert = async (db: TestDb, overrides: Partial<NewLlmUsage> = {}) => {
+  await db.insert(llmUsage).values(usageRow(overrides));
+};
+
+describe("llmUsageRepository", () => {
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    testDbHolder.db = db;
+  });
+
+  describe("create", () => {
+    it("記録した行を取得できる", async () => {
+      await llmUsageRepository.create(d1, usageRow({ model: "gpt-5.6" }));
+
+      const rows = await db.select().from(llmUsage).all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.model).toBe("gpt-5.6");
+    });
+  });
+
+  describe("countChatByThread", () => {
+    it("同一スレッドの source='chat' だけを数える", async () => {
+      await insert(db, { threadId: "t-1", source: "chat" });
+      await insert(db, { threadId: "t-1", source: "chat" });
+      await insert(db, { threadId: "t-1", source: "subagent" });
+      await insert(db, { threadId: "t-2", source: "chat" });
+
+      expect(await llmUsageRepository.countChatByThread(d1, "t-1")).toBe(2);
+    });
+
+    it("該当行が無ければ 0 を返す", async () => {
+      expect(await llmUsageRepository.countChatByThread(d1, "none")).toBe(0);
+    });
+  });
+
+  describe("sumByDateAndModel", () => {
+    it("JST の日付でグループ化する", async () => {
+      await insert(db, { createdAt: "2026-06-01T14:59:00.000Z" });
+      await insert(db, { createdAt: "2026-06-01T15:00:00.000Z" });
+
+      const rows = await llmUsageRepository.sumByDateAndModel(d1, {
+        from: "2026-06-01T00:00:00.000Z",
+      });
+
+      expect(rows.map((r) => r.date)).toEqual(["2026-06-01", "2026-06-02"]);
+    });
+
+    it("to を渡すと期間の上限が効く", async () => {
+      await insert(db, { createdAt: "2026-06-01T00:00:00.000Z" });
+      await insert(db, { createdAt: "2026-06-10T00:00:00.000Z" });
+
+      const rows = await llmUsageRepository.sumByDateAndModel(d1, {
+        from: "2026-06-01T00:00:00.000Z",
+        to: "2026-06-02T00:00:00.000Z",
+      });
+
+      expect(rows).toHaveLength(1);
+    });
+
+    it("cost_usd が NULL の行のトークンを legacy 列に振り分ける", async () => {
+      await insert(db, { costUsd: null, inputTokens: 10, outputTokens: 20 });
+      await insert(db, { costUsd: 0.5, inputTokens: 30, outputTokens: 40 });
+
+      const [row] = await llmUsageRepository.sumByDateAndModel(d1, {
+        from: "2026-06-01T00:00:00.000Z",
+      });
+
+      expect(Number(row?.inputTokens)).toBe(40);
+      expect(Number(row?.legacyInputTokens)).toBe(10);
+      expect(Number(row?.legacyOutputTokens)).toBe(20);
+      expect(Number(row?.persistedCostUsd)).toBe(0.5);
+    });
+  });
+
+  describe("sumByModel", () => {
+    it("期間外の行を除外してモデル別に合算する", async () => {
+      await insert(db, { model: "a", createdAt: "2026-06-01T00:00:00.000Z" });
+      await insert(db, { model: "a", createdAt: "2026-06-02T00:00:00.000Z" });
+      await insert(db, { model: "b", createdAt: "2026-06-09T00:00:00.000Z" });
+
+      const rows = await llmUsageRepository.sumByModel(d1, {
+        from: "2026-06-01T00:00:00.000Z",
+        to: "2026-06-08T00:00:00.000Z",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.model).toBe("a");
+      expect(Number(rows[0]?.totalTokens)).toBe(600);
+    });
+  });
+
+  describe("sumByCategory", () => {
+    const period = {
+      from: "2026-06-01T00:00:00.000Z",
+      to: "2026-06-08T00:00:00.000Z",
+    };
+
+    it("source が会話系なら conversation に分類する", async () => {
+      await insert(db, { source: "subagent" });
+
+      const [row] = await llmUsageRepository.sumByCategory(d1, period);
+      expect(row?.category).toBe("conversation");
+    });
+
+    it("embedding はスレッドに紐づくときだけ conversation に分類する", async () => {
+      await insert(db, { source: "embedding", threadId: "t-1" });
+      await insert(db, { source: "embedding", threadId: null });
+
+      const rows = await llmUsageRepository.sumByCategory(d1, period);
+      expect(new Set(rows.map((r) => r.category))).toEqual(
+        new Set(["conversation", "knowledge-base"]),
+      );
+    });
+
+    it("会話にも埋め込みにも当たらない source は batch に分類する", async () => {
+      await insert(db, { source: "weekly-report" });
+
+      const [row] = await llmUsageRepository.sumByCategory(d1, period);
+      expect(row?.category).toBe("batch");
+    });
+  });
+
+  describe("sumConversationByThread", () => {
+    const period = {
+      from: "2026-06-01T00:00:00.000Z",
+      to: "2026-06-08T00:00:00.000Z",
+    };
+
+    it("batch の行とスレッド無しの行を除外する", async () => {
+      await insert(db, { threadId: "t-1", source: "chat" });
+      await insert(db, { threadId: "t-2", source: "weekly-report" });
+      await insert(db, { threadId: null, source: "chat" });
+
+      const rows = await llmUsageRepository.sumConversationByThread(d1, period);
+
+      expect(rows.map((r) => r.threadId)).toEqual(["t-1"]);
+    });
+
+    it("chatCalls は source='chat' の件数だけを数える", async () => {
+      await insert(db, { threadId: "t-1", source: "chat" });
+      await insert(db, { threadId: "t-1", source: "chat" });
+      await insert(db, { threadId: "t-1", source: "subagent" });
+
+      const [row] = await llmUsageRepository.sumConversationByThread(
+        d1,
+        period,
+      );
+
+      expect(Number(row?.chatCalls)).toBe(2);
+      expect(Number(row?.totalTokens)).toBe(900);
+    });
+  });
+
+  describe("sumConversationByTurn", () => {
+    it("duration と応答時刻は source='chat' の行から取る", async () => {
+      await insert(db, {
+        threadId: "t-1",
+        source: "chat",
+        turnIndex: 1,
+        durationMs: 100,
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+      await insert(db, {
+        threadId: "t-1",
+        source: "subagent",
+        turnIndex: 1,
+        durationMs: 9999,
+        createdAt: "2026-06-01T01:00:00.000Z",
+      });
+
+      const [row] = await llmUsageRepository.sumConversationByTurn(d1, "t-1");
+
+      expect(Number(row?.durationMs)).toBe(100);
+      expect(row?.answeredAt).toBe("2026-06-01T00:00:00.000Z");
+    });
+
+    it("ターン順に並べる", async () => {
+      await insert(db, { threadId: "t-1", source: "chat", turnIndex: 2 });
+      await insert(db, { threadId: "t-1", source: "chat", turnIndex: 1 });
+
+      const rows = await llmUsageRepository.sumConversationByTurn(d1, "t-1");
+
+      expect(rows.map((r) => Number(r.turnIndex))).toEqual([1, 2]);
+    });
+  });
+});

--- a/server/src/repository/llm-usage-repository.ts
+++ b/server/src/repository/llm-usage-repository.ts
@@ -1,0 +1,161 @@
+import { and, count, eq, sql } from "drizzle-orm";
+
+import { createDb, llmUsage, type NewLlmUsage } from "~/db";
+
+type Period = { from: string; to: string };
+
+export type UsageSumRow = {
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  reasoningTokens: number;
+  cachedInputTokens: number;
+  totalTokens: number;
+  persistedCostUsd: number;
+  legacyInputTokens: number;
+  legacyOutputTokens: number;
+  legacyCachedInputTokens: number;
+};
+
+// cost_usd は記録時点の単価で永続化されるが、永続化開始前の行（NULL）は
+// legacy* のトークン数から呼び出し側が現行単価で概算して合算する
+const usageSumColumns = sql`
+  SUM(input_tokens) AS inputTokens,
+  SUM(output_tokens) AS outputTokens,
+  SUM(reasoning_tokens) AS reasoningTokens,
+  SUM(cached_input_tokens) AS cachedInputTokens,
+  SUM(total_tokens) AS totalTokens,
+  SUM(COALESCE(cost_usd, 0)) AS persistedCostUsd,
+  SUM(CASE WHEN cost_usd IS NULL THEN input_tokens ELSE 0 END) AS legacyInputTokens,
+  SUM(CASE WHEN cost_usd IS NULL THEN output_tokens ELSE 0 END) AS legacyOutputTokens,
+  SUM(CASE WHEN cost_usd IS NULL THEN cached_input_tokens ELSE 0 END) AS legacyCachedInputTokens
+`;
+
+// 会話に直接かかった費用と、それ以外の運用費を分けて見るための区分。
+// embedding は検索クエリ分（スレッドに紐づく）が会話、ナレッジ同期分が基盤
+const usageCategoryExpr = sql`
+  CASE
+    WHEN source IN ('chat', 'subagent', 'intent-classify', 'rerank') THEN 'conversation'
+    WHEN source = 'embedding' AND thread_id IS NOT NULL THEN 'conversation'
+    WHEN source = 'embedding' THEN 'knowledge-base'
+    ELSE 'batch'
+  END
+`;
+
+export const llmUsageRepository = {
+  async create(d1: D1Database, input: NewLlmUsage) {
+    const db = createDb(d1);
+
+    await db.insert(llmUsage).values(input);
+  },
+
+  async countChatByThread(d1: D1Database, threadId: string) {
+    const db = createDb(d1);
+
+    const row = await db
+      .select({ value: count() })
+      .from(llmUsage)
+      .where(and(eq(llmUsage.threadId, threadId), eq(llmUsage.source, "chat")))
+      .get();
+
+    return Number(row?.value ?? 0);
+  },
+
+  async sumByDateAndModel(
+    d1: D1Database,
+    params: { from: string; to?: string },
+  ) {
+    const db = createDb(d1);
+
+    const until = params.to ? sql`AND created_at < ${params.to}` : sql``;
+
+    return db.all<UsageSumRow & { date: string }>(sql`
+      SELECT date(created_at, '+9 hours') AS date,
+             model,
+             ${usageSumColumns}
+      FROM llm_usage
+      WHERE created_at >= ${params.from} ${until}
+      GROUP BY date, model
+      ORDER BY date, model
+    `);
+  },
+
+  async sumByModel(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<UsageSumRow>(sql`
+      SELECT model,
+             ${usageSumColumns}
+      FROM llm_usage
+      WHERE created_at >= ${period.from} AND created_at < ${period.to}
+      GROUP BY model
+      ORDER BY model
+    `);
+  },
+
+  async sumByCategory(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<UsageSumRow & { category: string; agent: string | null }>(sql`
+      SELECT ${usageCategoryExpr} AS category,
+             agent,
+             model,
+             ${usageSumColumns}
+      FROM llm_usage
+      WHERE created_at >= ${period.from} AND created_at < ${period.to}
+      GROUP BY category, agent, model
+    `);
+  },
+
+  async sumConversationByThread(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<
+      UsageSumRow & {
+        threadId: string;
+        agent: string | null;
+        platform: string | null;
+        chatCalls: number;
+      }
+    >(sql`
+      SELECT thread_id AS threadId,
+             agent,
+             model,
+             MAX(platform) AS platform,
+             SUM(CASE WHEN source = 'chat' THEN 1 ELSE 0 END) AS chatCalls,
+             ${usageSumColumns}
+      FROM llm_usage
+      WHERE created_at >= ${period.from} AND created_at < ${period.to}
+        AND thread_id IS NOT NULL
+        AND ${usageCategoryExpr} = 'conversation'
+      GROUP BY thread_id, agent, model
+    `);
+  },
+
+  async sumConversationByTurn(d1: D1Database, threadId: string) {
+    const db = createDb(d1);
+
+    return db.all<
+      UsageSumRow & {
+        turnIndex: number | null;
+        agent: string | null;
+        durationMs: number | null;
+        answeredAt: string;
+        intent: string | null;
+      }
+    >(sql`
+      SELECT turn_index AS turnIndex,
+             agent,
+             model,
+             MAX(CASE WHEN source = 'chat' THEN duration_ms END) AS durationMs,
+             MAX(CASE WHEN source = 'chat' THEN created_at END) AS answeredAt,
+             MAX(CASE WHEN source = 'chat' THEN intent END) AS intent,
+             ${usageSumColumns}
+      FROM llm_usage
+      WHERE thread_id = ${threadId}
+        AND ${usageCategoryExpr} = 'conversation'
+      GROUP BY turn_index, agent, model
+      ORDER BY turn_index, agent
+    `);
+  },
+};

--- a/server/src/repository/llm-usage-repository.ts
+++ b/server/src/repository/llm-usage-repository.ts
@@ -1,6 +1,7 @@
 import { and, count, eq, sql } from "drizzle-orm";
 
 import { createDb, llmUsage, type NewLlmUsage } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 type Period = { from: string; to: string };
 
@@ -157,5 +158,15 @@ export const llmUsageRepository = {
       GROUP BY turn_index, agent, model
       ORDER BY turn_index, agent
     `);
+  },
+
+  async deleteCreatedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      llmUsage,
+      sql`datetime(${llmUsage.createdAt}) < datetime(${cutoff})`,
+    );
   },
 };

--- a/server/src/repository/mastra-message-repository.test.ts
+++ b/server/src/repository/mastra-message-repository.test.ts
@@ -291,4 +291,23 @@ describe("mastraMessageRepository", () => {
       expect(await db.select().from(mastraMessages).all()).toHaveLength(1);
     });
   });
+
+  describe("deleteByThreadId", () => {
+    it("指定スレッドのメッセージだけを削除して件数を返す", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-2",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+
+      const deleted = await mastraMessageRepository.deleteByThreadId(d1, "t-1");
+
+      expect(deleted).toBe(1);
+      const rows = await db.select().from(mastraMessages).all();
+      expect(rows.map((r) => r.threadId)).toEqual(["t-2"]);
+    });
+  });
 });

--- a/server/src/repository/mastra-message-repository.test.ts
+++ b/server/src/repository/mastra-message-repository.test.ts
@@ -183,7 +183,7 @@ describe("mastraMessageRepository", () => {
     });
   });
 
-  describe("findSpansOfUsedThreads", () => {
+  describe("findMessageSpansForThreadsWithUsage", () => {
     it("llm_usage に記録のあるスレッドだけ最初と最後の時刻を返す", async () => {
       await db.insert(llmUsage).values({
         id: "u-1",
@@ -205,10 +205,11 @@ describe("mastraMessageRepository", () => {
         createdAt: "2026-06-02T00:00:00.000Z",
       });
 
-      const rows = await mastraMessageRepository.findSpansOfUsedThreads(
-        d1,
-        period,
-      );
+      const rows =
+        await mastraMessageRepository.findMessageSpansForThreadsWithUsage(
+          d1,
+          period,
+        );
 
       expect(rows).toEqual([
         {
@@ -233,10 +234,11 @@ describe("mastraMessageRepository", () => {
         createdAt: "2026-06-02T05:00:00.000Z",
       });
 
-      const rows = await mastraMessageRepository.findSpansOfUsedThreads(
-        d1,
-        period,
-      );
+      const rows =
+        await mastraMessageRepository.findMessageSpansForThreadsWithUsage(
+          d1,
+          period,
+        );
 
       expect(rows[0]?.lastMessageAt).toBe("2026-06-02T05:00:00.000Z");
     });

--- a/server/src/repository/mastra-message-repository.test.ts
+++ b/server/src/repository/mastra-message-repository.test.ts
@@ -265,4 +265,30 @@ describe("mastraMessageRepository", () => {
       ).toEqual({ "t-1": 2, "t-2": 1 });
     });
   });
+
+  describe("deleteCreatedBefore", () => {
+    it("期限より前のメッセージを役割を問わず削除する", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        role: "assistant",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-01T00:00:00.000Z",
+      });
+
+      const deleted = await mastraMessageRepository.deleteCreatedBefore(
+        d1,
+        "2026-03-01T00:00:00.000Z",
+      );
+
+      expect(deleted).toBe(2);
+      expect(await db.select().from(mastraMessages).all()).toHaveLength(1);
+    });
+  });
 });

--- a/server/src/repository/mastra-message-repository.test.ts
+++ b/server/src/repository/mastra-message-repository.test.ts
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+import { llmUsage, mastraMessages, mastraThreads } from "~/db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+const { mastraMessageRepository } = await import("./mastra-message-repository");
+
+const d1 = {} as D1Database;
+
+const period = {
+  from: "2026-06-01T00:00:00.000Z",
+  to: "2026-06-08T00:00:00.000Z",
+};
+
+let seq = 0;
+
+const insertMessage = async (
+  db: TestDb,
+  params: { threadId: string; role?: string; createdAt: string },
+) => {
+  await db.insert(mastraMessages).values({
+    id: `m-${++seq}`,
+    threadId: params.threadId,
+    role: params.role ?? "user",
+    createdAt: params.createdAt,
+  });
+};
+
+const insertThread = async (db: TestDb, id: string, resourceId: string) => {
+  await db
+    .insert(mastraThreads)
+    .values({ id, resourceId, createdAt: "2026-06-01T00:00:00.000Z" });
+};
+
+describe("mastraMessageRepository", () => {
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    testDbHolder.db = db;
+  });
+
+  describe("countUserMessagesByHour", () => {
+    it("JST の時刻で集計する", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:30:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.countUserMessagesByHour(
+        d1,
+        period,
+      );
+
+      expect(rows).toEqual([{ hour: 9, count: 1 }]);
+    });
+
+    it("assistant のメッセージは数えない", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        role: "assistant",
+        createdAt: "2026-06-02T00:30:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.countUserMessagesByHour(
+        d1,
+        period,
+      );
+
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe("countUserMessagesByWeekday", () => {
+    it("JST の曜日で集計する", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-06T15:30:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.countUserMessagesByWeekday(
+        d1,
+        period,
+      );
+
+      expect(rows).toEqual([{ dow: 0, count: 1 }]);
+    });
+  });
+
+  describe("countUserMessagesByDate", () => {
+    it("日付ごとにスレッド数とメッセージ数を返す", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T01:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-2",
+        createdAt: "2026-06-02T02:00:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.countUserMessagesByDate(
+        d1,
+        period,
+      );
+
+      expect(rows).toEqual([
+        { date: "2026-06-02", conversations: 2, messages: 3 },
+      ]);
+    });
+  });
+
+  describe("countUserMessagesByPlatform", () => {
+    it("スレッドの resourceId から流入元を判定する", async () => {
+      await insertThread(db, "t-line", "line:abc");
+      await insertThread(db, "t-admin", "admin:abc");
+      await insertThread(db, "t-widget", "widget-abc");
+      await insertThread(db, "t-web", "uuid-abc");
+      for (const threadId of ["t-line", "t-admin", "t-widget", "t-web"]) {
+        await insertMessage(db, {
+          threadId,
+          createdAt: "2026-06-02T00:00:00.000Z",
+        });
+      }
+
+      const rows = await mastraMessageRepository.countUserMessagesByPlatform(
+        d1,
+        period,
+      );
+
+      expect(
+        Object.fromEntries(rows.map((r) => [r.platform, r.count])),
+      ).toEqual({ line: 1, admin: 1, widget: 1, web: 1 });
+    });
+
+    it("スレッドが存在しないメッセージは含めない", async () => {
+      await insertMessage(db, {
+        threadId: "orphan",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.countUserMessagesByPlatform(
+        d1,
+        period,
+      );
+
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe("countUserMessageTotals", () => {
+    it("期間外のメッセージを除外する", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-2",
+        createdAt: "2026-06-09T00:00:00.000Z",
+      });
+
+      const row = await mastraMessageRepository.countUserMessageTotals(
+        d1,
+        period,
+      );
+
+      expect(row).toEqual({ conversations: 1, messages: 1 });
+    });
+  });
+
+  describe("findSpansOfUsedThreads", () => {
+    it("llm_usage に記録のあるスレッドだけ最初と最後の時刻を返す", async () => {
+      await db.insert(llmUsage).values({
+        id: "u-1",
+        model: "gpt-5-mini",
+        source: "chat",
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T03:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-2",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.findSpansOfUsedThreads(
+        d1,
+        period,
+      );
+
+      expect(rows).toEqual([
+        {
+          threadId: "t-1",
+          firstMessageAt: "2026-06-02T00:00:00.000Z",
+          lastMessageAt: "2026-06-02T03:00:00.000Z",
+        },
+      ]);
+    });
+
+    it("assistant のメッセージも期間に含める", async () => {
+      await db.insert(llmUsage).values({
+        id: "u-1",
+        model: "gpt-5-mini",
+        source: "chat",
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        role: "assistant",
+        createdAt: "2026-06-02T05:00:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.findSpansOfUsedThreads(
+        d1,
+        period,
+      );
+
+      expect(rows[0]?.lastMessageAt).toBe("2026-06-02T05:00:00.000Z");
+    });
+  });
+
+  describe("countByThread", () => {
+    it("役割を問わずスレッドごとの件数を返す", async () => {
+      await insertMessage(db, {
+        threadId: "t-1",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-1",
+        role: "assistant",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+      await insertMessage(db, {
+        threadId: "t-2",
+        createdAt: "2026-06-02T00:00:00.000Z",
+      });
+
+      const rows = await mastraMessageRepository.countByThread(d1);
+
+      expect(
+        Object.fromEntries(rows.map((r) => [r.threadId, r.count])),
+      ).toEqual({ "t-1": 2, "t-2": 1 });
+    });
+  });
+});

--- a/server/src/repository/mastra-message-repository.ts
+++ b/server/src/repository/mastra-message-repository.ts
@@ -1,4 +1,4 @@
-import { count, sql } from "drizzle-orm";
+import { count, eq, sql } from "drizzle-orm";
 
 import { createDb, mastraMessages } from "~/db";
 import { deleteWithCount } from "./delete-with-count";
@@ -104,6 +104,16 @@ export const mastraMessageRepository = {
       .from(mastraMessages)
       .groupBy(mastraMessages.threadId)
       .all();
+  },
+
+  async deleteByThreadId(d1: D1Database, threadId: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      mastraMessages,
+      eq(mastraMessages.threadId, threadId),
+    );
   },
 
   async deleteCreatedBefore(d1: D1Database, cutoff: string) {

--- a/server/src/repository/mastra-message-repository.ts
+++ b/server/src/repository/mastra-message-repository.ts
@@ -1,6 +1,7 @@
 import { count, sql } from "drizzle-orm";
 
 import { createDb, mastraMessages } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 type Period = { from: string; to: string };
 
@@ -103,5 +104,15 @@ export const mastraMessageRepository = {
       .from(mastraMessages)
       .groupBy(mastraMessages.threadId)
       .all();
+  },
+
+  async deleteCreatedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      mastraMessages,
+      sql`datetime(${mastraMessages.createdAt}) < datetime(${cutoff})`,
+    );
   },
 };

--- a/server/src/repository/mastra-message-repository.ts
+++ b/server/src/repository/mastra-message-repository.ts
@@ -74,7 +74,7 @@ export const mastraMessageRepository = {
     `);
   },
 
-  async findSpansOfUsedThreads(d1: D1Database, period: Period) {
+  async findMessageSpansForThreadsWithUsage(d1: D1Database, period: Period) {
     const db = createDb(d1);
 
     return db.all<{

--- a/server/src/repository/mastra-message-repository.ts
+++ b/server/src/repository/mastra-message-repository.ts
@@ -1,0 +1,107 @@
+import { count, sql } from "drizzle-orm";
+
+import { createDb, mastraMessages } from "~/db";
+
+type Period = { from: string; to: string };
+
+export const mastraMessageRepository = {
+  async countUserMessagesByHour(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<{ hour: number; count: number }>(sql`
+      SELECT CAST(strftime('%H', createdAt, '+9 hours') AS INTEGER) AS hour,
+             COUNT(*) AS count
+      FROM mastra_messages
+      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
+      GROUP BY hour
+    `);
+  },
+
+  async countUserMessagesByWeekday(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<{ dow: number; count: number }>(sql`
+      SELECT CAST(strftime('%w', createdAt, '+9 hours') AS INTEGER) AS dow,
+             COUNT(*) AS count
+      FROM mastra_messages
+      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
+      GROUP BY dow
+    `);
+  },
+
+  async countUserMessagesByDate(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<{
+      date: string;
+      conversations: number;
+      messages: number;
+    }>(sql`
+      SELECT strftime('%Y-%m-%d', createdAt, '+9 hours') AS date,
+             COUNT(DISTINCT thread_id) AS conversations,
+             COUNT(*) AS messages
+      FROM mastra_messages
+      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
+      GROUP BY date
+      ORDER BY date
+    `);
+  },
+
+  async countUserMessagesByPlatform(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<{ platform: string; count: number }>(sql`
+      SELECT CASE WHEN t.resourceId LIKE 'line:%' THEN 'line'
+                  WHEN t.resourceId LIKE 'admin:%' THEN 'admin'
+                  WHEN t.resourceId LIKE 'widget-%' THEN 'widget'
+                  ELSE 'web' END AS platform,
+             COUNT(*) AS count
+      FROM mastra_messages m
+      JOIN mastra_threads t ON m.thread_id = t.id
+      WHERE m.role = 'user' AND m.createdAt >= ${period.from} AND m.createdAt < ${period.to}
+      GROUP BY platform
+    `);
+  },
+
+  async countUserMessageTotals(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.get<{ conversations: number; messages: number }>(sql`
+      SELECT COUNT(DISTINCT thread_id) AS conversations, COUNT(*) AS messages
+      FROM mastra_messages
+      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
+    `);
+  },
+
+  async findSpansOfUsedThreads(d1: D1Database, period: Period) {
+    const db = createDb(d1);
+
+    return db.all<{
+      threadId: string;
+      firstMessageAt: string;
+      lastMessageAt: string;
+    }>(sql`
+      SELECT thread_id AS threadId,
+             MIN(createdAt) AS firstMessageAt,
+             MAX(createdAt) AS lastMessageAt
+      FROM mastra_messages
+      WHERE createdAt >= ${period.from} AND createdAt < ${period.to}
+        AND thread_id IN (
+          SELECT DISTINCT thread_id FROM llm_usage
+          WHERE created_at >= ${period.from} AND created_at < ${period.to}
+            AND thread_id IS NOT NULL
+        )
+      GROUP BY thread_id
+    `);
+  },
+
+  async countByThread(d1: D1Database) {
+    const db = createDb(d1);
+
+    return db
+      .select({ threadId: mastraMessages.threadId, count: count() })
+      .from(mastraMessages)
+      .groupBy(mastraMessages.threadId)
+      .all();
+  },
+};

--- a/server/src/repository/mastra-resource-repository.test.ts
+++ b/server/src/repository/mastra-resource-repository.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+import { mastraResources } from "~/db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+const { mastraResourceRepository } = await import(
+  "./mastra-resource-repository"
+);
+
+const d1 = {} as D1Database;
+
+describe("mastraResourceRepository", () => {
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    testDbHolder.db = db;
+  });
+
+  describe("deleteUpdatedBefore", () => {
+    it("更新時刻が期限より前のリソースを削除する", async () => {
+      await db
+        .insert(mastraResources)
+        .values({ id: "r-old", updatedAt: "2026-01-01T00:00:00.000Z" });
+      await db
+        .insert(mastraResources)
+        .values({ id: "r-new", updatedAt: "2026-06-01T00:00:00.000Z" });
+
+      const deleted = await mastraResourceRepository.deleteUpdatedBefore(
+        d1,
+        "2026-03-01T00:00:00.000Z",
+      );
+
+      expect(deleted).toBe(1);
+      const rows = await db.select().from(mastraResources).all();
+      expect(rows.map((r) => r.id)).toEqual(["r-new"]);
+    });
+  });
+});

--- a/server/src/repository/mastra-resource-repository.test.ts
+++ b/server/src/repository/mastra-resource-repository.test.ts
@@ -48,4 +48,21 @@ describe("mastraResourceRepository", () => {
       expect(rows.map((r) => r.id)).toEqual(["r-new"]);
     });
   });
+
+  describe("deleteById", () => {
+    it("指定リソースだけを削除して件数を返す", async () => {
+      await db
+        .insert(mastraResources)
+        .values({ id: "r-1", updatedAt: "2026-06-01T00:00:00.000Z" });
+      await db
+        .insert(mastraResources)
+        .values({ id: "r-2", updatedAt: "2026-06-01T00:00:00.000Z" });
+
+      const deleted = await mastraResourceRepository.deleteById(d1, "r-1");
+
+      expect(deleted).toBe(1);
+      const rows = await db.select().from(mastraResources).all();
+      expect(rows.map((r) => r.id)).toEqual(["r-2"]);
+    });
+  });
 });

--- a/server/src/repository/mastra-resource-repository.ts
+++ b/server/src/repository/mastra-resource-repository.ts
@@ -1,0 +1,16 @@
+import { sql } from "drizzle-orm";
+
+import { createDb, mastraResources } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
+
+export const mastraResourceRepository = {
+  async deleteUpdatedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      mastraResources,
+      sql`datetime(${mastraResources.updatedAt}) < datetime(${cutoff})`,
+    );
+  },
+};

--- a/server/src/repository/mastra-resource-repository.ts
+++ b/server/src/repository/mastra-resource-repository.ts
@@ -1,9 +1,15 @@
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { createDb, mastraResources } from "~/db";
 import { deleteWithCount } from "./delete-with-count";
 
 export const mastraResourceRepository = {
+  async deleteById(d1: D1Database, id: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(db, mastraResources, eq(mastraResources.id, id));
+  },
+
   async deleteUpdatedBefore(d1: D1Database, cutoff: string) {
     const db = createDb(d1);
 

--- a/server/src/repository/mastra-thread-repository.test.ts
+++ b/server/src/repository/mastra-thread-repository.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
+import { mastraThreads } from "~/db";
+
+const { testDbHolder } = vi.hoisted(() => ({
+  testDbHolder: { db: null as TestDb | null },
+}));
+
+vi.mock("~/db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/db")>();
+  return {
+    ...actual,
+    createDb: () => testDbHolder.db,
+  };
+});
+
+const { mastraThreadRepository } = await import("./mastra-thread-repository");
+
+const d1 = {} as D1Database;
+
+const insertThread = async (
+  db: TestDb,
+  id: string,
+  resourceId: string | null,
+) => {
+  await db
+    .insert(mastraThreads)
+    .values({ id, resourceId, createdAt: "2026-06-01T00:00:00.000Z" });
+};
+
+describe("mastraThreadRepository", () => {
+  let db: TestDb;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    testDbHolder.db = db;
+  });
+
+  describe("findAll", () => {
+    it("id の降順で返す", async () => {
+      await insertThread(db, "t-1", "web:a");
+      await insertThread(db, "t-3", "web:c");
+      await insertThread(db, "t-2", "web:b");
+
+      const rows = await mastraThreadRepository.findAll(d1);
+
+      expect(rows.map((r) => r.id)).toEqual(["t-3", "t-2", "t-1"]);
+    });
+
+    it("resourceId が無いスレッドも返す", async () => {
+      await insertThread(db, "t-1", null);
+
+      const rows = await mastraThreadRepository.findAll(d1);
+
+      expect(rows).toEqual([{ id: "t-1", resourceId: null }]);
+    });
+  });
+
+  describe("findById", () => {
+    it("見つからなければ null を返す", async () => {
+      expect(await mastraThreadRepository.findById(d1, "none")).toBeNull();
+    });
+
+    it("id と resourceId を返す", async () => {
+      await insertThread(db, "t-1", "line:abc");
+
+      expect(await mastraThreadRepository.findById(d1, "t-1")).toEqual({
+        id: "t-1",
+        resourceId: "line:abc",
+      });
+    });
+  });
+});

--- a/server/src/repository/mastra-thread-repository.test.ts
+++ b/server/src/repository/mastra-thread-repository.test.ts
@@ -123,4 +123,17 @@ describe("mastraThreadRepository", () => {
       expect(await db.select().from(mastraThreads).all()).toHaveLength(0);
     });
   });
+
+  describe("deleteById", () => {
+    it("指定スレッドだけを削除して件数を返す", async () => {
+      await insertThread(db, "t-1", "web:a");
+      await insertThread(db, "t-2", "web:b");
+
+      const deleted = await mastraThreadRepository.deleteById(d1, "t-1");
+
+      expect(deleted).toBe(1);
+      const rows = await db.select().from(mastraThreads).all();
+      expect(rows.map((r) => r.id)).toEqual(["t-2"]);
+    });
+  });
 });

--- a/server/src/repository/mastra-thread-repository.test.ts
+++ b/server/src/repository/mastra-thread-repository.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createTestDb, type TestDb } from "~/__tests__/helpers/test-db";
-import { mastraThreads } from "~/db";
+import { mastraMessages, mastraThreads } from "~/db";
 
 const { testDbHolder } = vi.hoisted(() => ({
   testDbHolder: { db: null as TestDb | null },
@@ -69,6 +69,58 @@ describe("mastraThreadRepository", () => {
         id: "t-1",
         resourceId: "line:abc",
       });
+    });
+  });
+
+  describe("deleteEmptyCreatedBefore", () => {
+    const insertMessage = async (threadId: string) => {
+      await db.insert(mastraMessages).values({
+        id: `m-${threadId}`,
+        threadId,
+        role: "user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+    };
+
+    const insertThreadAt = async (id: string, createdAt: string) => {
+      await db
+        .insert(mastraThreads)
+        .values({ id, resourceId: "web:a", createdAt });
+    };
+
+    it("メッセージが残っているスレッドは期限を過ぎても消さない", async () => {
+      await insertThreadAt("t-1", "2026-01-01T00:00:00.000Z");
+      await insertMessage("t-1");
+
+      const deleted = await mastraThreadRepository.deleteEmptyCreatedBefore(
+        d1,
+        "2026-03-01T00:00:00.000Z",
+      );
+
+      expect(deleted).toBe(0);
+    });
+
+    it("期限内に作られた空スレッドは消さない", async () => {
+      await insertThreadAt("t-1", "2026-06-01T00:00:00.000Z");
+
+      const deleted = await mastraThreadRepository.deleteEmptyCreatedBefore(
+        d1,
+        "2026-03-01T00:00:00.000Z",
+      );
+
+      expect(deleted).toBe(0);
+    });
+
+    it("期限を過ぎた空スレッドを削除する", async () => {
+      await insertThreadAt("t-1", "2026-01-01T00:00:00.000Z");
+
+      const deleted = await mastraThreadRepository.deleteEmptyCreatedBefore(
+        d1,
+        "2026-03-01T00:00:00.000Z",
+      );
+
+      expect(deleted).toBe(1);
+      expect(await db.select().from(mastraThreads).all()).toHaveLength(0);
     });
   });
 });

--- a/server/src/repository/mastra-thread-repository.ts
+++ b/server/src/repository/mastra-thread-repository.ts
@@ -32,6 +32,12 @@ export const mastraThreadRepository = {
     return result ?? null;
   },
 
+  async deleteById(d1: D1Database, id: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(db, mastraThreads, eq(mastraThreads.id, id));
+  },
+
   async deleteEmptyCreatedBefore(d1: D1Database, cutoff: string) {
     const db = createDb(d1);
 

--- a/server/src/repository/mastra-thread-repository.ts
+++ b/server/src/repository/mastra-thread-repository.ts
@@ -1,0 +1,33 @@
+import { desc, eq } from "drizzle-orm";
+
+import { createDb, mastraThreads } from "~/db";
+
+export const mastraThreadRepository = {
+  async findAll(d1: D1Database) {
+    const db = createDb(d1);
+
+    return db
+      .select({
+        id: mastraThreads.id,
+        resourceId: mastraThreads.resourceId,
+      })
+      .from(mastraThreads)
+      .orderBy(desc(mastraThreads.id))
+      .all();
+  },
+
+  async findById(d1: D1Database, id: string) {
+    const db = createDb(d1);
+
+    const result = await db
+      .select({
+        id: mastraThreads.id,
+        resourceId: mastraThreads.resourceId,
+      })
+      .from(mastraThreads)
+      .where(eq(mastraThreads.id, id))
+      .get();
+
+    return result ?? null;
+  },
+};

--- a/server/src/repository/mastra-thread-repository.ts
+++ b/server/src/repository/mastra-thread-repository.ts
@@ -1,6 +1,7 @@
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 
 import { createDb, mastraThreads } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 export const mastraThreadRepository = {
   async findAll(d1: D1Database) {
@@ -29,5 +30,16 @@ export const mastraThreadRepository = {
       .get();
 
     return result ?? null;
+  },
+
+  async deleteEmptyCreatedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      mastraThreads,
+      sql`${mastraThreads.id} NOT IN (SELECT DISTINCT thread_id FROM mastra_messages)
+        AND datetime(${mastraThreads.createdAt}) < datetime(${cutoff})`,
+    );
   },
 };

--- a/server/src/repository/persona-repository.test.ts
+++ b/server/src/repository/persona-repository.test.ts
@@ -612,4 +612,129 @@ describe("personaRepository", () => {
       expect(result[0].topTags).toEqual([]);
     });
   });
+
+  describe("listCreatedBetween", () => {
+    it("createdAt が期間内の声だけを返す", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", createdAt: "2030-01-01T00:00:00Z" }),
+      );
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-2", createdAt: "2030-01-08T00:00:00Z" }),
+      );
+
+      const result = await personaRepository.listCreatedBetween(fakeD1, {
+        from: "2030-01-01T00:00:00Z",
+        to: "2030-01-08T00:00:00Z",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].content).toBe("好きな食べ物はラーメン");
+    });
+  });
+
+  describe("listAttributes", () => {
+    it("期間指定が無ければ会話終了時刻が無い声も含める", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: null }),
+      );
+
+      expect(await personaRepository.listAttributes(fakeD1)).toHaveLength(1);
+    });
+
+    it("会話終了時刻で期間を絞る", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T00:00:00Z" }),
+      );
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-2", conversationEndedAt: "2030-01-09T00:00:00Z" }),
+      );
+
+      const result = await personaRepository.listAttributes(fakeD1, {
+        from: "2030-01-01T00:00:00Z",
+        to: "2030-01-08T00:00:00Z",
+      });
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("countByConversationHour", () => {
+    it("JST の時刻で集計する", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T00:30:00Z" }),
+      );
+
+      expect(await personaRepository.countByConversationHour(fakeD1)).toEqual([
+        { hour: 9, count: 1 },
+      ]);
+    });
+
+    it("会話終了時刻が無い声は数えない", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: null }),
+      );
+
+      expect(await personaRepository.countByConversationHour(fakeD1)).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe("countByConversationWeekday", () => {
+    it("JST の曜日で集計する", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: "2030-01-05T15:00:00Z" }),
+      );
+
+      expect(
+        await personaRepository.countByConversationWeekday(fakeD1),
+      ).toEqual([{ dow: 0, count: 1 }]);
+    });
+  });
+
+  describe("countOfficeHours", () => {
+    it("平日 8〜17 時 JST を開庁として数える", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T00:00:00Z" }),
+      );
+
+      expect(await personaRepository.countOfficeHours(fakeD1)).toEqual({
+        open: 1,
+        total: 1,
+      });
+    });
+
+    it("平日でも 17 時以降は閉庁として数える", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T08:00:00Z" }),
+      );
+
+      expect(await personaRepository.countOfficeHours(fakeD1)).toEqual({
+        open: 0,
+        total: 1,
+      });
+    });
+
+    it("土日は開庁時間帯でも閉庁として数える", async () => {
+      await personaRepository.create(
+        fakeD1,
+        baseInput({ id: "p-1", conversationEndedAt: "2030-01-06T00:00:00Z" }),
+      );
+
+      expect(await personaRepository.countOfficeHours(fakeD1)).toEqual({
+        open: 0,
+        total: 1,
+      });
+    });
+  });
 });

--- a/server/src/repository/persona-repository.test.ts
+++ b/server/src/repository/persona-repository.test.ts
@@ -641,7 +641,9 @@ describe("personaRepository", () => {
         baseInput({ id: "p-1", conversationEndedAt: null }),
       );
 
-      expect(await personaRepository.listAttributes(fakeD1)).toHaveLength(1);
+      expect(await personaRepository.listAttributes(fakeD1, {})).toHaveLength(
+        1,
+      );
     });
 
     it("会話終了時刻で期間を絞る", async () => {
@@ -670,9 +672,9 @@ describe("personaRepository", () => {
         baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T00:30:00Z" }),
       );
 
-      expect(await personaRepository.countByConversationHour(fakeD1)).toEqual([
-        { hour: 9, count: 1 },
-      ]);
+      expect(
+        await personaRepository.countByConversationHour(fakeD1, {}),
+      ).toEqual([{ hour: 9, count: 1 }]);
     });
 
     it("会話終了時刻が無い声は数えない", async () => {
@@ -681,9 +683,9 @@ describe("personaRepository", () => {
         baseInput({ id: "p-1", conversationEndedAt: null }),
       );
 
-      expect(await personaRepository.countByConversationHour(fakeD1)).toEqual(
-        [],
-      );
+      expect(
+        await personaRepository.countByConversationHour(fakeD1, {}),
+      ).toEqual([]);
     });
   });
 
@@ -695,7 +697,7 @@ describe("personaRepository", () => {
       );
 
       expect(
-        await personaRepository.countByConversationWeekday(fakeD1),
+        await personaRepository.countByConversationWeekday(fakeD1, {}),
       ).toEqual([{ dow: 0, count: 1 }]);
     });
   });
@@ -707,7 +709,7 @@ describe("personaRepository", () => {
         baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T00:00:00Z" }),
       );
 
-      expect(await personaRepository.countOfficeHours(fakeD1)).toEqual({
+      expect(await personaRepository.countOfficeHours(fakeD1, {})).toEqual({
         open: 1,
         total: 1,
       });
@@ -719,7 +721,7 @@ describe("personaRepository", () => {
         baseInput({ id: "p-1", conversationEndedAt: "2030-01-02T08:00:00Z" }),
       );
 
-      expect(await personaRepository.countOfficeHours(fakeD1)).toEqual({
+      expect(await personaRepository.countOfficeHours(fakeD1, {})).toEqual({
         open: 0,
         total: 1,
       });
@@ -731,7 +733,7 @@ describe("personaRepository", () => {
         baseInput({ id: "p-1", conversationEndedAt: "2030-01-06T00:00:00Z" }),
       );
 
-      expect(await personaRepository.countOfficeHours(fakeD1)).toEqual({
+      expect(await personaRepository.countOfficeHours(fakeD1, {})).toEqual({
         open: 0,
         total: 1,
       });

--- a/server/src/repository/persona-repository.ts
+++ b/server/src/repository/persona-repository.ts
@@ -54,7 +54,7 @@ const personaFilters = (options: PersonaFilter): SQL[] => {
 // 集計は正規化後の話題で行う（NULL と未知の値は その他 に寄せる）
 const normalizedTopic = sql`CASE WHEN ${inArray(persona.topic, NAMED_TOPICS)} THEN ${persona.topic} ELSE ${OTHER_TOPIC} END`;
 
-// 会話のあった時刻での集計。createdAt は抽出バッチの実行時刻で会話の期間を表さない
+// sortDate と違い conversationEndedAt が NULL の声は期間に含めない
 type ConversationPeriod = { from?: string; to?: string };
 
 const conversationPeriodFilters = (period: ConversationPeriod): SQL[] =>
@@ -448,7 +448,7 @@ export const personaRepository = {
       .all();
   },
 
-  async listAttributes(d1: D1Database, period: ConversationPeriod = {}) {
+  async listAttributes(d1: D1Database, period: ConversationPeriod) {
     const db = createDb(d1);
 
     const conditions = conversationPeriodFilters(period);
@@ -465,7 +465,7 @@ export const personaRepository = {
       .all();
   },
 
-  async listAttributesWithEntities(d1: D1Database) {
+  async listAllAttributesWithEntities(d1: D1Database) {
     const db = createDb(d1);
 
     return db
@@ -480,10 +480,7 @@ export const personaRepository = {
       .all();
   },
 
-  async countByConversationHour(
-    d1: D1Database,
-    period: ConversationPeriod = {},
-  ) {
+  async countByConversationHour(d1: D1Database, period: ConversationPeriod) {
     const db = createDb(d1);
 
     return db
@@ -494,10 +491,7 @@ export const personaRepository = {
       .all();
   },
 
-  async countByConversationWeekday(
-    d1: D1Database,
-    period: ConversationPeriod = {},
-  ) {
+  async countByConversationWeekday(d1: D1Database, period: ConversationPeriod) {
     const db = createDb(d1);
 
     return db
@@ -508,7 +502,7 @@ export const personaRepository = {
       .all();
   },
 
-  async countOfficeHours(d1: D1Database, period: ConversationPeriod = {}) {
+  async countOfficeHours(d1: D1Database, period: ConversationPeriod) {
     const db = createDb(d1);
 
     return db

--- a/server/src/repository/persona-repository.ts
+++ b/server/src/repository/persona-repository.ts
@@ -4,8 +4,11 @@ import {
   count,
   desc,
   eq,
+  gte,
   inArray,
+  isNotNull,
   like,
+  lt,
   or,
   type SQL,
   sql,
@@ -50,6 +53,26 @@ const personaFilters = (options: PersonaFilter): SQL[] => {
 
 // 集計は正規化後の話題で行う（NULL と未知の値は その他 に寄せる）
 const normalizedTopic = sql`CASE WHEN ${inArray(persona.topic, NAMED_TOPICS)} THEN ${persona.topic} ELSE ${OTHER_TOPIC} END`;
+
+// 会話のあった時刻での集計。createdAt は抽出バッチの実行時刻で会話の期間を表さない
+type ConversationPeriod = { from?: string; to?: string };
+
+const conversationPeriodFilters = (period: ConversationPeriod): SQL[] =>
+  [
+    period.from ? gte(persona.conversationEndedAt, period.from) : undefined,
+    period.to ? lt(persona.conversationEndedAt, period.to) : undefined,
+  ].filter((c) => c !== undefined);
+
+const conversationHour = sql<number>`CAST(strftime('%H', ${persona.conversationEndedAt}, '+9 hours') AS INTEGER)`;
+const conversationWeekday = sql<number>`CAST(strftime('%w', ${persona.conversationEndedAt}, '+9 hours') AS INTEGER)`;
+// 開庁 = 平日（月〜金）の 8〜17 時 JST。それ以外は閉庁
+const isOfficeOpen = sql<number>`CASE WHEN ${conversationWeekday} BETWEEN 1 AND 5 AND ${conversationHour} BETWEEN 8 AND 16 THEN 1 ELSE 0 END`;
+
+const endedInPeriod = (period: ConversationPeriod) =>
+  and(
+    isNotNull(persona.conversationEndedAt),
+    ...conversationPeriodFilters(period),
+  );
 
 const TOP_TAGS_LIMIT = 3;
 
@@ -400,6 +423,102 @@ export const personaRepository = {
         topTags: topTagsByTopic.get(row.topic) ?? [],
       }))
       .sort((a, b) => b.total - a.total);
+  },
+
+  async listCreatedBetween(
+    d1: D1Database,
+    period: { from: string; to: string },
+  ) {
+    const db = createDb(d1);
+
+    return db
+      .select({
+        category: persona.category,
+        topic: persona.topic,
+        sentiment: persona.sentiment,
+        content: persona.content,
+      })
+      .from(persona)
+      .where(
+        and(
+          gte(persona.createdAt, period.from),
+          lt(persona.createdAt, period.to),
+        ),
+      )
+      .all();
+  },
+
+  async listAttributes(d1: D1Database, period: ConversationPeriod = {}) {
+    const db = createDb(d1);
+
+    const conditions = conversationPeriodFilters(period);
+
+    return db
+      .select({
+        tags: persona.tags,
+        demographicSummary: persona.demographicSummary,
+        topic: persona.topic,
+        sentiment: persona.sentiment,
+      })
+      .from(persona)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .all();
+  },
+
+  async listAttributesWithEntities(d1: D1Database) {
+    const db = createDb(d1);
+
+    return db
+      .select({
+        tags: persona.tags,
+        demographicSummary: persona.demographicSummary,
+        topic: persona.topic,
+        sentiment: persona.sentiment,
+        entities: persona.entities,
+      })
+      .from(persona)
+      .all();
+  },
+
+  async countByConversationHour(
+    d1: D1Database,
+    period: ConversationPeriod = {},
+  ) {
+    const db = createDb(d1);
+
+    return db
+      .select({ hour: conversationHour, count: sql<number>`COUNT(*)` })
+      .from(persona)
+      .where(endedInPeriod(period))
+      .groupBy(conversationHour)
+      .all();
+  },
+
+  async countByConversationWeekday(
+    d1: D1Database,
+    period: ConversationPeriod = {},
+  ) {
+    const db = createDb(d1);
+
+    return db
+      .select({ dow: conversationWeekday, count: sql<number>`COUNT(*)` })
+      .from(persona)
+      .where(endedInPeriod(period))
+      .groupBy(conversationWeekday)
+      .all();
+  },
+
+  async countOfficeHours(d1: D1Database, period: ConversationPeriod = {}) {
+    const db = createDb(d1);
+
+    return db
+      .select({
+        open: sql<number>`SUM(${isOfficeOpen})`,
+        total: sql<number>`COUNT(*)`,
+      })
+      .from(persona)
+      .where(endedInPeriod(period))
+      .get();
   },
 
   async getStats(d1: D1Database) {

--- a/server/src/repository/poll-repository.test.ts
+++ b/server/src/repository/poll-repository.test.ts
@@ -300,4 +300,33 @@ describe("pollRepository", () => {
       ).rejects.toThrow();
     });
   });
+
+  describe("deleteSubmissionsCreatedBefore", () => {
+    it("期限より前の回答を削除する", async () => {
+      await pollRepository.create(fakeD1, baseInput);
+      await db.insert(pollSubmissions).values({
+        id: "s-old",
+        pollId: "p-1",
+        userId: "u-1",
+        selectedChoice: "春",
+        createdAt: "2024-01-01T00:00:00Z",
+      });
+      await db.insert(pollSubmissions).values({
+        id: "s-new",
+        pollId: "p-1",
+        userId: "u-2",
+        selectedChoice: "夏",
+        createdAt: "2026-01-01T00:00:00Z",
+      });
+
+      const deleted = await pollRepository.deleteSubmissionsCreatedBefore(
+        fakeD1,
+        "2025-01-01T00:00:00Z",
+      );
+
+      expect(deleted).toBe(1);
+      const remaining = await db.select().from(pollSubmissions).all();
+      expect(remaining.map((r) => r.id)).toEqual(["s-new"]);
+    });
+  });
 });

--- a/server/src/repository/poll-repository.test.ts
+++ b/server/src/repository/poll-repository.test.ts
@@ -329,4 +329,33 @@ describe("pollRepository", () => {
       expect(remaining.map((r) => r.id)).toEqual(["s-new"]);
     });
   });
+
+  describe("deleteSubmissionsByUserId", () => {
+    it("指定ユーザーの回答だけを削除して件数を返す", async () => {
+      await pollRepository.create(fakeD1, baseInput);
+      await db.insert(pollSubmissions).values({
+        id: "s-1",
+        pollId: "p-1",
+        userId: "u-1",
+        selectedChoice: "春",
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+      await db.insert(pollSubmissions).values({
+        id: "s-2",
+        pollId: "p-1",
+        userId: "u-2",
+        selectedChoice: "夏",
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+
+      const deleted = await pollRepository.deleteSubmissionsByUserId(
+        fakeD1,
+        "u-1",
+      );
+
+      expect(deleted).toBe(1);
+      const remaining = await db.select().from(pollSubmissions).all();
+      expect(remaining.map((r) => r.id)).toEqual(["s-2"]);
+    });
+  });
 });

--- a/server/src/repository/poll-repository.ts
+++ b/server/src/repository/poll-repository.ts
@@ -179,6 +179,16 @@ export const pollRepository = {
     return input.id;
   },
 
+  async deleteSubmissionsByUserId(d1: D1Database, userId: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      pollSubmissions,
+      eq(pollSubmissions.userId, userId),
+    );
+  },
+
   async deleteSubmissionsCreatedBefore(d1: D1Database, cutoff: string) {
     const db = createDb(d1);
 

--- a/server/src/repository/poll-repository.ts
+++ b/server/src/repository/poll-repository.ts
@@ -7,6 +7,7 @@ import {
   pollSubmissions,
   polls,
 } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 type PollStatus = Poll["status"];
 
@@ -176,6 +177,16 @@ export const pollRepository = {
     const db = createDb(d1);
     await db.insert(pollSubmissions).values(input);
     return input.id;
+  },
+
+  async deleteSubmissionsCreatedBefore(d1: D1Database, cutoff: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      pollSubmissions,
+      sql`datetime(${pollSubmissions.createdAt}) < datetime(${cutoff})`,
+    );
   },
 
   async findSubmissionsByPoll(d1: D1Database, pollId: string) {

--- a/server/src/repository/thread-persona-status-repository.test.ts
+++ b/server/src/repository/thread-persona-status-repository.test.ts
@@ -117,10 +117,10 @@ describe("threadPersonaStatusRepository", () => {
       expect(all.map((r) => r.threadId)).toEqual(["t-2"]);
     });
 
-    it("冪等: 存在しない threadId の削除はエラーにならない", async () => {
+    it("冪等: 存在しない threadId の削除は 0 件を返す", async () => {
       await expect(
         threadPersonaStatusRepository.delete(fakeD1, "ghost"),
-      ).resolves.toBeUndefined();
+      ).resolves.toBe(0);
     });
   });
 

--- a/server/src/repository/thread-persona-status-repository.test.ts
+++ b/server/src/repository/thread-persona-status-repository.test.ts
@@ -14,6 +14,7 @@ vi.mock("~/db", async (importOriginal) => {
   };
 });
 
+const { mastraMessages, mastraThreads } = await import("~/db");
 const { threadPersonaStatusRepository } = await import(
   "./thread-persona-status-repository"
 );
@@ -120,6 +121,78 @@ describe("threadPersonaStatusRepository", () => {
       await expect(
         threadPersonaStatusRepository.delete(fakeD1, "ghost"),
       ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("syncMessageCounts", () => {
+    it("残っているメッセージ数で処理済み件数を再計算する", async () => {
+      await threadPersonaStatusRepository.upsert(fakeD1, {
+        threadId: "t-1",
+        lastExtractedAt: "2025-01-01T00:00:00Z",
+        lastMessageCount: 10,
+      });
+      const db = testDbHolder.db;
+      if (!db) throw new Error("test db is not initialized");
+      await db.insert(mastraMessages).values({
+        id: "m-1",
+        threadId: "t-1",
+        role: "user",
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+
+      await threadPersonaStatusRepository.syncMessageCounts(fakeD1);
+
+      const found = await threadPersonaStatusRepository.findByThreadId(
+        fakeD1,
+        "t-1",
+      );
+      expect(found?.lastMessageCount).toBe(1);
+    });
+
+    it("メッセージが残っていなければ 0 にする", async () => {
+      await threadPersonaStatusRepository.upsert(fakeD1, {
+        threadId: "t-1",
+        lastExtractedAt: "2025-01-01T00:00:00Z",
+        lastMessageCount: 10,
+      });
+
+      await threadPersonaStatusRepository.syncMessageCounts(fakeD1);
+
+      const found = await threadPersonaStatusRepository.findByThreadId(
+        fakeD1,
+        "t-1",
+      );
+      expect(found?.lastMessageCount).toBe(0);
+    });
+  });
+
+  describe("deleteOrphaned", () => {
+    it("スレッドが消えた状態だけを削除する", async () => {
+      const db = testDbHolder.db;
+      if (!db) throw new Error("test db is not initialized");
+      await db.insert(mastraThreads).values({
+        id: "t-alive",
+        resourceId: "web:a",
+        createdAt: "2025-01-01T00:00:00Z",
+      });
+      for (const threadId of ["t-alive", "t-gone"]) {
+        await threadPersonaStatusRepository.upsert(fakeD1, {
+          threadId,
+          lastExtractedAt: "2025-01-01T00:00:00Z",
+          lastMessageCount: 1,
+        });
+      }
+
+      const deleted =
+        await threadPersonaStatusRepository.deleteOrphaned(fakeD1);
+
+      expect(deleted).toBe(1);
+      expect(
+        await threadPersonaStatusRepository.findByThreadId(fakeD1, "t-alive"),
+      ).not.toBeNull();
+      expect(
+        await threadPersonaStatusRepository.findByThreadId(fakeD1, "t-gone"),
+      ).toBeNull();
     });
   });
 });

--- a/server/src/repository/thread-persona-status-repository.ts
+++ b/server/src/repository/thread-persona-status-repository.ts
@@ -72,9 +72,11 @@ export const threadPersonaStatusRepository = {
   async delete(d1: D1Database, threadId: string) {
     const db = createDb(d1);
 
-    await db
-      .delete(threadPersonaStatus)
-      .where(eq(threadPersonaStatus.threadId, threadId));
+    return deleteWithCount(
+      db,
+      threadPersonaStatus,
+      eq(threadPersonaStatus.threadId, threadId),
+    );
   },
 };
 

--- a/server/src/repository/thread-persona-status-repository.ts
+++ b/server/src/repository/thread-persona-status-repository.ts
@@ -1,6 +1,7 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 
 import { createDb, type ThreadPersonaStatus, threadPersonaStatus } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 type UpsertInput = {
   threadId: string;
@@ -44,6 +45,28 @@ export const threadPersonaStatusRepository = {
           lastMessageCount: input.lastMessageCount,
         },
       });
+  },
+
+  async syncMessageCounts(d1: D1Database) {
+    const db = createDb(d1);
+
+    await db.run(sql`
+      UPDATE thread_persona_status
+      SET last_message_count = COALESCE((
+        SELECT COUNT(*) FROM mastra_messages
+        WHERE mastra_messages.thread_id = thread_persona_status.thread_id
+      ), 0)
+    `);
+  },
+
+  async deleteOrphaned(d1: D1Database) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      threadPersonaStatus,
+      sql`${threadPersonaStatus.threadId} NOT IN (SELECT id FROM mastra_threads)`,
+    );
   },
 
   async delete(d1: D1Database, threadId: string) {

--- a/server/src/repository/user-broadcast-state-repository.test.ts
+++ b/server/src/repository/user-broadcast-state-repository.test.ts
@@ -68,4 +68,36 @@ describe("userBroadcastStateRepository", () => {
     );
     expect(result?.lastInjectedAt).toBe("2025-01-02T00:00:00Z");
   });
+
+  it("deleteByUserId: 指定ユーザーの状態だけを削除して件数を返す", async () => {
+    await userBroadcastStateRepository.upsert(
+      fakeD1,
+      "u1",
+      "2025-01-01T00:00:00Z",
+    );
+    await userBroadcastStateRepository.upsert(
+      fakeD1,
+      "u2",
+      "2025-01-01T00:00:00Z",
+    );
+
+    const deleted = await userBroadcastStateRepository.deleteByUserId(
+      fakeD1,
+      "u1",
+    );
+
+    expect(deleted).toBe(1);
+    expect(
+      await userBroadcastStateRepository.findByUserId(fakeD1, "u1"),
+    ).toBeNull();
+    expect(
+      await userBroadcastStateRepository.findByUserId(fakeD1, "u2"),
+    ).not.toBeNull();
+  });
+
+  it("deleteByUserId: 該当が無ければ 0 件を返す", async () => {
+    expect(
+      await userBroadcastStateRepository.deleteByUserId(fakeD1, "ghost"),
+    ).toBe(0);
+  });
 });

--- a/server/src/repository/user-broadcast-state-repository.ts
+++ b/server/src/repository/user-broadcast-state-repository.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { createDb, userBroadcastState } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 export const userBroadcastStateRepository = {
   async findByUserId(d1: D1Database, userId: string) {
@@ -25,5 +26,15 @@ export const userBroadcastStateRepository = {
         target: userBroadcastState.userId,
         set: { lastInjectedAt },
       });
+  },
+
+  async deleteByUserId(d1: D1Database, userId: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(
+      db,
+      userBroadcastState,
+      eq(userBroadcastState.userId, userId),
+    );
   },
 };

--- a/server/src/repository/user-poll-state-repository.test.ts
+++ b/server/src/repository/user-poll-state-repository.test.ts
@@ -44,4 +44,23 @@ describe("userPollStateRepository", () => {
     const result = await userPollStateRepository.findByUserId(fakeD1, "u1");
     expect(result?.lastInjectedAt).toBe("2025-01-02T00:00:00Z");
   });
+
+  it("deleteByUserId: 指定ユーザーの状態だけを削除して件数を返す", async () => {
+    await userPollStateRepository.upsert(fakeD1, "u1", "2025-01-01T00:00:00Z");
+    await userPollStateRepository.upsert(fakeD1, "u2", "2025-01-01T00:00:00Z");
+
+    const deleted = await userPollStateRepository.deleteByUserId(fakeD1, "u1");
+
+    expect(deleted).toBe(1);
+    expect(await userPollStateRepository.findByUserId(fakeD1, "u1")).toBeNull();
+    expect(
+      await userPollStateRepository.findByUserId(fakeD1, "u2"),
+    ).not.toBeNull();
+  });
+
+  it("deleteByUserId: 該当が無ければ 0 件を返す", async () => {
+    expect(await userPollStateRepository.deleteByUserId(fakeD1, "ghost")).toBe(
+      0,
+    );
+  });
 });

--- a/server/src/repository/user-poll-state-repository.ts
+++ b/server/src/repository/user-poll-state-repository.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 
 import { createDb, userPollState } from "~/db";
+import { deleteWithCount } from "./delete-with-count";
 
 export const userPollStateRepository = {
   async findByUserId(d1: D1Database, userId: string) {
@@ -25,5 +26,11 @@ export const userPollStateRepository = {
         target: userPollState.userId,
         set: { lastInjectedAt },
       });
+  },
+
+  async deleteByUserId(d1: D1Database, userId: string) {
+    const db = createDb(d1);
+
+    return deleteWithCount(db, userPollState, eq(userPollState.userId, userId));
   },
 };

--- a/server/src/services/analytics/aggregate.ts
+++ b/server/src/services/analytics/aggregate.ts
@@ -8,6 +8,10 @@ import {
 import { and, gte, isNotNull, lt, sql } from "drizzle-orm";
 import { createDb, persona } from "~/db";
 import { calcCostUsd } from "~/lib/llm-pricing";
+import {
+  llmUsageRepository,
+  type UsageSumRow,
+} from "~/repository/llm-usage-repository";
 
 // D1 の createdAt は UTC ISO 文字列。集計はすべて JST（+9 hours）で行い、
 // API は JST ラベル済みのデータを返す（フロントでは変換しない）。
@@ -107,34 +111,6 @@ export const getConversationStats = async (d1: D1Database, period: Period) => {
   };
 };
 
-type UsageSumRow = {
-  model: string;
-  inputTokens: number;
-  outputTokens: number;
-  reasoningTokens: number;
-  cachedInputTokens: number;
-  totalTokens: number;
-  persistedCostUsd: number;
-  legacyInputTokens: number;
-  legacyOutputTokens: number;
-  legacyCachedInputTokens: number;
-};
-
-// トークン合算と costUsd 算出用の SELECT 列。
-// cost_usd は記録時点の単価で永続化されるが、永続化開始前の行（NULL）は
-// legacy* のトークン数から現行単価で概算して合算する
-const usageSumColumns = sql`
-  SUM(input_tokens) AS inputTokens,
-  SUM(output_tokens) AS outputTokens,
-  SUM(reasoning_tokens) AS reasoningTokens,
-  SUM(cached_input_tokens) AS cachedInputTokens,
-  SUM(total_tokens) AS totalTokens,
-  SUM(COALESCE(cost_usd, 0)) AS persistedCostUsd,
-  SUM(CASE WHEN cost_usd IS NULL THEN input_tokens ELSE 0 END) AS legacyInputTokens,
-  SUM(CASE WHEN cost_usd IS NULL THEN output_tokens ELSE 0 END) AS legacyOutputTokens,
-  SUM(CASE WHEN cost_usd IS NULL THEN cached_input_tokens ELSE 0 END) AS legacyCachedInputTokens
-`;
-
 const usageCostUsd = (row: UsageSumRow) =>
   Number(row.persistedCostUsd) +
   calcCostUsd(row.model, {
@@ -157,41 +133,15 @@ export const getDailyUsage = async (
   d1: D1Database,
   params: { from: string },
 ) => {
-  const db = createDb(d1);
-
-  const rows = await db.all<UsageSumRow & { date: string }>(sql`
-    SELECT date(created_at, '+9 hours') AS date,
-           model,
-           ${usageSumColumns}
-    FROM llm_usage
-    WHERE created_at >= ${params.from}
-    GROUP BY date, model
-    ORDER BY date, model
-  `);
+  const rows = await llmUsageRepository.sumByDateAndModel(d1, params);
 
   return rows.map((row) => ({ date: row.date, ...withCost(row) }));
 };
 
 export const getUsageByModel = async (d1: D1Database, period: Period) => {
-  const db = createDb(d1);
-
-  const rows = await db.all<UsageSumRow>(sql`
-    SELECT model,
-           ${usageSumColumns}
-    FROM llm_usage
-    WHERE created_at >= ${period.from} AND created_at < ${period.to}
-    GROUP BY model
-    ORDER BY model
-  `);
+  const rows = await llmUsageRepository.sumByModel(d1, period);
 
   return rows.map(withCost);
-};
-
-type ThreadUsageRow = UsageSumRow & {
-  threadId: string;
-  agent: string | null;
-  platform: string | null;
-  chatCalls: number;
 };
 
 type AgentTotals = {
@@ -216,17 +166,6 @@ const addAgentTotals = (
 
 const sortedAgentTotals = (map: Map<string | null, AgentTotals>) =>
   [...map.values()].sort((a, b) => b.costUsd - a.costUsd);
-
-// 会話に直接かかった費用と、それ以外の運用費を分けて見るための区分。
-// embedding は検索クエリ分（スレッドに紐づく）が会話、ナレッジ同期分が基盤
-const usageCategoryExpr = sql`
-  CASE
-    WHEN source IN ('chat', 'subagent', 'intent-classify', 'rerank') THEN 'conversation'
-    WHEN source = 'embedding' AND thread_id IS NOT NULL THEN 'conversation'
-    WHEN source = 'embedding' THEN 'knowledge-base'
-    ELSE 'batch'
-  END
-`;
 
 // 請求元の突き合わせ用。モデル ID からプロバイダを判定する
 const providerOf = (model: string) => {
@@ -257,27 +196,9 @@ const addProviderTotals = (
 };
 
 export const getOperationCost = async (d1: D1Database, period: Period) => {
-  const db = createDb(d1);
-
   const [rows, dailyRows] = await Promise.all([
-    db.all<UsageSumRow & { category: string; agent: string | null }>(sql`
-      SELECT ${usageCategoryExpr} AS category,
-             agent,
-             model,
-             ${usageSumColumns}
-      FROM llm_usage
-      WHERE created_at >= ${period.from} AND created_at < ${period.to}
-      GROUP BY category, agent, model
-    `),
-    db.all<UsageSumRow & { date: string }>(sql`
-      SELECT date(created_at, '+9 hours') AS date,
-             model,
-             ${usageSumColumns}
-      FROM llm_usage
-      WHERE created_at >= ${period.from} AND created_at < ${period.to}
-      GROUP BY date, model
-      ORDER BY date
-    `),
+    llmUsageRepository.sumByCategory(d1, period),
+    llmUsageRepository.sumByDateAndModel(d1, period),
   ]);
 
   const dailyTotals = new Map<string, number>();
@@ -336,19 +257,7 @@ export const getThreadUsage = async (
   const db = createDb(d1);
 
   const [threadModelRows, messageRows] = await Promise.all([
-    db.all<ThreadUsageRow>(sql`
-      SELECT thread_id AS threadId,
-             agent,
-             model,
-             MAX(platform) AS platform,
-             SUM(CASE WHEN source = 'chat' THEN 1 ELSE 0 END) AS chatCalls,
-             ${usageSumColumns}
-      FROM llm_usage
-      WHERE created_at >= ${period.from} AND created_at < ${period.to}
-        AND thread_id IS NOT NULL
-        AND ${usageCategoryExpr} = 'conversation'
-      GROUP BY thread_id, agent, model
-    `),
+    llmUsageRepository.sumConversationByThread(d1, period),
     db.all<{
       threadId: string;
       firstMessageAt: string;
@@ -463,30 +372,7 @@ export const getThreadUsage = async (
 };
 
 export const getThreadTurnUsage = async (d1: D1Database, threadId: string) => {
-  const db = createDb(d1);
-
-  const rows = await db.all<
-    UsageSumRow & {
-      turnIndex: number | null;
-      agent: string | null;
-      durationMs: number | null;
-      answeredAt: string;
-      intent: string | null;
-    }
-  >(sql`
-    SELECT turn_index AS turnIndex,
-           agent,
-           model,
-           MAX(CASE WHEN source = 'chat' THEN duration_ms END) AS durationMs,
-           MAX(CASE WHEN source = 'chat' THEN created_at END) AS answeredAt,
-           MAX(CASE WHEN source = 'chat' THEN intent END) AS intent,
-           ${usageSumColumns}
-    FROM llm_usage
-    WHERE thread_id = ${threadId}
-      AND ${usageCategoryExpr} = 'conversation'
-    GROUP BY turn_index, agent, model
-    ORDER BY turn_index, agent
-  `);
+  const rows = await llmUsageRepository.sumConversationByTurn(d1, threadId);
 
   type TurnTotals = {
     turnIndex: number | null;

--- a/server/src/services/analytics/aggregate.ts
+++ b/server/src/services/analytics/aggregate.ts
@@ -12,6 +12,7 @@ import {
   llmUsageRepository,
   type UsageSumRow,
 } from "~/repository/llm-usage-repository";
+import { mastraMessageRepository } from "~/repository/mastra-message-repository";
 
 // D1 の createdAt は UTC ISO 文字列。集計はすべて JST（+9 hours）で行い、
 // API は JST ラベル済みのデータを返す（フロントでは変換しない）。
@@ -47,49 +48,13 @@ const AGE_GROUPS = [
 const RESIDENCES = ["村内", "村外"] as const;
 
 export const getConversationStats = async (d1: D1Database, period: Period) => {
-  const db = createDb(d1);
-
   const [hourlyRows, weekdayRows, daily, platforms, totalsRow] =
     await Promise.all([
-      db.all<{ hour: number; count: number }>(sql`
-      SELECT CAST(strftime('%H', createdAt, '+9 hours') AS INTEGER) AS hour,
-             COUNT(*) AS count
-      FROM mastra_messages
-      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
-      GROUP BY hour
-    `),
-      db.all<{ dow: number; count: number }>(sql`
-      SELECT CAST(strftime('%w', createdAt, '+9 hours') AS INTEGER) AS dow,
-             COUNT(*) AS count
-      FROM mastra_messages
-      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
-      GROUP BY dow
-    `),
-      db.all<{ date: string; conversations: number; messages: number }>(sql`
-      SELECT strftime('%Y-%m-%d', createdAt, '+9 hours') AS date,
-             COUNT(DISTINCT thread_id) AS conversations,
-             COUNT(*) AS messages
-      FROM mastra_messages
-      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
-      GROUP BY date
-      ORDER BY date
-    `),
-      db.all<{ platform: string; count: number }>(sql`
-      SELECT CASE WHEN t.resourceId LIKE 'line:%' THEN 'line'
-                  WHEN t.resourceId LIKE 'admin:%' THEN 'admin'
-                  WHEN t.resourceId LIKE 'widget-%' THEN 'widget'
-                  ELSE 'web' END AS platform,
-             COUNT(*) AS count
-      FROM mastra_messages m
-      JOIN mastra_threads t ON m.thread_id = t.id
-      WHERE m.role = 'user' AND m.createdAt >= ${period.from} AND m.createdAt < ${period.to}
-      GROUP BY platform
-    `),
-      db.get<{ conversations: number; messages: number }>(sql`
-      SELECT COUNT(DISTINCT thread_id) AS conversations, COUNT(*) AS messages
-      FROM mastra_messages
-      WHERE role = 'user' AND createdAt >= ${period.from} AND createdAt < ${period.to}
-    `),
+      mastraMessageRepository.countUserMessagesByHour(d1, period),
+      mastraMessageRepository.countUserMessagesByWeekday(d1, period),
+      mastraMessageRepository.countUserMessagesByDate(d1, period),
+      mastraMessageRepository.countUserMessagesByPlatform(d1, period),
+      mastraMessageRepository.countUserMessageTotals(d1, period),
     ]);
 
   return {
@@ -254,27 +219,9 @@ export const getThreadUsage = async (
   period: Period,
   params: { limit: number },
 ) => {
-  const db = createDb(d1);
-
   const [threadModelRows, messageRows] = await Promise.all([
     llmUsageRepository.sumConversationByThread(d1, period),
-    db.all<{
-      threadId: string;
-      firstMessageAt: string;
-      lastMessageAt: string;
-    }>(sql`
-      SELECT thread_id AS threadId,
-             MIN(createdAt) AS firstMessageAt,
-             MAX(createdAt) AS lastMessageAt
-      FROM mastra_messages
-      WHERE createdAt >= ${period.from} AND createdAt < ${period.to}
-        AND thread_id IN (
-          SELECT DISTINCT thread_id FROM llm_usage
-          WHERE created_at >= ${period.from} AND created_at < ${period.to}
-            AND thread_id IS NOT NULL
-        )
-      GROUP BY thread_id
-    `),
+    mastraMessageRepository.findSpansOfUsedThreads(d1, period),
   ]);
 
   const messagesByThread = new Map(

--- a/server/src/services/analytics/aggregate.ts
+++ b/server/src/services/analytics/aggregate.ts
@@ -13,8 +13,7 @@ import {
 import { mastraMessageRepository } from "~/repository/mastra-message-repository";
 import { personaRepository } from "~/repository/persona-repository";
 
-// D1 の createdAt は UTC ISO 文字列。集計はすべて JST（+9 hours）で行い、
-// API は JST ラベル済みのデータを返す（フロントでは変換しない）。
+// API は JST ラベル済みのデータを返す（フロントでは変換しない）
 
 type Period = { from: string; to: string };
 
@@ -220,7 +219,7 @@ export const getThreadUsage = async (
 ) => {
   const [threadModelRows, messageRows] = await Promise.all([
     llmUsageRepository.sumConversationByThread(d1, period),
-    mastraMessageRepository.findSpansOfUsedThreads(d1, period),
+    mastraMessageRepository.findMessageSpansForThreadsWithUsage(d1, period),
   ]);
 
   const messagesByThread = new Map(

--- a/server/src/services/analytics/aggregate.ts
+++ b/server/src/services/analytics/aggregate.ts
@@ -5,14 +5,13 @@ import {
   personaAttributes,
   TOPICS,
 } from "@nepp-chan/shared/lib/persona-attributes";
-import { and, gte, isNotNull, lt, sql } from "drizzle-orm";
-import { createDb, persona } from "~/db";
 import { calcCostUsd } from "~/lib/llm-pricing";
 import {
   llmUsageRepository,
   type UsageSumRow,
 } from "~/repository/llm-usage-repository";
 import { mastraMessageRepository } from "~/repository/mastra-message-repository";
+import { personaRepository } from "~/repository/persona-repository";
 
 // D1 の createdAt は UTC ISO 文字列。集計はすべて JST（+9 hours）で行い、
 // API は JST ラベル済みのデータを返す（フロントでは変換しない）。
@@ -389,55 +388,11 @@ export const getPersonaAnalytics = async (
   d1: D1Database,
   params: { from?: string; to?: string },
 ) => {
-  const db = createDb(d1);
-
-  // 期間はすべて会話終了時刻（conversationEndedAt）基準。
-  // createdAt は抽出バッチの実行時刻で、会話のあった期間を表さないため
-  const periodConditions = [
-    params.from ? gte(persona.conversationEndedAt, params.from) : undefined,
-    params.to ? lt(persona.conversationEndedAt, params.to) : undefined,
-  ].filter((c) => c !== undefined);
-
-  const hourExpr = sql<number>`CAST(strftime('%H', ${persona.conversationEndedAt}, '+9 hours') AS INTEGER)`;
-  const dowExpr = sql<number>`CAST(strftime('%w', ${persona.conversationEndedAt}, '+9 hours') AS INTEGER)`;
-  // 開庁 = 平日（月〜金）の 8〜17 時 JST。それ以外は閉庁
-  const isOpenExpr = sql<number>`CASE WHEN ${dowExpr} BETWEEN 1 AND 5 AND ${hourExpr} BETWEEN 8 AND 16 THEN 1 ELSE 0 END`;
-  const hourlyConditions = [
-    isNotNull(persona.conversationEndedAt),
-    ...periodConditions,
-  ];
-
   const [rows, hourlyRows, weekdayRows, officeRow] = await Promise.all([
-    db
-      .select({
-        tags: persona.tags,
-        demographicSummary: persona.demographicSummary,
-        topic: persona.topic,
-        sentiment: persona.sentiment,
-      })
-      .from(persona)
-      .where(periodConditions.length > 0 ? and(...periodConditions) : undefined)
-      .all(),
-    db
-      .select({ hour: hourExpr, count: sql<number>`COUNT(*)` })
-      .from(persona)
-      .where(and(...hourlyConditions))
-      .groupBy(hourExpr)
-      .all(),
-    db
-      .select({ dow: dowExpr, count: sql<number>`COUNT(*)` })
-      .from(persona)
-      .where(and(...hourlyConditions))
-      .groupBy(dowExpr)
-      .all(),
-    db
-      .select({
-        open: sql<number>`SUM(${isOpenExpr})`,
-        total: sql<number>`COUNT(*)`,
-      })
-      .from(persona)
-      .where(and(...hourlyConditions))
-      .get(),
+    personaRepository.listAttributes(d1, params),
+    personaRepository.countByConversationHour(d1, params),
+    personaRepository.countByConversationWeekday(d1, params),
+    personaRepository.countOfficeHours(d1, params),
   ]);
 
   const ageSentiment = new Map(

--- a/server/src/services/analytics/llm-usage.ts
+++ b/server/src/services/analytics/llm-usage.ts
@@ -1,9 +1,8 @@
 import type { RequestContext } from "@mastra/core/request-context";
 import type { MastraOnFinishCallbackArgs } from "@mastra/core/stream";
-import { and, count, eq } from "drizzle-orm";
-import { createDb, llmUsage } from "~/db";
 import { calcCostUsd, type LlmServiceTier } from "~/lib/llm-pricing";
 import { logger } from "~/lib/logger";
+import { llmUsageRepository } from "~/repository/llm-usage-repository";
 
 export type LlmUsagePlatform = "web" | "line" | "lp" | "widget" | "voice";
 
@@ -50,12 +49,11 @@ export const recordLlmUsage = async (
   params: LlmUsageParams,
 ) => {
   try {
-    const db = createDb(d1);
     const inputTokens = finiteOrZero(params.usage?.inputTokens);
     const outputTokens = finiteOrZero(params.usage?.outputTokens);
     const reasoningTokens = finiteOrZero(params.usage?.reasoningTokens);
     const cachedInputTokens = finiteOrZero(params.usage?.cachedInputTokens);
-    await db.insert(llmUsage).values({
+    await llmUsageRepository.create(d1, {
       id: crypto.randomUUID(),
       model: params.model,
       inputTokens,
@@ -95,13 +93,8 @@ export const recordLlmUsage = async (
  */
 export const nextTurnIndex = async (d1: D1Database, threadId: string) => {
   try {
-    const db = createDb(d1);
-    const row = await db
-      .select({ value: count() })
-      .from(llmUsage)
-      .where(and(eq(llmUsage.threadId, threadId), eq(llmUsage.source, "chat")))
-      .get();
-    return Number(row?.value ?? 0) + 1;
+    const chatCalls = await llmUsageRepository.countChatByThread(d1, threadId);
+    return chatCalls + 1;
   } catch (error) {
     logger.warn("[LlmUsage] failed to resolve turn index", {
       error: String(error),

--- a/server/src/services/analytics/ontology.ts
+++ b/server/src/services/analytics/ontology.ts
@@ -153,7 +153,7 @@ type EntityAgg = {
 };
 
 export const getOntology = async (d1: D1Database): Promise<OntologyData> => {
-  const rows = await personaRepository.listAttributesWithEntities(d1);
+  const rows = await personaRepository.listAllAttributesWithEntities(d1);
 
   const segmentCounts = new Map<Segment, number>();
   const topicAgg = new Map<

--- a/server/src/services/analytics/ontology.ts
+++ b/server/src/services/analytics/ontology.ts
@@ -3,7 +3,7 @@ import {
   normalizeTopic,
   personaAttributes,
 } from "@nepp-chan/shared/lib/persona-attributes";
-import { createDb, persona } from "~/db";
+import { personaRepository } from "~/repository/persona-repository";
 import { personaEntitiesSchema } from "~/schemas/persona-entity-schema";
 import { emptySentimentCounts } from "./aggregate";
 
@@ -153,18 +153,7 @@ type EntityAgg = {
 };
 
 export const getOntology = async (d1: D1Database): Promise<OntologyData> => {
-  const db = createDb(d1);
-
-  const rows = await db
-    .select({
-      tags: persona.tags,
-      demographicSummary: persona.demographicSummary,
-      topic: persona.topic,
-      sentiment: persona.sentiment,
-      entities: persona.entities,
-    })
-    .from(persona)
-    .all();
+  const rows = await personaRepository.listAttributesWithEntities(d1);
 
   const segmentCounts = new Map<Segment, number>();
   const topicAgg = new Map<

--- a/server/src/services/analytics/weekly-report.ts
+++ b/server/src/services/analytics/weekly-report.ts
@@ -1,6 +1,4 @@
 import { Mastra } from "@mastra/core/mastra";
-import { and, gte, lt } from "drizzle-orm";
-import { createDb, persona } from "~/db";
 import { DAY_MS, jstDateLabel, startOfJstWeek, WEEK_MS } from "~/lib/date";
 import { OPENAI_LITE } from "~/lib/llm-models";
 import { logger } from "~/lib/logger";
@@ -10,6 +8,7 @@ import {
   weeklyReportAgent,
 } from "~/mastra/agents/weekly-report-agent";
 import { createRequestContext } from "~/mastra/request-context";
+import { personaRepository } from "~/repository/persona-repository";
 import { weeklyReportRepository } from "~/repository/weekly-report-repository";
 import type { WeeklyStats } from "~/schemas/analytics-schema";
 import {
@@ -42,23 +41,7 @@ const generateWeeklySummary = async (
   env: CloudflareBindings,
   period: { from: string; to: string },
 ) => {
-  const db = createDb(env.DB);
-
-  const voices = await db
-    .select({
-      category: persona.category,
-      topic: persona.topic,
-      sentiment: persona.sentiment,
-      content: persona.content,
-    })
-    .from(persona)
-    .where(
-      and(
-        gte(persona.createdAt, period.from),
-        lt(persona.createdAt, period.to),
-      ),
-    )
-    .all();
+  const voices = await personaRepository.listCreatedBetween(env.DB, period);
 
   if (voices.length === 0) {
     return NO_VOICE_SUMMARY;

--- a/server/src/services/data-retention.ts
+++ b/server/src/services/data-retention.ts
@@ -35,7 +35,6 @@ export const runDataRetention = async (
 ): Promise<DataRetentionResult[]> => {
   const now = options.now ?? new Date();
   const executedAt = now.toISOString();
-  const expiredAt = (days: number) => cutoff(now, days);
 
   try {
     // Mastra テーブルは drizzle の migration 対象外。未初期化の D1 に対して
@@ -48,7 +47,7 @@ export const runDataRetention = async (
       table: "mastra_messages",
       deletedCount: await mastraMessageRepository.deleteCreatedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.mastra_messages),
+        cutoff(now, RETENTION_DAYS.mastra_messages),
       ),
     });
 
@@ -63,7 +62,7 @@ export const runDataRetention = async (
       table: "mastra_threads",
       deletedCount: await mastraThreadRepository.deleteEmptyCreatedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.mastra_threads),
+        cutoff(now, RETENTION_DAYS.mastra_threads),
       ),
     });
 
@@ -76,7 +75,7 @@ export const runDataRetention = async (
       table: "mastra_resources",
       deletedCount: await mastraResourceRepository.deleteUpdatedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.mastra_resources),
+        cutoff(now, RETENTION_DAYS.mastra_resources),
       ),
     });
 
@@ -84,7 +83,7 @@ export const runDataRetention = async (
       table: "message_feedback",
       deletedCount: await feedbackRepository.deleteCreatedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.message_feedback),
+        cutoff(now, RETENTION_DAYS.message_feedback),
       ),
     });
 
@@ -92,7 +91,7 @@ export const runDataRetention = async (
       table: "llm_usage",
       deletedCount: await llmUsageRepository.deleteCreatedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.llm_usage),
+        cutoff(now, RETENTION_DAYS.llm_usage),
       ),
     });
 
@@ -100,7 +99,7 @@ export const runDataRetention = async (
       table: "poll_submissions",
       deletedCount: await pollRepository.deleteSubmissionsCreatedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.poll_submissions),
+        cutoff(now, RETENTION_DAYS.poll_submissions),
       ),
     });
 
@@ -108,7 +107,7 @@ export const runDataRetention = async (
       table: "data_retention_logs",
       deletedCount: await dataRetentionLogRepository.deleteExecutedBefore(
         env.DB,
-        expiredAt(RETENTION_DAYS.data_retention_logs),
+        cutoff(now, RETENTION_DAYS.data_retention_logs),
       ),
     });
 

--- a/server/src/services/data-retention.ts
+++ b/server/src/services/data-retention.ts
@@ -1,21 +1,13 @@
-import type { SQL } from "drizzle-orm";
-import { sql } from "drizzle-orm";
-import type { SQLiteTable } from "drizzle-orm/sqlite-core";
-
-import {
-  createDb,
-  type DbClient,
-  dataRetentionLogs,
-  llmUsage,
-  mastraMessages,
-  mastraResources,
-  mastraThreads,
-  messageFeedback,
-  pollSubmissions,
-  threadPersonaStatus,
-} from "~/db";
 import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
+import { dataRetentionLogRepository } from "~/repository/data-retention-log-repository";
+import { feedbackRepository } from "~/repository/feedback-repository";
+import { llmUsageRepository } from "~/repository/llm-usage-repository";
+import { mastraMessageRepository } from "~/repository/mastra-message-repository";
+import { mastraResourceRepository } from "~/repository/mastra-resource-repository";
+import { mastraThreadRepository } from "~/repository/mastra-thread-repository";
+import { pollRepository } from "~/repository/poll-repository";
+import { threadPersonaStatusRepository } from "~/repository/thread-persona-status-repository";
 
 const RETENTION_DAYS = {
   mastra_messages: 30,
@@ -37,30 +29,13 @@ export type DataRetentionResult = {
 const cutoff = (now: Date, days: number) =>
   new Date(now.getTime() - days * DAY_MS).toISOString();
 
-const countAndDelete = async (
-  db: DbClient,
-  table: SQLiteTable,
-  where: SQL,
-): Promise<number> => {
-  const row = await db
-    .select({ c: sql<number>`COUNT(*)` })
-    .from(table)
-    .where(where)
-    .get();
-  const count = Number(row?.c ?? 0);
-  if (count > 0) {
-    await db.delete(table).where(where);
-  }
-  return count;
-};
-
 export const runDataRetention = async (
   env: CloudflareBindings,
   options: { now?: Date } = {},
 ): Promise<DataRetentionResult[]> => {
   const now = options.now ?? new Date();
   const executedAt = now.toISOString();
-  const db = createDb(env.DB);
+  const expiredAt = (days: number) => cutoff(now, days);
 
   try {
     // Mastra テーブルは drizzle の migration 対象外。未初期化の D1 に対して
@@ -71,92 +46,74 @@ export const runDataRetention = async (
 
     results.push({
       table: "mastra_messages",
-      deletedCount: await countAndDelete(
-        db,
-        mastraMessages,
-        sql`datetime(${mastraMessages.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.mastra_messages)})`,
+      deletedCount: await mastraMessageRepository.deleteCreatedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.mastra_messages),
       ),
     });
 
     // mastra_messages 削除により thread_persona_status.last_message_count が
     // 現実より大きいまま残ると、persona-extractor が新規メッセージを抽出対象外と
     // 判定してしまう。残メッセージ数で再計算して整合性を取る。
-    await db.run(sql`
-      UPDATE thread_persona_status
-      SET last_message_count = COALESCE((
-        SELECT COUNT(*) FROM mastra_messages
-        WHERE mastra_messages.thread_id = thread_persona_status.thread_id
-      ), 0)
-    `);
+    await threadPersonaStatusRepository.syncMessageCounts(env.DB);
 
     // 紐づくメッセージが無く、かつ作成から猶予期間を超えたスレッドのみ削除。
     // 新規作成直後の空スレッドが Cron で消えると POST /threads → チャット投稿の間に 404 になる。
     results.push({
       table: "mastra_threads",
-      deletedCount: await countAndDelete(
-        db,
-        mastraThreads,
-        sql`${mastraThreads.id} NOT IN (SELECT DISTINCT thread_id FROM mastra_messages)
-          AND datetime(${mastraThreads.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.mastra_threads)})`,
+      deletedCount: await mastraThreadRepository.deleteEmptyCreatedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.mastra_threads),
       ),
     });
 
     results.push({
       table: "thread_persona_status",
-      deletedCount: await countAndDelete(
-        db,
-        threadPersonaStatus,
-        sql`${threadPersonaStatus.threadId} NOT IN (SELECT id FROM mastra_threads)`,
-      ),
+      deletedCount: await threadPersonaStatusRepository.deleteOrphaned(env.DB),
     });
 
     results.push({
       table: "mastra_resources",
-      deletedCount: await countAndDelete(
-        db,
-        mastraResources,
-        sql`datetime(${mastraResources.updatedAt}) < datetime(${cutoff(now, RETENTION_DAYS.mastra_resources)})`,
+      deletedCount: await mastraResourceRepository.deleteUpdatedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.mastra_resources),
       ),
     });
 
     results.push({
       table: "message_feedback",
-      deletedCount: await countAndDelete(
-        db,
-        messageFeedback,
-        sql`datetime(${messageFeedback.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.message_feedback)})`,
+      deletedCount: await feedbackRepository.deleteCreatedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.message_feedback),
       ),
     });
 
     results.push({
       table: "llm_usage",
-      deletedCount: await countAndDelete(
-        db,
-        llmUsage,
-        sql`datetime(${llmUsage.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.llm_usage)})`,
+      deletedCount: await llmUsageRepository.deleteCreatedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.llm_usage),
       ),
     });
 
     results.push({
       table: "poll_submissions",
-      deletedCount: await countAndDelete(
-        db,
-        pollSubmissions,
-        sql`datetime(${pollSubmissions.createdAt}) < datetime(${cutoff(now, RETENTION_DAYS.poll_submissions)})`,
+      deletedCount: await pollRepository.deleteSubmissionsCreatedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.poll_submissions),
       ),
     });
 
     results.push({
       table: "data_retention_logs",
-      deletedCount: await countAndDelete(
-        db,
-        dataRetentionLogs,
-        sql`datetime(${dataRetentionLogs.executedAt}) < datetime(${cutoff(now, RETENTION_DAYS.data_retention_logs)})`,
+      deletedCount: await dataRetentionLogRepository.deleteExecutedBefore(
+        env.DB,
+        expiredAt(RETENTION_DAYS.data_retention_logs),
       ),
     });
 
     for (const r of results) {
-      await db.insert(dataRetentionLogs).values({
+      await dataRetentionLogRepository.create(env.DB, {
         id: crypto.randomUUID(),
         executedAt,
         targetTable: r.table,

--- a/server/src/services/persona-extractor.ts
+++ b/server/src/services/persona-extractor.ts
@@ -1,15 +1,15 @@
 import { Mastra } from "@mastra/core/mastra";
 import { Memory } from "@mastra/memory";
-import { count, desc, eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { createDb, mastraMessages, mastraThreads } from "~/db";
 import type { LlmServiceTier } from "~/lib/llm-pricing";
 import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
 import { getPersonaAgent } from "~/mastra/agents/persona-agent";
 import { getWorkingMemoryByThread } from "~/mastra/memory";
 import { createRequestContext } from "~/mastra/request-context";
+import { mastraMessageRepository } from "~/repository/mastra-message-repository";
+import { mastraThreadRepository } from "~/repository/mastra-thread-repository";
 import { threadPersonaStatusRepository } from "~/repository/thread-persona-status-repository";
 
 type ExtractResult =
@@ -131,33 +131,15 @@ export const extractPersonaFromThread = async (
 type ThreadInfo = { id: string; resourceId: string };
 
 const getAllThreads = async (d1: D1Database): Promise<ThreadInfo[]> => {
-  const db = createDb(d1);
+  const threads = await mastraThreadRepository.findAll(d1);
 
-  const results = await db
-    .select({
-      id: mastraThreads.id,
-      resourceId: mastraThreads.resourceId,
-    })
-    .from(mastraThreads)
-    .orderBy(desc(mastraThreads.id))
-    .all();
-
-  return results.filter((t): t is ThreadInfo => t.resourceId !== null);
+  return threads.filter((t): t is ThreadInfo => t.resourceId !== null);
 };
 
 const getMessageCountsByThread = async (
   d1: D1Database,
 ): Promise<Map<string, number>> => {
-  const db = createDb(d1);
-
-  const results = await db
-    .select({
-      threadId: mastraMessages.threadId,
-      count: count(),
-    })
-    .from(mastraMessages)
-    .groupBy(mastraMessages.threadId)
-    .all();
+  const results = await mastraMessageRepository.countByThread(d1);
 
   return new Map(results.map((r) => [r.threadId, r.count]));
 };
@@ -218,16 +200,7 @@ const findThreadById = async (
   d1: D1Database,
   threadId: string,
 ): Promise<ThreadInfo> => {
-  const db = createDb(d1);
-
-  const thread = await db
-    .select({
-      id: mastraThreads.id,
-      resourceId: mastraThreads.resourceId,
-    })
-    .from(mastraThreads)
-    .where(eq(mastraThreads.id, threadId))
-    .get();
+  const thread = await mastraThreadRepository.findById(d1, threadId);
 
   if (!thread?.resourceId) {
     throw new HTTPException(404, { message: "スレッドが見つかりません" });

--- a/server/src/services/thread.test.ts
+++ b/server/src/services/thread.test.ts
@@ -44,10 +44,8 @@ describe("deleteThreadWithRelatedData", () => {
 
   it("存在するスレッドの関連データを全て削除できる", async () => {
     mockGetThreadById.mockResolvedValue({ id: threadId });
-    vi.mocked(feedbackRepository.deleteByThreadId).mockResolvedValue(undefined);
-    vi.mocked(threadPersonaStatusRepository.delete).mockResolvedValue(
-      undefined,
-    );
+    vi.mocked(feedbackRepository.deleteByThreadId).mockResolvedValue(0);
+    vi.mocked(threadPersonaStatusRepository.delete).mockResolvedValue(0);
     mockDeleteThread.mockResolvedValue(undefined);
 
     await deleteThreadWithRelatedData(threadId, mockDb);
@@ -70,11 +68,13 @@ describe("deleteThreadWithRelatedData", () => {
     vi.mocked(feedbackRepository.deleteByThreadId).mockImplementation(
       async () => {
         callOrder.push("feedback");
+        return 0;
       },
     );
     vi.mocked(threadPersonaStatusRepository.delete).mockImplementation(
       async () => {
         callOrder.push("personaStatus");
+        return 0;
       },
     );
     mockDeleteThread.mockImplementation(async () => {

--- a/server/src/services/user-deletion.ts
+++ b/server/src/services/user-deletion.ts
@@ -1,32 +1,14 @@
-import type { SQL } from "drizzle-orm";
-import { eq, sql } from "drizzle-orm";
-import type { SQLiteTable } from "drizzle-orm/sqlite-core";
-
-import {
-  createDb,
-  type DbClient,
-  mastraMessages,
-  mastraResources,
-  mastraThreads,
-  messageFeedback,
-  pollSubmissions,
-  threadPersonaStatus,
-  userBroadcastState,
-  userPollState,
-} from "~/db";
 import { hmacSha256 } from "~/lib/crypto";
 import { logger } from "~/lib/logger";
 import { getStorage } from "~/lib/storage";
-
-const countAndDelete = async (db: DbClient, table: SQLiteTable, where: SQL) => {
-  const row = await db
-    .select({ c: sql<number>`COUNT(*)` })
-    .from(table)
-    .where(where)
-    .get();
-  await db.delete(table).where(where);
-  return Number(row?.c ?? 0);
-};
+import { feedbackRepository } from "~/repository/feedback-repository";
+import { mastraMessageRepository } from "~/repository/mastra-message-repository";
+import { mastraResourceRepository } from "~/repository/mastra-resource-repository";
+import { mastraThreadRepository } from "~/repository/mastra-thread-repository";
+import { pollRepository } from "~/repository/poll-repository";
+import { threadPersonaStatusRepository } from "~/repository/thread-persona-status-repository";
+import { userBroadcastStateRepository } from "~/repository/user-broadcast-state-repository";
+import { userPollStateRepository } from "~/repository/user-poll-state-repository";
 
 export const deleteAllByLineUserId = async (
   env: CloudflareBindings,
@@ -36,53 +18,35 @@ export const deleteAllByLineUserId = async (
   const lineThreadId = `line-thread:${hashedUserId}`;
   const lineResourceId = `line:${hashedUserId}`;
 
-  const db = createDb(env.DB);
-
   try {
     // Mastra テーブルは drizzle の migration 対象外（tablesFilter で除外）。
     // 未初期化の D1 に対して unfollow が最初に届くと "no such table" になるため、
     // D1Store.init() を経由してテーブルの存在を保証する。
     await getStorage(env.DB);
 
-    const mastraMessagesDeleted = await countAndDelete(
-      db,
-      mastraMessages,
-      eq(mastraMessages.threadId, lineThreadId),
+    const mastraMessagesDeleted =
+      await mastraMessageRepository.deleteByThreadId(env.DB, lineThreadId);
+    const messageFeedbackDeleted = await feedbackRepository.deleteByThreadId(
+      env.DB,
+      lineThreadId,
     );
-    const messageFeedbackDeleted = await countAndDelete(
-      db,
-      messageFeedback,
-      eq(messageFeedback.threadId, lineThreadId),
+    const threadPersonaStatusDeleted =
+      await threadPersonaStatusRepository.delete(env.DB, lineThreadId);
+    const mastraThreadsDeleted = await mastraThreadRepository.deleteById(
+      env.DB,
+      lineThreadId,
     );
-    const threadPersonaStatusDeleted = await countAndDelete(
-      db,
-      threadPersonaStatus,
-      eq(threadPersonaStatus.threadId, lineThreadId),
+    const mastraResourcesDeleted = await mastraResourceRepository.deleteById(
+      env.DB,
+      lineResourceId,
     );
-    const mastraThreadsDeleted = await countAndDelete(
-      db,
-      mastraThreads,
-      eq(mastraThreads.id, lineThreadId),
-    );
-    const mastraResourcesDeleted = await countAndDelete(
-      db,
-      mastraResources,
-      eq(mastraResources.id, lineResourceId),
-    );
-    const pollSubmissionsDeleted = await countAndDelete(
-      db,
-      pollSubmissions,
-      eq(pollSubmissions.userId, hashedUserId),
-    );
-    const userBroadcastStateDeleted = await countAndDelete(
-      db,
-      userBroadcastState,
-      eq(userBroadcastState.userId, hashedUserId),
-    );
-    const userPollStateDeleted = await countAndDelete(
-      db,
-      userPollState,
-      eq(userPollState.userId, hashedUserId),
+    const pollSubmissionsDeleted =
+      await pollRepository.deleteSubmissionsByUserId(env.DB, hashedUserId);
+    const userBroadcastStateDeleted =
+      await userBroadcastStateRepository.deleteByUserId(env.DB, hashedUserId);
+    const userPollStateDeleted = await userPollStateRepository.deleteByUserId(
+      env.DB,
+      hashedUserId,
     );
 
     logger.info("user_data_deleted", {


### PR DESCRIPTION
## 概要

「SQL を書けるのは `repository/` だけ。`services/` は repository を組み合わせる」という原則に、server 全体を合わせた。

これまでは薄い CRUD が routes → repository、集計・横断処理が routes → service → db という 2 経路になっていて、service が SQL を直接持っていた。この PR で後者の SQL をすべて repository へ移し、プロダクトコードで `createDb` / drizzle / 生 SQL を使うファイルを `repository/` と `db/` だけにした。

## 置き場の判断基準

`server/CLAUDE.md` に規約として追記した。

- どの repository に置くかは、結合したテーブル数ではなく **返す行・変更する行がどのテーブルのものか** で決める。JOIN の相手は問わない
- 主テーブルが無い横断処理（ユーザーデータ一括削除・保管期間削除）は service に置き、service が各 repository を順に呼ぶ
- repository のメソッド名は意図で名付ける。service / routes から `SQL` 断片を受け取る API にしない

## 変更内容

| 新規 repository | 移動元 |
| --- | --- |
| `llm-usage-repository` | `services/analytics/llm-usage.ts`, `aggregate.ts` |
| `mastra-message-repository` | `aggregate.ts`, `persona-extractor.ts` |
| `mastra-thread-repository` | `persona-extractor.ts`, `data-retention.ts`, `user-deletion.ts` |
| `mastra-resource-repository` | `data-retention.ts`, `user-deletion.ts` |
| `data-retention-log-repository` | `data-retention.ts` |
| `delete-with-count` | 両 service に重複していた `countAndDelete` を統合した共有ヘルパ |

既存の `persona` / `feedback` / `poll` / `thread-persona-status` / `user-broadcast-state` / `user-poll-state` repository にはメソッドを追加した。

## 振る舞いの変更

抽出リファクタだが、次の 3 点は変わっている。

1. `feedbackRepository.deleteByThreadId` と `threadPersonaStatusRepository.delete` が削除件数を返すようになった。`services/thread.ts`（管理画面のスレッド削除）でテーブルごとに COUNT が 1 本増え、0 件時は DELETE を撃たなくなる。`thread.test.ts` のモックを合わせている
2. `user-deletion` の削除が 0 件のとき DELETE を発行しなくなった。`data-retention` 側の既存実装に統合先を寄せた結果で、削除結果は同じ
3. `getOperationCost` の日次クエリを `getDailyUsage` と統合したため ORDER BY が `date` から `date, model` になった。結果は日付キーの Map に畳むので出力は変わらない

## 検証

- `pnpm lint` / `tsc --noEmit` エラーなし
- server 1478 tests green、coverage 97.6 / 89.42 / 98.59 / 98.19（閾値 96 / 87 / 97 / 97）
- 既存の service テスト群（`aggregate.test.ts` 43 ケース、`data-retention.test.ts` 15、`user-deletion.test.ts` 5、`persona-extractor.test.ts` 14）は一切変更していない。`createDb` をモックして in-memory libsql に実 SQL を流すブラックボックステストなので、SQL の等価性の担保になっている

## 既知の弱点

COUNT → DELETE は非アトミックなので、`deleteOrphaned` などは 2 クエリの間に状態が変われば実削除件数とログの件数がずれる。既存 `countAndDelete` からの踏襲で、この PR による劣化ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzxpvwwHzdQiCdEUT8Aw6H
