### PR TITLE
chore(biome): .claude の除外をリポジトリ直下だけにする

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,7 @@
       "!**/.astro",
       "!**/.mastra",
       "!**/.wrangler",
-      "!**/.claude",
+      "!.claude",
       "!**/.brain",
       "!**/.design-sync",
       "!**/.ds-sync",


### PR DESCRIPTION
## Summary
- `biome.json` の `files.includes` にある `!**/.claude` を `!.claude` に変更する

## 主な変更内容
`!**/.claude` は絶対パスの祖先ディレクトリにもマッチするため、`.claude/worktrees/` 配下に作った git worktree では `biome check .`（`pnpm lint` の先頭）がディレクトリ走査をそこで打ち切り、「Checked 0 files / No files were processed」で失敗していた。ファイルを明示して渡す `post-edit-lint.sh` は動くため気付きにくく、`pnpm lint` だけが worktree 内で通らない状態だった。

config ルート相対の `!.claude` に変えると、除外されるのはリポジトリ直下の `.claude/` だけになる。

確認したこと:
- 通常のチェックアウトで `biome check .` の処理数は変更前後とも 731 ファイルで変わらない
- `biome check .claude` は変更後も 0 ファイル（除外は維持）
- `.claude/worktrees/` 配下の既存 worktree で `biome check .` が 0 → 719 ファイルになる
- リポジトリ内に `.claude` という名前のディレクトリはルート以外に無い

## Test plan
- [ ] CI の `biome check .` が通る
- [ ] `.claude/worktrees/` 配下の worktree で `pnpm lint` が通る