### PR TITLE
ナレッジ画面に公式資料の一括アップロードを追加し、R2 を official/ と curated/ に区分する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ pnpm db:migrate:dev      # dev 環境 D1 適用
 pnpm db:migrate:prd      # prd 環境 D1 適用
 
 # ナレッジ
-pnpm knowledge:upload:local  # ローカル R2 → Vectorize 同期
+pnpm knowledge:upload:local  # knowledge/ を R2 の official/ に投入（初期投入・再構築用）
 pnpm knowledge:upload:dev    # dev 環境
 pnpm knowledge:upload:prd    # prd 環境
 ```
@@ -47,9 +47,18 @@ knowledge/ 配下を clean アップロードした場合の正しいベクタ�
 | 2026-03-09 | 329 | 2,891 | clean 後の正確な値 |
 | 2026-09-04 | 335 | 4,210 | source metadata index 作成、チャンク maxSize 1000 導入後の値 |
 
-### 管理画面から追加した curated ナレッジ
+### R2 のナレッジ配置
 
-ダッシュボードの「ナレッジを追加」は、URL・文章・画像/PDF から LLM が下書きを作り、確認後に R2 の `curated/<slug>.md` として保存する（frontmatter は `source_type: curated` / `source_authority: 2` / `verified_at` / `url`）。git 管理外なので `knowledge:upload` では投入されず、`--clean` 後は Vectorize 側だけ消える。clean したら `POST /admin/knowledge/sync` で R2 全体を再同期する。
+R2 のキーはプレフィクスで区分し、ルート直下には置かない。
+
+| プレフィクス | 内容 | 投入経路 |
+|---|---|---|
+| `official/` | 公式資料の Markdown。ディレクトリ階層をそのまま保つ | 管理画面ナレッジタブ「公式資料」の一括アップロード（`POST /admin/knowledge/upload`）、または `knowledge:upload`（`knowledge/<path>.md` → `official/<path>.md`） |
+| `curated/` | 管理画面から追加したナレッジ。`curated/<slug>.md` | 管理画面ナレッジタブ「追加したナレッジ」（URL・文章・画像/PDF から LLM が下書きを作り、確認後に保存。frontmatter は `source_type: curated` / `source_authority: 2` / `verified_at` / `url`） |
+
+`GET /admin/knowledge/files` は `prefix` と `cursor` でページングする。Vectorize への反映は R2 イベント経由で、削除も同様に伝播する。`knowledge:upload --clean` は Vectorize インデックスを作り直すだけで R2 は消えないので、clean 後は `POST /admin/knowledge/sync` で R2 全体を再同期する。
+
+`DELETE /admin/knowledge/legacy` は `official/` `curated/` 以外のオブジェクトを全削除する移行用の一時エンドポイントで、移行完了後に削除する。
 
 ## コーディング規約
 

--- a/scripts/upload-knowledge.ts
+++ b/scripts/upload-knowledge.ts
@@ -40,16 +40,17 @@ const printUsage = () => {
 Usage: pnpm knowledge:upload:<local|dev|prd> [options]
 
 Options:
-  --clean           Vectorizeのナレッジを全削除（wrangler経由）
+  --clean           Vectorize インデックスを再作成する（wrangler 経由）
   --file=<filename> 特定のファイルのみアップロード
   --help, -h        ヘルプを表示
 
 Examples:
-  pnpm knowledge:upload:dev                    # 全ファイルをR2にアップロード
+  pnpm knowledge:upload:dev                    # 全ファイルを R2 の official/ にアップロード
   pnpm knowledge:upload:dev --file=foo.md      # 特定ファイルのみ
-  pnpm knowledge:upload:dev --clean            # 全ナレッジを削除
+  pnpm knowledge:upload:dev --clean            # Vectorize インデックスを再作成
 
 Note:
+  knowledge/<path>.md は official/<path>.md として保存されます。
   R2へのアップロード後、R2 Event Notificationsにより
   自動的にVectorizeへの同期が行われます。
 `);
@@ -146,7 +147,7 @@ const main = async () => {
 
   let uploadedCount = 0;
   for (const filepath of files) {
-    const key = filepath.replace("knowledge/", "");
+    const key = `official/${filepath.replace("knowledge/", "")}`;
     if (uploadToR2(target, filepath, key)) {
       uploadedCount++;
     }

--- a/server/README.md
+++ b/server/README.md
@@ -232,21 +232,20 @@ pnpm knowledge:upload:dev --file=mayor-interview.md
 pnpm knowledge:upload:dev --clean --file=mayor-interview.md
 ```
 
-アップロード先は `--env` で決まり、バケット名と Vectorize インデックス名は `scripts/upload-knowledge.ts` の定数。
+アップロード先は `--env` で決まり、バケット名と Vectorize インデックス名は `scripts/upload-knowledge.ts` の定数。`knowledge/<path>.md` は R2 の `official/<path>.md` として保存され、`--clean` は Vectorize インデックスの再作成だけを行う。
 
 ### 管理API
 
 | パス                              | メソッド   | 説明                           |
 | --------------------------------- | ---------- | ------------------------------ |
-| `/admin/knowledge`                | DELETE     | 全ナレッジを削除               |
-| `/admin/knowledge/sync`           | POST       | 全ナレッジを同期               |
-| `/admin/knowledge/files`          | GET        | ファイル一覧取得               |
+| `/admin/knowledge/sync`           | POST       | R2 の全 Markdown を同期キューに投入 |
+| `/admin/knowledge/files`          | GET        | ファイル一覧取得。`prefix`・`limit`・`cursor` でページング |
 | `/admin/knowledge/files/:key`     | GET/PUT/DELETE | ファイル取得・保存・削除   |
-| `/admin/knowledge/upload`         | POST       | Markdown アップロード          |
+| `/admin/knowledge/upload`         | POST       | Markdown を `official/` 配下にアップロード |
+| `/admin/knowledge/legacy`         | DELETE     | `official/` `curated/` 以外を全削除する移行用の一時エンドポイント |
 | `/admin/knowledge/convert`        | POST       | 画像/PDF → Markdown 変換       |
-| `/admin/knowledge/unified`        | GET        | 統合ファイル一覧取得           |
-| `/admin/knowledge/originals/:key` | GET        | 元ファイル取得                 |
 | `/admin/knowledge/reconvert`      | POST       | 元ファイルから Markdown 再生成 |
+| `/admin/knowledge/curated-draft`  | POST       | URL・文章・画像/PDF から curated 下書きを生成 |
 | `/admin/persona`                  | GET/DELETE | ペルソナ一覧・全削除           |
 | `/admin/persona/extract`          | POST       | ペルソナ抽出                   |
 | `/admin/persona/extract/:threadId`| POST       | 特定スレッドのペルソナ抽出     |

--- a/server/src/routes/admin/knowledge/convert.ts
+++ b/server/src/routes/admin/knowledge/convert.ts
@@ -1,5 +1,8 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
-import { CURATED_DRAFT_LIMITS } from "@nepp-chan/shared/constants/knowledge";
+import {
+  CURATED_DRAFT_LIMITS,
+  OFFICIAL_PREFIX,
+} from "@nepp-chan/shared/constants/knowledge";
 import { HTTPException } from "hono/http-exception";
 import { isSupportedMimeType } from "~/lib/image-converter";
 import { errorResponse } from "~/lib/openapi-errors";
@@ -25,13 +28,12 @@ export const knowledgeConvertRoutes = new OpenAPIHono<{
   Variables: Partial<PrincipalVariables>;
 }>();
 
-// POST /admin/knowledge/upload - ファイルアップロード
 const uploadFileRoute = createRoute({
   method: "post",
   path: "/upload",
-  summary: "ファイルをアップロード",
+  summary: "公式資料の Markdown をアップロード",
   description:
-    "Markdownファイルをアップロードし、R2に保存してVectorizeに同期します",
+    "Markdown ファイルを R2 の official/ 配下に保存します。Vectorize への同期は R2 イベント経由で非同期に行われます",
   tags: ["Admin - Knowledge"],
   request: {
     body: {
@@ -39,7 +41,10 @@ const uploadFileRoute = createRoute({
         "multipart/form-data": {
           schema: z.object({
             file: z.any().openapi({ type: "string", format: "binary" }),
-            filename: z.string().optional(),
+            filename: z.string().optional().openapi({
+              description:
+                "official/ からの相対パス。省略時はファイル名をそのまま使う",
+            }),
           }),
         },
       },
@@ -71,14 +76,17 @@ knowledgeConvertRoutes.openapi(uploadFileRoute, async (c) => {
     throw new HTTPException(400, { message: "File is required" });
   }
 
-  const customFilename =
-    typeof body.filename === "string" ? body.filename : null;
-  if (customFilename) validateFileKey(customFilename);
+  const relativePath =
+    typeof body.filename === "string" && body.filename
+      ? body.filename
+      : file.name;
+  validateFileKey(relativePath);
 
-  const result = await uploadMarkdownFile(file, customFilename, {
-    bucket: c.env.KNOWLEDGE_BUCKET,
-    d1: c.env.DB,
-  });
+  const result = await uploadMarkdownFile(
+    file,
+    `${OFFICIAL_PREFIX}${relativePath}`,
+    { bucket: c.env.KNOWLEDGE_BUCKET, d1: c.env.DB },
+  );
 
   return c.json(
     {
@@ -90,7 +98,6 @@ knowledgeConvertRoutes.openapi(uploadFileRoute, async (c) => {
   );
 });
 
-// POST /admin/knowledge/convert - 画像/PDF → Markdown 変換
 const convertFileRoute = createRoute({
   method: "post",
   path: "/convert",
@@ -160,7 +167,6 @@ knowledgeConvertRoutes.openapi(convertFileRoute, async (c) => {
   );
 });
 
-// POST /admin/knowledge/reconvert - 元ファイルからMarkdownを再生成
 const reconvertFileRoute = createRoute({
   method: "post",
   path: "/reconvert",
@@ -224,7 +230,6 @@ knowledgeConvertRoutes.openapi(reconvertFileRoute, async (c) => {
   );
 });
 
-// POST /admin/knowledge/curated-draft - URL・テキスト・画像から curated 下書きを生成
 const curatedDraftRoute = createRoute({
   method: "post",
   path: "/curated-draft",

--- a/server/src/routes/admin/knowledge/files.ts
+++ b/server/src/routes/admin/knowledge/files.ts
@@ -5,18 +5,18 @@ import { errorResponse } from "~/lib/openapi-errors";
 import type { PrincipalVariables } from "~/lib/principal";
 import {
   deleteFile,
+  deleteLegacyFiles,
   getFile,
-  getOriginalFile,
   listFiles,
-  listUnifiedFiles,
 } from "~/services/knowledge";
 import {
   FileContentResponseSchema,
   FileKeyParamSchema,
+  FilesListQuerySchema,
   FilesListResponseSchema,
+  LegacyDeleteResponseSchema,
   SaveFileRequestSchema,
   SuccessResponseSchema,
-  UnifiedFilesListResponseSchema,
   validateFileKey,
 } from "./schemas";
 
@@ -25,13 +25,14 @@ export const knowledgeFilesRoutes = new OpenAPIHono<{
   Variables: Partial<PrincipalVariables>;
 }>();
 
-// GET /admin/knowledge/files - ファイル一覧取得
 const listFilesRoute = createRoute({
   method: "get",
   path: "/files",
   summary: "ファイル一覧を取得",
-  description: "R2バケット内のファイル一覧を取得します",
+  description:
+    "R2 バケット内のファイル一覧をプレフィクスで絞り込み、カーソルでページングして取得します",
   tags: ["Admin - Knowledge"],
+  request: { query: FilesListQuerySchema },
   responses: {
     200: {
       description: "ファイル一覧",
@@ -43,11 +44,15 @@ const listFilesRoute = createRoute({
 });
 
 knowledgeFilesRoutes.openapi(listFilesRoute, async (c) => {
-  const result = await listFiles(c.env.KNOWLEDGE_BUCKET);
+  const { prefix, limit, cursor } = c.req.valid("query");
+  const result = await listFiles(c.env.KNOWLEDGE_BUCKET, {
+    prefix,
+    limit,
+    cursor,
+  });
   return c.json(result, 200);
 });
 
-// GET /admin/knowledge/files/{key} - ファイル内容取得
 const getFileRoute = createRoute({
   method: "get",
   path: "/files/{key}",
@@ -77,7 +82,6 @@ knowledgeFilesRoutes.openapi(getFileRoute, async (c) => {
   return c.json(result, 200);
 });
 
-// PUT /admin/knowledge/files/{key} - ファイル保存（作成・更新）
 const saveFileRoute = createRoute({
   method: "put",
   path: "/files/{key}",
@@ -117,7 +121,6 @@ knowledgeFilesRoutes.openapi(saveFileRoute, async (c) => {
   );
 });
 
-// DELETE /admin/knowledge/files/{key} - ファイル完全削除
 const deleteFileRoute = createRoute({
   method: "delete",
   path: "/files/{key}",
@@ -145,19 +148,18 @@ knowledgeFilesRoutes.openapi(deleteFileRoute, async (c) => {
   return c.json({ message: `${baseName} を完全に削除しました` }, 200);
 });
 
-// GET /admin/knowledge/unified - 統合ファイル一覧取得
-const listUnifiedFilesRoute = createRoute({
-  method: "get",
-  path: "/unified",
-  summary: "統合ファイル一覧を取得",
+const deleteLegacyRoute = createRoute({
+  method: "delete",
+  path: "/legacy",
+  summary: "旧配置のナレッジを全削除",
   description:
-    "元ファイル（originals/）とMarkdownファイルを統合した一覧を取得します",
+    "curated/ と official/ のどちらにも属さないオブジェクト（ルート直下の Markdown と originals/）を R2 から全て削除します。Vectorize のデータは R2 イベント経由で削除されます。official/ への移行後に 1 回だけ使う一時的なエンドポイントで、移行完了後に削除する予定です",
   tags: ["Admin - Knowledge"],
   responses: {
     200: {
-      description: "統合ファイル一覧",
+      description: "削除成功",
       content: {
-        "application/json": { schema: UnifiedFilesListResponseSchema },
+        "application/json": { schema: LegacyDeleteResponseSchema },
       },
     },
     401: errorResponse(401),
@@ -165,41 +167,7 @@ const listUnifiedFilesRoute = createRoute({
   },
 });
 
-knowledgeFilesRoutes.openapi(listUnifiedFilesRoute, async (c) => {
-  const result = await listUnifiedFiles(c.env.KNOWLEDGE_BUCKET);
+knowledgeFilesRoutes.openapi(deleteLegacyRoute, async (c) => {
+  const result = await deleteLegacyFiles(c.env.KNOWLEDGE_BUCKET);
   return c.json(result, 200);
-});
-
-// GET /admin/knowledge/originals/{key} - 元ファイル取得
-const getOriginalFileRoute = createRoute({
-  method: "get",
-  path: "/originals/{key}",
-  summary: "元ファイルを取得",
-  description: "originals/ 配下の元ファイルを取得します（画像/PDF）",
-  tags: ["Admin - Knowledge"],
-  request: { params: FileKeyParamSchema },
-  responses: {
-    200: { description: "元ファイル（バイナリ）" },
-    401: errorResponse(401),
-    404: errorResponse(404),
-    500: errorResponse(500),
-  },
-});
-
-knowledgeFilesRoutes.openapi(getOriginalFileRoute, async (c) => {
-  const { key } = c.req.valid("param");
-  validateFileKey(key);
-
-  const result = await getOriginalFile(c.env.KNOWLEDGE_BUCKET, key);
-  if (!result) {
-    throw new HTTPException(404, { message: "File not found" });
-  }
-
-  return new Response(result.body, {
-    headers: {
-      "Content-Type": result.contentType,
-      "Content-Length": result.size.toString(),
-      "Content-Disposition": `inline; filename="${encodeURIComponent(key)}"`,
-    },
-  });
 });

--- a/server/src/routes/admin/knowledge/index.test.ts
+++ b/server/src/routes/admin/knowledge/index.test.ts
@@ -7,9 +7,8 @@ vi.mock("~/services/knowledge", async (importOriginal) => ({
   ...(await importOriginal<typeof import("~/services/knowledge")>()),
   listFiles: vi.fn(),
   getFile: vi.fn(),
-  getOriginalFile: vi.fn(),
-  listUnifiedFiles: vi.fn(),
   deleteFile: vi.fn(),
+  deleteLegacyFiles: vi.fn(),
   syncFile: vi.fn(),
   syncAll: vi.fn(),
   uploadMarkdownFile: vi.fn(),
@@ -111,9 +110,7 @@ describe("knowledge routes 統合テスト", () => {
       { method: "GET", path: "/files/test.md" },
       { method: "PUT", path: "/files/test.md" },
       { method: "DELETE", path: "/files/test.md" },
-      { method: "GET", path: "/unified" },
-      { method: "GET", path: "/originals/test.pdf" },
-      { method: "DELETE", path: "/" },
+      { method: "DELETE", path: "/legacy" },
       { method: "POST", path: "/sync" },
       { method: "POST", path: "/upload" },
       { method: "POST", path: "/convert" },
@@ -130,29 +127,51 @@ describe("knowledge routes 統合テスト", () => {
   });
 
   describe("GET /files", () => {
-    it("ファイル一覧を返す", async () => {
-      const mockFiles = {
-        files: [
-          {
-            key: "test.md",
-            size: 100,
-            lastModified: "2024-01-01",
-            etag: "abc",
-          },
-        ],
-        truncated: false,
-      };
+    const mockFiles = {
+      files: [
+        { key: "official/test.md", size: 100, lastModified: "2024-01-01" },
+      ],
+      nextCursor: "next",
+      hasMore: true,
+    };
+
+    it("prefix・limit・cursor をサービスに渡し、ページ応答をそのまま返す", async () => {
       vi.mocked(knowledgeService.listFiles).mockResolvedValue(mockFiles);
 
       const res = await app.request(
-        authedRequest("/files"),
+        authedRequest("/files?prefix=official%2F&limit=10&cursor=abc"),
         undefined,
         mockEnv,
       );
 
       expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual(mockFiles);
+      expect(await res.json()).toEqual(mockFiles);
+      expect(knowledgeService.listFiles).toHaveBeenCalledWith(
+        mockEnv.KNOWLEDGE_BUCKET,
+        { prefix: "official/", limit: 10, cursor: "abc" },
+      );
+    });
+
+    it("limit 省略時は 30、prefix と cursor は undefined", async () => {
+      vi.mocked(knowledgeService.listFiles).mockResolvedValue(mockFiles);
+
+      await app.request(authedRequest("/files"), undefined, mockEnv);
+
+      expect(knowledgeService.listFiles).toHaveBeenCalledWith(
+        mockEnv.KNOWLEDGE_BUCKET,
+        { prefix: undefined, limit: 30, cursor: undefined },
+      );
+    });
+
+    it("curated/ official/ 以外の prefix は 400", async () => {
+      const res = await app.request(
+        authedRequest("/files?prefix=originals%2F"),
+        undefined,
+        mockEnv,
+      );
+
+      expect(res.status).toBe(400);
+      expect(knowledgeService.listFiles).not.toHaveBeenCalled();
     });
   });
 
@@ -226,58 +245,23 @@ describe("knowledge routes 統合テスト", () => {
     });
   });
 
-  describe("GET /unified", () => {
-    it("統合ファイル一覧を返す", async () => {
-      const mockFiles = {
-        files: [{ baseName: "test", hasMarkdown: true }],
-        truncated: false,
-      };
-      vi.mocked(knowledgeService.listUnifiedFiles).mockResolvedValue(mockFiles);
-
-      const res = await app.request(
-        authedRequest("/unified"),
-        undefined,
-        mockEnv,
-      );
-
-      expect(res.status).toBe(200);
-      const body = await res.json();
-      expect(body).toEqual(mockFiles);
-    });
-  });
-
-  describe("GET /originals/:key", () => {
-    it("元ファイルが見つからない場合は 404 を返す", async () => {
-      vi.mocked(knowledgeService.getOriginalFile).mockResolvedValue(null);
-
-      const res = await app.request(
-        authedRequest("/originals/notfound.pdf"),
-        undefined,
-        mockEnv,
-      );
-
-      expect(res.status).toBe(404);
-    });
-
-    it("正常系: body と Content-Type を返す", async () => {
-      const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
-      vi.mocked(knowledgeService.getOriginalFile).mockResolvedValue({
-        body: bytes.buffer,
-        contentType: "application/pdf",
-        size: 8,
+  describe("DELETE /legacy", () => {
+    it("旧配置の削除件数を返す", async () => {
+      vi.mocked(knowledgeService.deleteLegacyFiles).mockResolvedValue({
+        deleted: 12,
       });
 
       const res = await app.request(
-        authedRequest("/originals/doc.pdf"),
+        authedRequest("/legacy", { method: "DELETE" }),
         undefined,
         mockEnv,
       );
 
       expect(res.status).toBe(200);
-      expect(res.headers.get("Content-Type")).toBe("application/pdf");
-      expect(res.headers.get("Content-Length")).toBe("8");
-      const returned = new Uint8Array(await res.arrayBuffer());
-      expect(Array.from(returned)).toEqual(Array.from(bytes));
+      expect(await res.json()).toEqual({ deleted: 12 });
+      expect(knowledgeService.deleteLegacyFiles).toHaveBeenCalledWith(
+        mockEnv.KNOWLEDGE_BUCKET,
+      );
     });
   });
 
@@ -342,16 +326,16 @@ describe("knowledge routes 統合テスト", () => {
       expect(res.status).toBe(400);
     });
 
-    it("正常系: uploadMarkdownFile を呼び 200 を返す", async () => {
+    it("正常系: filename の相対パスに official/ を前置して保存する", async () => {
       vi.mocked(knowledgeService.uploadMarkdownFile).mockResolvedValue({
-        key: "doc.md",
+        key: "official/kurashi/gomi.md",
       });
-      const file = new File(["# c"], "doc.md", { type: "text/markdown" });
+      const file = new File(["# c"], "gomi.md", { type: "text/markdown" });
 
       const res = await app.request(
         authedRequest("/upload", {
           method: "POST",
-          body: buildForm(file, "doc.md"),
+          body: buildForm(file, "kurashi/gomi.md"),
         }),
         undefined,
         mockEnv,
@@ -359,17 +343,17 @@ describe("knowledge routes 統合テスト", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as { key: string };
-      expect(body.key).toBe("doc.md");
+      expect(body.key).toBe("official/kurashi/gomi.md");
       expect(knowledgeService.uploadMarkdownFile).toHaveBeenCalledWith(
         expect.any(File),
-        "doc.md",
+        "official/kurashi/gomi.md",
         expect.objectContaining({ bucket: mockEnv.KNOWLEDGE_BUCKET }),
       );
     });
 
-    it("filename 省略時は null を渡す", async () => {
+    it("filename 省略時はファイル名を official/ 直下に置く", async () => {
       vi.mocked(knowledgeService.uploadMarkdownFile).mockResolvedValue({
-        key: "x.md",
+        key: "official/x.md",
       });
       const file = new File(["# c"], "x.md", { type: "text/markdown" });
 
@@ -384,7 +368,7 @@ describe("knowledge routes 統合テスト", () => {
 
       expect(knowledgeService.uploadMarkdownFile).toHaveBeenCalledWith(
         expect.any(File),
-        null,
+        "official/x.md",
         expect.any(Object),
       );
     });

--- a/server/src/routes/admin/knowledge/schemas.ts
+++ b/server/src/routes/admin/knowledge/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "@hono/zod-openapi";
+import { KNOWLEDGE_PREFIXES } from "@nepp-chan/shared/constants/knowledge";
 import { HTTPException } from "hono/http-exception";
 
 export const SuccessResponseSchema = z.object({
@@ -10,38 +11,22 @@ export const FileInfoSchema = z.object({
   key: z.string(),
   size: z.number(),
   lastModified: z.string(),
-  etag: z.string(),
-  edited: z.boolean().optional(),
+});
+
+export const FilesListQuerySchema = z.object({
+  prefix: z.enum(KNOWLEDGE_PREFIXES).optional(),
+  limit: z.coerce.number().int().min(1).max(1000).optional().default(30),
+  cursor: z.string().optional(),
 });
 
 export const FilesListResponseSchema = z.object({
   files: z.array(FileInfoSchema),
-  truncated: z.boolean(),
+  nextCursor: z.string().nullable(),
+  hasMore: z.boolean(),
 });
 
-export const UnifiedFileInfoSchema = z.object({
-  baseName: z.string(),
-  original: z
-    .object({
-      key: z.string(),
-      size: z.number(),
-      lastModified: z.string(),
-      contentType: z.string(),
-    })
-    .optional(),
-  markdown: z
-    .object({
-      key: z.string(),
-      size: z.number(),
-      lastModified: z.string(),
-    })
-    .optional(),
-  hasMarkdown: z.boolean(),
-});
-
-export const UnifiedFilesListResponseSchema = z.object({
-  files: z.array(UnifiedFileInfoSchema),
-  truncated: z.boolean(),
+export const LegacyDeleteResponseSchema = z.object({
+  deleted: z.number(),
 });
 
 export const FileContentResponseSchema = z.object({

--- a/server/src/services/knowledge/files.test.ts
+++ b/server/src/services/knowledge/files.test.ts
@@ -4,16 +4,24 @@ vi.mock("~/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
-const { deleteFile, getFile, getOriginalFile, listFiles, listUnifiedFiles } =
-  await import("./files");
+const { deleteFile, deleteLegacyFiles, getFile, listFiles } = await import(
+  "./files"
+);
 
 type ObjStub = {
   key: string;
   size: number;
   uploaded: Date;
-  etag?: string;
-  contentType?: string;
 };
+
+type ListPage = { objects: ObjStub[]; cursor?: string };
+
+const toR2Object = (o: ObjStub) => ({
+  key: o.key,
+  size: o.size,
+  uploaded: o.uploaded,
+  etag: "etag",
+});
 
 const buildBucket = (
   objects: ObjStub[],
@@ -22,185 +30,134 @@ const buildBucket = (
   const matchPrefix = (prefix: string | undefined) =>
     objects
       .filter((o) => (prefix ? o.key.startsWith(prefix) : true))
-      .map((o) => ({
-        key: o.key,
-        size: o.size,
-        uploaded: o.uploaded,
-        etag: o.etag ?? "etag",
-        httpMetadata: o.contentType
-          ? { contentType: o.contentType }
-          : undefined,
-      }));
+      .map(toR2Object);
 
-  const bucket = {
+  return {
     list: vi.fn(async (opts?: { prefix?: string; limit?: number }) => ({
       objects: matchPrefix(opts?.prefix),
       truncated: false,
     })),
     get: vi.fn(async (key: string) => getMap[key] ?? null),
-    head: vi.fn(async (key: string) => {
-      const o = objects.find((obj) => obj.key === key);
-      if (!o) return null;
-      return {
-        httpMetadata: o.contentType
-          ? { contentType: o.contentType }
-          : undefined,
-      };
-    }),
-    delete: vi.fn(async (_key: string) => {}),
+    delete: vi.fn(async (_keys: string | string[]) => {}),
     put: vi.fn(),
   } as unknown as R2Bucket;
-  return bucket;
 };
 
+const buildPagedBucket = (pages: ListPage[]) => {
+  const byCursor = new Map(
+    pages.map((page, i) => [i === 0 ? undefined : `c${i}`, { page, i }]),
+  );
+  return {
+    list: vi.fn(async (opts?: { cursor?: string }) => {
+      const found = byCursor.get(opts?.cursor);
+      if (!found) throw new Error(`unknown cursor: ${opts?.cursor}`);
+      const isLast = found.i === pages.length - 1;
+      return {
+        objects: found.page.objects.map(toR2Object),
+        truncated: !isLast,
+        ...(isLast ? {} : { cursor: `c${found.i + 1}` }),
+      };
+    }),
+    delete: vi.fn(async (_keys: string | string[]) => {}),
+  } as unknown as R2Bucket;
+};
+
+const obj = (key: string, uploaded = "2030-01-01T00:00:00Z") => ({
+  key,
+  size: 1,
+  uploaded: new Date(uploaded),
+});
+
 describe("listFiles", () => {
-  it("originals/ プレフィックスは除外し、Markdown のみ返す", async () => {
+  it("prefix・limit・cursor を R2 にそのまま渡し、key/size/lastModified に写す", async () => {
     const bucket = buildBucket([
       {
-        key: "originals/doc.pdf",
-        size: 100,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
-      {
-        key: "doc.md",
+        key: "official/a.md",
         size: 200,
         uploaded: new Date("2030-01-01T00:00:01Z"),
       },
+      obj("curated/b.md"),
     ]);
 
-    const { files, truncated } = await listFiles(bucket);
-    expect(files.map((f) => f.key)).toEqual(["doc.md"]);
-    expect(truncated).toBe(false);
+    const result = await listFiles(bucket, {
+      prefix: "official/",
+      limit: 30,
+      cursor: "abc",
+    });
+
+    expect(bucket.list).toHaveBeenCalledWith({
+      prefix: "official/",
+      limit: 30,
+      cursor: "abc",
+    });
+    expect(result).toEqual({
+      files: [
+        {
+          key: "official/a.md",
+          size: 200,
+          lastModified: "2030-01-01T00:00:01.000Z",
+        },
+      ],
+      nextCursor: null,
+      hasMore: false,
+    });
   });
 
-  it("Markdown が original より EDIT_THRESHOLD_MS 以上後ろなら edited=true", async () => {
-    const bucket = buildBucket([
-      {
-        key: "originals/x.pdf",
-        size: 100,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
-      {
-        key: "x.md",
-        size: 50,
-        uploaded: new Date("2030-01-01T00:01:00Z"), // 60 秒後
-      },
+  it("truncated なら nextCursor と hasMore を返す", async () => {
+    const bucket = buildPagedBucket([
+      { objects: [obj("official/a.md")] },
+      { objects: [obj("official/b.md")] },
     ]);
 
-    const { files } = await listFiles(bucket);
-    expect(files[0].edited).toBe(true);
-  });
+    const result = await listFiles(bucket, { limit: 1 });
 
-  it("EDIT_THRESHOLD_MS 以内なら edited は undefined", async () => {
-    const bucket = buildBucket([
-      {
-        key: "originals/x.pdf",
-        size: 100,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
-      {
-        key: "x.md",
-        size: 50,
-        uploaded: new Date("2030-01-01T00:00:01Z"), // 1 秒後
-      },
-    ]);
-
-    const { files } = await listFiles(bucket);
-    expect(files[0].edited).toBeUndefined();
-  });
-
-  it("originals に対応する元ファイルがなければ edited は undefined", async () => {
-    const bucket = buildBucket([
-      {
-        key: "lonely.md",
-        size: 50,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
-    ]);
-
-    const { files } = await listFiles(bucket);
-    expect(files[0].edited).toBeUndefined();
+    expect(result.nextCursor).toBe("c1");
+    expect(result.hasMore).toBe(true);
   });
 });
 
-describe("listUnifiedFiles", () => {
-  it("original と markdown を baseName で紐付け", async () => {
-    const bucket = buildBucket([
+describe("deleteLegacyFiles", () => {
+  it("curated/ official/ 以外をページごとにまとめて削除し、件数を返す", async () => {
+    const bucket = buildPagedBucket([
       {
-        key: "originals/doc.pdf",
-        size: 100,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-        contentType: "application/pdf",
+        objects: [
+          obj("welcome.md"),
+          obj("curated/keep.md"),
+          obj("originals/chirashi.pdf"),
+        ],
       },
       {
-        key: "doc.md",
-        size: 50,
-        uploaded: new Date("2030-01-02T00:00:00Z"),
+        objects: [
+          obj("villotoinep/index.md"),
+          obj("official/keep.md"),
+          obj("official.md"),
+        ],
       },
     ]);
 
-    const { files } = await listUnifiedFiles(bucket);
-    expect(files).toHaveLength(1);
-    expect(files[0]).toMatchObject({
-      baseName: "doc",
-      hasMarkdown: true,
-      original: { contentType: "application/pdf", size: 100 },
-      markdown: { size: 50 },
-    });
+    const result = await deleteLegacyFiles(bucket);
+
+    expect(bucket.delete).toHaveBeenCalledTimes(2);
+    expect(bucket.delete).toHaveBeenNthCalledWith(1, [
+      "welcome.md",
+      "originals/chirashi.pdf",
+    ]);
+    expect(bucket.delete).toHaveBeenNthCalledWith(2, [
+      "villotoinep/index.md",
+      "official.md",
+    ]);
+    expect(result).toEqual({ deleted: 4 });
   });
 
-  it("markdown だけのファイルは original undefined", async () => {
-    const bucket = buildBucket([
-      {
-        key: "md-only.md",
-        size: 50,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
+  it("消す対象が無いページでは delete を呼ばない", async () => {
+    const bucket = buildPagedBucket([
+      { objects: [obj("curated/a.md"), obj("official/b.md")] },
     ]);
-    const { files } = await listUnifiedFiles(bucket);
-    expect(files[0]).toMatchObject({
-      baseName: "md-only",
-      hasMarkdown: true,
-      original: undefined,
-    });
-  });
 
-  it("original だけのファイルは hasMarkdown=false", async () => {
-    const bucket = buildBucket([
-      {
-        key: "originals/orphan.pdf",
-        size: 100,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
-    ]);
-    const { files } = await listUnifiedFiles(bucket);
-    expect(files[0]).toMatchObject({
-      baseName: "orphan",
-      hasMarkdown: false,
-      markdown: undefined,
-    });
-  });
+    const result = await deleteLegacyFiles(bucket);
 
-  it("contentType 不明なら application/octet-stream にフォールバック", async () => {
-    const bucket = buildBucket([
-      {
-        key: "originals/unknown.bin",
-        size: 100,
-        uploaded: new Date("2030-01-01T00:00:00Z"),
-      },
-    ]);
-    const { files } = await listUnifiedFiles(bucket);
-    expect(files[0].original?.contentType).toBe("application/octet-stream");
-  });
-
-  it("最終更新日 (markdown 優先) の新しい順でソート", async () => {
-    const bucket = buildBucket([
-      { key: "a.md", size: 1, uploaded: new Date("2030-01-01T00:00:00Z") },
-      { key: "b.md", size: 1, uploaded: new Date("2030-03-01T00:00:00Z") },
-      { key: "c.md", size: 1, uploaded: new Date("2030-02-01T00:00:00Z") },
-    ]);
-    const { files } = await listUnifiedFiles(bucket);
-    expect(files.map((f) => f.baseName)).toEqual(["b", "c", "a"]);
+    expect(bucket.delete).not.toHaveBeenCalled();
+    expect(result).toEqual({ deleted: 0 });
   });
 });
 
@@ -239,42 +196,6 @@ describe("getFile", () => {
     });
     const result = await getFile(bucket, "x.md");
     expect(result?.contentType).toBe("text/markdown");
-  });
-});
-
-describe("getOriginalFile", () => {
-  it("originals/<key> から取得", async () => {
-    const buf = new ArrayBuffer(8);
-    const bucket = buildBucket([], {
-      "originals/doc.pdf": {
-        arrayBuffer: async () => buf,
-        size: 8,
-        httpMetadata: { contentType: "application/pdf" },
-      },
-    });
-    const result = await getOriginalFile(bucket, "doc.pdf");
-    expect(result).toMatchObject({
-      body: buf,
-      contentType: "application/pdf",
-      size: 8,
-    });
-  });
-
-  it("存在しなければ null", async () => {
-    const bucket = buildBucket([]);
-    expect(await getOriginalFile(bucket, "ghost")).toBeNull();
-  });
-
-  it("contentType 未指定は application/octet-stream", async () => {
-    const bucket = buildBucket([], {
-      "originals/x.bin": {
-        arrayBuffer: async () => new ArrayBuffer(1),
-        size: 1,
-        httpMetadata: undefined,
-      },
-    });
-    const result = await getOriginalFile(bucket, "x.bin");
-    expect(result?.contentType).toBe("application/octet-stream");
   });
 });
 

--- a/server/src/services/knowledge/files.ts
+++ b/server/src/services/knowledge/files.ts
@@ -1,33 +1,11 @@
+import { KNOWLEDGE_PREFIXES } from "@nepp-chan/shared/constants/knowledge";
 import { logger } from "~/lib/logger";
-import {
-  buildOriginalsMap,
-  extractBaseName,
-  isEditedAfterOriginal,
-  markdownBaseName,
-} from "./utils";
+import { extractBaseName, markdownBaseName } from "./utils";
 
 export type FileInfo = {
   key: string;
   size: number;
   lastModified: string;
-  etag: string;
-  edited?: boolean;
-};
-
-export type UnifiedFileInfo = {
-  baseName: string;
-  original?: {
-    key: string;
-    size: number;
-    lastModified: string;
-    contentType: string;
-  };
-  markdown?: {
-    key: string;
-    size: number;
-    lastModified: string;
-  };
-  hasMarkdown: boolean;
 };
 
 export type FileContent = {
@@ -38,105 +16,50 @@ export type FileContent = {
   lastModified: string;
 };
 
-export const listFiles = async (
-  bucket: R2Bucket,
-): Promise<{ files: FileInfo[]; truncated: boolean }> => {
-  const listed = await bucket.list({ limit: 1000 });
-  const allObjects = listed.objects;
-  const originalsMap = buildOriginalsMap(allObjects);
-
-  const files = allObjects
-    .filter((obj) => !obj.key.startsWith("originals/"))
-    .map((obj) => {
-      const isEdited = isEditedAfterOriginal(
-        obj.uploaded,
-        originalsMap.get(markdownBaseName(obj.key)),
-      );
-
-      return {
-        key: obj.key,
-        size: obj.size,
-        lastModified: obj.uploaded.toISOString(),
-        etag: obj.etag,
-        edited: isEdited || undefined,
-      };
-    });
-
-  return { files, truncated: listed.truncated };
+type ListFilesOptions = {
+  prefix?: string;
+  limit: number;
+  cursor?: string;
 };
 
-export const listUnifiedFiles = async (
+export const listFiles = async (
   bucket: R2Bucket,
-): Promise<{ files: UnifiedFileInfo[]; truncated: boolean }> => {
-  const listed = await bucket.list({ limit: 1000 });
-  const allObjects = listed.objects;
+  { prefix, limit, cursor }: ListFilesOptions,
+) => {
+  const listed = await bucket.list({ prefix, limit, cursor });
+  const files: FileInfo[] = listed.objects.map((obj) => ({
+    key: obj.key,
+    size: obj.size,
+    lastModified: obj.uploaded.toISOString(),
+  }));
 
-  const originalsMap = new Map<
-    string,
-    { key: string; size: number; uploaded: Date; contentType: string }
-  >();
-  for (const obj of allObjects) {
-    if (obj.key.startsWith("originals/")) {
-      const file = await bucket.head(obj.key);
-      originalsMap.set(extractBaseName(obj.key), {
-        key: obj.key,
-        size: obj.size,
-        uploaded: obj.uploaded,
-        contentType:
-          file?.httpMetadata?.contentType || "application/octet-stream",
-      });
+  return {
+    files,
+    nextCursor: listed.truncated ? listed.cursor : null,
+    hasMore: listed.truncated,
+  };
+};
+
+const isManagedKey = (key: string) =>
+  KNOWLEDGE_PREFIXES.some((prefix) => key.startsWith(prefix));
+
+export const deleteLegacyFiles = async (bucket: R2Bucket) => {
+  let deleted = 0;
+  let cursor: string | undefined;
+  do {
+    const listed = await bucket.list({ cursor });
+    const targets = listed.objects
+      .map((obj) => obj.key)
+      .filter((key) => !isManagedKey(key));
+    if (targets.length > 0) {
+      await bucket.delete(targets);
+      deleted += targets.length;
     }
-  }
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
 
-  const markdownMap = new Map<
-    string,
-    { key: string; size: number; uploaded: Date }
-  >();
-  for (const obj of allObjects) {
-    if (obj.key.endsWith(".md") && !obj.key.startsWith("originals/")) {
-      markdownMap.set(markdownBaseName(obj.key), {
-        key: obj.key,
-        size: obj.size,
-        uploaded: obj.uploaded,
-      });
-    }
-  }
-
-  const allBaseNames = new Set([...originalsMap.keys(), ...markdownMap.keys()]);
-  const files: UnifiedFileInfo[] = [];
-
-  for (const baseName of allBaseNames) {
-    const original = originalsMap.get(baseName);
-    const markdown = markdownMap.get(baseName);
-
-    files.push({
-      baseName,
-      original: original
-        ? {
-            key: original.key,
-            size: original.size,
-            lastModified: original.uploaded.toISOString(),
-            contentType: original.contentType,
-          }
-        : undefined,
-      markdown: markdown
-        ? {
-            key: markdown.key,
-            size: markdown.size,
-            lastModified: markdown.uploaded.toISOString(),
-          }
-        : undefined,
-      hasMarkdown: !!markdown,
-    });
-  }
-
-  files.sort((a, b) => {
-    const aDate = a.markdown?.lastModified || a.original?.lastModified || "";
-    const bDate = b.markdown?.lastModified || b.original?.lastModified || "";
-    return bDate.localeCompare(aDate);
-  });
-
-  return { files, truncated: listed.truncated };
+  logger.info(`[Delete] Deleted ${deleted} legacy objects from R2`);
+  return { deleted };
 };
 
 export const getFile = async (
@@ -153,21 +76,6 @@ export const getFile = async (
     contentType: object.httpMetadata?.contentType || "text/markdown",
     size: object.size,
     lastModified: object.uploaded.toISOString(),
-  };
-};
-
-export const getOriginalFile = async (
-  bucket: R2Bucket,
-  key: string,
-): Promise<{ body: ArrayBuffer; contentType: string; size: number } | null> => {
-  const fullKey = `originals/${key}`;
-  const object = await bucket.get(fullKey);
-  if (!object) return null;
-
-  return {
-    body: await object.arrayBuffer(),
-    contentType: object.httpMetadata?.contentType || "application/octet-stream",
-    size: object.size,
   };
 };
 

--- a/server/src/services/knowledge/index.ts
+++ b/server/src/services/knowledge/index.ts
@@ -5,13 +5,11 @@ export {
 } from "./curated-draft";
 export {
   deleteFile,
+  deleteLegacyFiles,
   type FileContent,
   type FileInfo,
   getFile,
-  getOriginalFile,
   listFiles,
-  listUnifiedFiles,
-  type UnifiedFileInfo,
 } from "./files";
 export { type R2EventMessage, syncAll, syncFile } from "./sync";
 export {

--- a/server/src/services/knowledge/upload.test.ts
+++ b/server/src/services/knowledge/upload.test.ts
@@ -42,36 +42,29 @@ beforeEach(() => {
 });
 
 describe("uploadMarkdownFile", () => {
-  it("正常系: 本文を text/markdown として R2 に保存し key を返す", async () => {
+  it("正常系: 渡された key で本文を text/markdown として R2 に保存する", async () => {
     const bucket = buildBucket();
-    const file = buildFile("# hello", { name: "doc.md" });
+    const file = buildFile("# hello", { name: "ignored.md" });
 
-    const result = await uploadMarkdownFile(file, null, { bucket });
+    const result = await uploadMarkdownFile(file, "official/doc.md", {
+      bucket,
+    });
 
-    expect(bucket.put).toHaveBeenCalledWith("doc.md", "# hello", {
+    expect(bucket.put).toHaveBeenCalledWith("official/doc.md", "# hello", {
       httpMetadata: { contentType: "text/markdown" },
     });
-    expect(result).toEqual({ key: "doc.md" });
+    expect(result).toEqual({ key: "official/doc.md" });
   });
 
-  it("customFilename が指定されたらそちらを使う", async () => {
+  it(".md が無ければ付ける", async () => {
     const bucket = buildBucket();
     const file = buildFile("x", { name: "any.md" });
 
-    const result = await uploadMarkdownFile(file, "custom", {
+    const result = await uploadMarkdownFile(file, "official/custom", {
       bucket,
     });
 
-    expect(result.key).toBe("custom.md");
-  });
-
-  it("既に .md 付きならそのまま", async () => {
-    const bucket = buildBucket();
-    const file = buildFile("x", { name: "ignored" });
-    const result = await uploadMarkdownFile(file, "ready.md", {
-      bucket,
-    });
-    expect(result.key).toBe("ready.md");
+    expect(result.key).toBe("official/custom.md");
   });
 
   it("file.size が上限超過なら throw", async () => {
@@ -82,7 +75,7 @@ describe("uploadMarkdownFile", () => {
     });
 
     await expect(
-      uploadMarkdownFile(file, null, {
+      uploadMarkdownFile(file, "official/huge.md", {
         bucket,
       }),
     ).rejects.toThrow(/exceeds limit/);

--- a/server/src/services/knowledge/upload.ts
+++ b/server/src/services/knowledge/upload.ts
@@ -17,7 +17,7 @@ const withMarkdownExtension = (name: string) =>
 
 export const uploadMarkdownFile = async (
   file: File,
-  customFilename: string | null,
+  key: string,
   deps: UploadDeps,
 ) => {
   if (file.size > MAX_FILE_SIZE) {
@@ -26,12 +26,12 @@ export const uploadMarkdownFile = async (
     );
   }
 
-  const key = withMarkdownExtension(customFilename || file.name);
+  const markdownKey = withMarkdownExtension(key);
   const content = await file.text();
-  logger.info(`[Upload] Uploaded ${key} (${content.length} bytes)`);
+  logger.info(`[Upload] Uploaded ${markdownKey} (${content.length} bytes)`);
 
-  await storeMarkdown(deps.bucket, key, content);
-  return { key };
+  await storeMarkdown(deps.bucket, markdownKey, content);
+  return { key: markdownKey };
 };
 
 export const convertAndUpload = async (

--- a/server/src/services/knowledge/utils.test.ts
+++ b/server/src/services/knowledge/utils.test.ts
@@ -1,18 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  buildOriginalsMap,
-  EDIT_THRESHOLD_MS,
-  extractBaseName,
-  isEditedAfterOriginal,
-  markdownBaseName,
-} from "./utils";
-
-describe("EDIT_THRESHOLD_MS", () => {
-  it("5000 ミリ秒で定義されている", () => {
-    expect(EDIT_THRESHOLD_MS).toBe(5000);
-  });
-});
+import { extractBaseName, markdownBaseName } from "./utils";
 
 describe("extractBaseName", () => {
   it("originals/ プレフィックスを除去", () => {
@@ -33,53 +21,6 @@ describe("extractBaseName", () => {
 
   it("複数のドットがある場合は最後の拡張子のみ削除", () => {
     expect(extractBaseName("originals/my.file.name.txt")).toBe("my.file.name");
-  });
-});
-
-describe("buildOriginalsMap", () => {
-  const obj = (key: string, date: string): R2Object =>
-    ({ key, uploaded: new Date(date) }) as R2Object;
-
-  it("originals/ プレフィックスのオブジェクトだけ Map に入れる", () => {
-    const result = buildOriginalsMap([
-      obj("originals/a.md", "2030-01-01T00:00:00Z"),
-      obj("normal/b.md", "2030-01-02T00:00:00Z"),
-      obj("originals/c.pdf", "2030-01-03T00:00:00Z"),
-    ]);
-
-    expect(result.size).toBe(2);
-    expect(result.has("a")).toBe(true);
-    expect(result.has("c")).toBe(true);
-    expect(result.has("b")).toBe(false);
-  });
-
-  it("値は R2Object の uploaded Date", () => {
-    const map = buildOriginalsMap([
-      obj("originals/x.md", "2030-05-05T12:00:00Z"),
-    ]);
-    expect(map.get("x")).toEqual(new Date("2030-05-05T12:00:00Z"));
-  });
-
-  it("空配列なら空 Map", () => {
-    expect(buildOriginalsMap([]).size).toBe(0);
-  });
-});
-
-describe("isEditedAfterOriginal", () => {
-  it("original が無ければ false", () => {
-    expect(isEditedAfterOriginal(new Date("2030-01-01"), undefined)).toBe(
-      false,
-    );
-  });
-
-  it("差が閾値以内なら false、超えたら true", () => {
-    const original = new Date("2030-01-01T00:00:00Z");
-    expect(
-      isEditedAfterOriginal(new Date(original.getTime() + 5000), original),
-    ).toBe(false);
-    expect(
-      isEditedAfterOriginal(new Date(original.getTime() + 5001), original),
-    ).toBe(true);
   });
 });
 

--- a/server/src/services/knowledge/utils.ts
+++ b/server/src/services/knowledge/utils.ts
@@ -1,23 +1,4 @@
-export const EDIT_THRESHOLD_MS = 5000;
-
 export const extractBaseName = (key: string) =>
   key.replace("originals/", "").replace(/\.[^.]+$/, "");
 
 export const markdownBaseName = (key: string) => key.replace(/\.md$/, "");
-
-export const isEditedAfterOriginal = (
-  markdownUploaded: Date,
-  originalUploaded: Date | undefined,
-) =>
-  originalUploaded !== undefined &&
-  markdownUploaded.getTime() - originalUploaded.getTime() > EDIT_THRESHOLD_MS;
-
-export const buildOriginalsMap = (objects: R2Object[]) => {
-  const map = new Map<string, Date>();
-  for (const obj of objects) {
-    if (obj.key.startsWith("originals/")) {
-      map.set(extractBaseName(obj.key), obj.uploaded);
-    }
-  }
-  return map;
-};

--- a/shared/src/api/repository/knowledge-repository.test.ts
+++ b/shared/src/api/repository/knowledge-repository.test.ts
@@ -8,7 +8,7 @@ import {
 import { server } from "../../test/msw-server";
 import { createKnowledgeRepository, toFormData } from "./knowledge-repository";
 
-const repo = createKnowledgeRepository(testApiClient, API);
+const repo = createKnowledgeRepository(testApiClient);
 
 beforeEach(() => {
   setTestAuthToken("admin-token");
@@ -39,14 +39,29 @@ describe("toFormData", () => {
 });
 
 describe("knowledge-repository", () => {
-  it("fetchFiles: ファイル一覧を返す", async () => {
+  it("fetchFiles: prefix・limit・cursor をクエリに載せる", async () => {
+    let query = "";
     server.use(
-      http.get(`${API}/admin/knowledge/files`, () =>
-        HttpResponse.json({ files: [] }),
-      ),
+      http.get(`${API}/admin/knowledge/files`, ({ request }) => {
+        query = new URL(request.url).search;
+        return HttpResponse.json({
+          files: [],
+          nextCursor: null,
+          hasMore: false,
+        });
+      }),
     );
 
-    await repo.fetchFiles();
+    const result = await repo.fetchFiles({
+      prefix: "official/",
+      limit: 30,
+      cursor: "abc",
+    });
+
+    expect(new URLSearchParams(query).get("prefix")).toBe("official/");
+    expect(new URLSearchParams(query).get("limit")).toBe("30");
+    expect(new URLSearchParams(query).get("cursor")).toBe("abc");
+    expect(result).toEqual({ files: [], nextCursor: null, hasMore: false });
   });
 
   it("fetchFileContent: key を path に埋め込む", async () => {
@@ -82,14 +97,18 @@ describe("knowledge-repository", () => {
     await repo.deleteFile("doc.md");
   });
 
-  it("uploadFile: multipart に file + filename を入れる", async () => {
+  it("uploadFile: multipart で送って key を返す", async () => {
     server.use(
       http.post(`${API}/admin/knowledge/upload`, () =>
-        HttpResponse.json({ key: "k" }),
+        HttpResponse.json({ key: "official/dir/foo.md" }),
       ),
     );
 
-    await repo.uploadFile(new File(["x"], "foo.md"), "foo.md");
+    const result = await repo.uploadFile(
+      new File(["x"], "foo.md"),
+      "dir/foo.md",
+    );
+    expect(result?.key).toBe("official/dir/foo.md");
   });
 
   it("convertFile: multipart で送る", async () => {
@@ -100,6 +119,17 @@ describe("knowledge-repository", () => {
     );
 
     await repo.convertFile(new File(["x"], "in.pdf"), "in.pdf");
+  });
+
+  it("syncAll: POST /admin/knowledge/sync の結果を返す", async () => {
+    server.use(
+      http.post(`${API}/admin/knowledge/sync`, () =>
+        HttpResponse.json({ message: "queued", queued: 12 }),
+      ),
+    );
+
+    const result = await repo.syncAll();
+    expect(result?.queued).toBe(12);
   });
 
   it("draftCurated: POST /admin/knowledge/curated-draft に multipart で送る", async () => {
@@ -122,16 +152,6 @@ describe("knowledge-repository", () => {
     expect(result?.key).toBe("curated/x.md");
   });
 
-  it("fetchUnifiedFiles", async () => {
-    server.use(
-      http.get(`${API}/admin/knowledge/unified`, () =>
-        HttpResponse.json({ files: [] }),
-      ),
-    );
-
-    await repo.fetchUnifiedFiles();
-  });
-
   it("reconvertFile: originalKey を JSON 送信", async () => {
     server.use(
       http.post(`${API}/admin/knowledge/reconvert`, async ({ request }) => {
@@ -142,12 +162,6 @@ describe("knowledge-repository", () => {
     );
 
     await repo.reconvertFile("originals/x.pdf", "x.md");
-  });
-
-  it("getOriginalFileUrl: originals/ プレフィックスを除いて URL 生成", () => {
-    const url = repo.getOriginalFileUrl("originals/foo bar.pdf");
-    expect(url).toMatch(/foo%20bar\.pdf$/);
-    expect(url).not.toContain("originals/originals");
   });
 
   it("失敗系: fetchFileContent 404 は throw", async () => {
@@ -177,7 +191,9 @@ describe("knowledge-repository", () => {
           HttpResponse.json({ error: { message: "x" } }, { status: 500 }),
         ),
       );
-      await expect(repo.fetchFiles()).rejects.toBeDefined();
+      await expect(
+        repo.fetchFiles({ prefix: "official/" }),
+      ).rejects.toBeDefined();
     });
 
     it("deleteFile: 5xx は throw", async () => {
@@ -209,15 +225,6 @@ describe("knowledge-repository", () => {
       await expect(
         repo.convertFile(new File(["x"], "f.pdf"), "f.pdf"),
       ).rejects.toBeDefined();
-    });
-
-    it("fetchUnifiedFiles: 5xx は throw", async () => {
-      server.use(
-        http.get(`${API}/admin/knowledge/unified`, () =>
-          HttpResponse.json({ error: { message: "x" } }, { status: 500 }),
-        ),
-      );
-      await expect(repo.fetchUnifiedFiles()).rejects.toBeDefined();
     });
 
     it("reconvertFile: 5xx は throw", async () => {

--- a/shared/src/api/repository/knowledge-repository.ts
+++ b/shared/src/api/repository/knowledge-repository.ts
@@ -1,3 +1,4 @@
+import type { KnowledgePrefix } from "../../constants/knowledge";
 import type { ApiClient } from "../create-client";
 import type { CuratedDraftRequest } from "../types";
 
@@ -11,12 +12,17 @@ export const toFormData = (body: unknown) => {
   return fd;
 };
 
-export const createKnowledgeRepository = (
-  client: ApiClient,
-  baseUrl: string,
-) => ({
-  fetchFiles: async () => {
-    const { data, error } = await client.GET("/admin/knowledge/files");
+export type FetchFilesParams = {
+  prefix: KnowledgePrefix;
+  limit?: number;
+  cursor?: string;
+};
+
+export const createKnowledgeRepository = (client: ApiClient) => ({
+  fetchFiles: async (params: FetchFilesParams) => {
+    const { data, error } = await client.GET("/admin/knowledge/files", {
+      params: { query: params },
+    });
     if (error) throw error;
     return data;
   },
@@ -49,7 +55,7 @@ export const createKnowledgeRepository = (
     return data;
   },
 
-  uploadFile: async (file: File, filename?: string) => {
+  uploadFile: async (file: File, filename: string) => {
     const { data, error } = await client.POST("/admin/knowledge/upload", {
       body: { file: file as unknown as string, filename },
       bodySerializer: toFormData,
@@ -63,6 +69,12 @@ export const createKnowledgeRepository = (
       body: { file: file as unknown as string, filename },
       bodySerializer: toFormData,
     });
+    if (error) throw error;
+    return data;
+  },
+
+  syncAll: async () => {
+    const { data, error } = await client.POST("/admin/knowledge/sync");
     if (error) throw error;
     return data;
   },
@@ -83,23 +95,12 @@ export const createKnowledgeRepository = (
     return data;
   },
 
-  fetchUnifiedFiles: async () => {
-    const { data, error } = await client.GET("/admin/knowledge/unified");
-    if (error) throw error;
-    return data;
-  },
-
   reconvertFile: async (originalKey: string, filename: string) => {
     const { data, error } = await client.POST("/admin/knowledge/reconvert", {
       body: { originalKey, filename },
     });
     if (error) throw error;
     return data;
-  },
-
-  getOriginalFileUrl: (key: string) => {
-    const encodedKey = encodeURIComponent(key.replace("originals/", ""));
-    return `${baseUrl}/admin/knowledge/originals/${encodedKey}`;
   },
 });
 

--- a/shared/src/api/types.d.ts
+++ b/shared/src/api/types.d.ts
@@ -2467,11 +2467,15 @@ export interface paths {
         };
         /**
          * ファイル一覧を取得
-         * @description R2バケット内のファイル一覧を取得します
+         * @description R2 バケット内のファイル一覧をプレフィクスで絞り込み、カーソルでページングして取得します
          */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    prefix?: "official/" | "curated/";
+                    limit?: number;
+                    cursor?: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
@@ -2489,10 +2493,9 @@ export interface paths {
                                 key: string;
                                 size: number;
                                 lastModified: string;
-                                etag: string;
-                                edited?: boolean;
                             }[];
-                            truncated: boolean;
+                            nextCursor: string | null;
+                            hasMore: boolean;
                         };
                     };
                 };
@@ -2755,18 +2758,21 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/admin/knowledge/unified": {
+    "/admin/knowledge/legacy": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
+        get?: never;
+        put?: never;
+        post?: never;
         /**
-         * 統合ファイル一覧を取得
-         * @description 元ファイル（originals/）とMarkdownファイルを統合した一覧を取得します
+         * 旧配置のナレッジを全削除
+         * @description curated/ と official/ のどちらにも属さないオブジェクト（ルート直下の Markdown と originals/）を R2 から全て削除します。Vectorize のデータは R2 イベント経由で削除されます。official/ への移行後に 1 回だけ使う一時的なエンドポイントで、移行完了後に削除する予定です
          */
-        get: {
+        delete: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -2775,29 +2781,14 @@ export interface paths {
             };
             requestBody?: never;
             responses: {
-                /** @description 統合ファイル一覧 */
+                /** @description 削除成功 */
                 200: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
                         "application/json": {
-                            files: {
-                                baseName: string;
-                                original?: {
-                                    key: string;
-                                    size: number;
-                                    lastModified: string;
-                                    contentType: string;
-                                };
-                                markdown?: {
-                                    key: string;
-                                    size: number;
-                                    lastModified: string;
-                                };
-                                hasMarkdown: boolean;
-                            }[];
-                            truncated: boolean;
+                            deleted: number;
                         };
                     };
                 };
@@ -2831,90 +2822,6 @@ export interface paths {
                 };
             };
         };
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/knowledge/originals/{key}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * 元ファイルを取得
-         * @description originals/ 配下の元ファイルを取得します（画像/PDF）
-         */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    key: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description 元ファイル（バイナリ） */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description 認証エラー */
-                401: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: {
-                                code: number;
-                                message: string;
-                            };
-                        };
-                    };
-                };
-                /** @description リソースが見つかりません */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: {
-                                code: number;
-                                message: string;
-                            };
-                        };
-                    };
-                };
-                /** @description サーバーエラー */
-                500: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": {
-                            error: {
-                                code: number;
-                                message: string;
-                            };
-                        };
-                    };
-                };
-            };
-        };
-        put?: never;
-        post?: never;
-        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -2930,8 +2837,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * ファイルをアップロード
-         * @description Markdownファイルをアップロードし、R2に保存してVectorizeに同期します
+         * 公式資料の Markdown をアップロード
+         * @description Markdown ファイルを R2 の official/ 配下に保存します。Vectorize への同期は R2 イベント経由で非同期に行われます
          */
         post: {
             parameters: {
@@ -2945,6 +2852,7 @@ export interface paths {
                     "multipart/form-data": {
                         /** Format: binary */
                         file?: string;
+                        /** @description official/ からの相対パス。省略時はファイル名をそのまま使う */
                         filename?: string;
                     };
                 };

--- a/shared/src/api/types.ts
+++ b/shared/src/api/types.ts
@@ -96,8 +96,6 @@ export type FilesListResponse = GetOk<"/admin/knowledge/files">;
 export type FileInfo = FilesListResponse["files"][number];
 export type FileContentResponse = GetOk<"/admin/knowledge/files/{key}">;
 export type SaveFileResponse = PutOk<"/admin/knowledge/files/{key}">;
-export type UnifiedFilesListResponse = GetOk<"/admin/knowledge/unified">;
-export type UnifiedFileInfo = UnifiedFilesListResponse["files"][number];
 
 export type CuratedDraft = PostOk<"/admin/knowledge/curated-draft">;
 // multipart なので生成型を使わず手書き

--- a/shared/src/constants/knowledge.ts
+++ b/shared/src/constants/knowledge.ts
@@ -11,3 +11,8 @@ export const CURATED_DRAFT_LIMITS = {
   files: 5,
   filesTotalBytes: 20 * 1024 * 1024,
 } as const;
+
+export const CURATED_PREFIX = "curated/";
+export const OFFICIAL_PREFIX = "official/";
+export const KNOWLEDGE_PREFIXES = [OFFICIAL_PREFIX, CURATED_PREFIX] as const;
+export type KnowledgePrefix = (typeof KNOWLEDGE_PREFIXES)[number];

--- a/web/src/app/dashboard/components/KnowledgePanel.tsx
+++ b/web/src/app/dashboard/components/KnowledgePanel.tsx
@@ -3,29 +3,82 @@ import {
   CuratedComposer,
   FileEditor,
   FileList,
+  FileUpload,
   FileViewer,
 } from "~/app/dashboard/components/knowledge";
-import { partitionFiles } from "~/app/dashboard/components/knowledge/helpers";
+import {
+  CURATED_PREFIX,
+  type KnowledgePrefix,
+  OFFICIAL_PREFIX,
+} from "~/app/dashboard/components/knowledge/helpers";
+import { useInfiniteScroll } from "~/app/dashboard/hooks/useInfiniteScroll";
 import {
   useDeleteFile,
-  useUnifiedFiles,
+  useKnowledgeFiles,
+  useSyncKnowledge,
 } from "~/app/dashboard/hooks/useKnowledge";
 
-type FileTab = "curated" | "base";
-
-const FILE_TABS = [
-  { id: "curated", label: "追加したナレッジ" },
-  { id: "base", label: "基本ナレッジ" },
+const TABS = [
+  { prefix: CURATED_PREFIX, label: "追加したナレッジ" },
+  { prefix: OFFICIAL_PREFIX, label: "公式資料" },
 ] as const;
 
-const EMPTY_MESSAGE: Record<FileTab, string> = {
-  curated: "まだありません。上の「ナレッジを追加」から作れます",
-  base: "ファイルがありません",
+const SECTION_HEADING = "text-base font-bold text-stone-800 mb-4";
+
+const EMPTY_MESSAGE: Record<KnowledgePrefix, string> = {
+  [CURATED_PREFIX]: "まだありません。上の「ナレッジを追加」から作れます",
+  [OFFICIAL_PREFIX]: "まだありません。上からファイルを追加できます",
+};
+
+type ListProps = {
+  prefix: KnowledgePrefix;
+  onView: (key: string) => void;
+  onEdit: (key: string) => void;
+  onDelete: (key: string) => void;
+  isDeleting: boolean;
+};
+
+const KnowledgeFiles = ({ prefix, ...handlers }: ListProps) => {
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useKnowledgeFiles(prefix);
+  const loadMoreRef = useInfiniteScroll({
+    hasNextPage: hasNextPage ?? false,
+    isFetching: isFetchingNextPage,
+    onFetch: fetchNextPage,
+  });
+
+  if (isLoading) {
+    return <div className="text-center py-8 text-stone-500">読み込み中...</div>;
+  }
+  if (error) {
+    return (
+      <div className="text-center py-8 text-red-500">
+        エラー:{" "}
+        {error instanceof Error ? error.message : "読み込みに失敗しました"}
+      </div>
+    );
+  }
+
+  return (
+    <FileList
+      files={data?.pages.flatMap((page) => page.files) ?? []}
+      emptyMessage={EMPTY_MESSAGE[prefix]}
+      loadMoreRef={loadMoreRef}
+      hasNextPage={hasNextPage ?? false}
+      isFetchingNextPage={isFetchingNextPage}
+      {...handlers}
+    />
+  );
 };
 
 export const KnowledgePanel = () => {
-  const { data: filesData, isLoading, error } = useUnifiedFiles();
-  const [fileTab, setFileTab] = useState<FileTab>("curated");
+  const [tab, setTab] = useState<KnowledgePrefix>(CURATED_PREFIX);
   const [viewingFile, setViewingFile] = useState<string | null>(null);
   const [editingFile, setEditingFile] = useState<string | null>(null);
   const [message, setMessage] = useState<{
@@ -33,26 +86,40 @@ export const KnowledgePanel = () => {
     text: string;
   } | null>(null);
   const deleteFileMutation = useDeleteFile();
+  const syncMutation = useSyncKnowledge();
 
-  const existingKeys =
-    filesData?.files.flatMap((f) => (f.markdown ? [f.markdown.key] : [])) ?? [];
-  const partitioned = partitionFiles(filesData?.files ?? []);
-
-  const handleDeleteFile = (baseName: string) => {
+  const handleSync = () => {
     if (
       !confirm(
-        `${baseName} を完全に削除しますか？\n（Markdown、元ファイル、ベクトルデータがすべて削除されます）`,
+        "R2 にある全ファイルを検索データに再同期します。反映まで数分かかります",
       )
     ) {
       return;
     }
     setMessage(null);
-    deleteFileMutation.mutate(`${baseName}.md`, {
-      onSuccess: () => {
+    syncMutation.mutate(undefined, {
+      onSuccess: (result) => {
+        setMessage({ type: "success", text: result.message });
+      },
+      onError: (err) => {
         setMessage({
-          type: "success",
-          text: `${baseName} を削除しました`,
+          type: "error",
+          text: `再同期失敗: ${err instanceof Error ? err.message : "Unknown error"}`,
         });
+      },
+    });
+  };
+
+  const handleDeleteFile = (key: string) => {
+    if (
+      !confirm(`${key} を削除しますか？\nMarkdown と検索データが削除されます`)
+    ) {
+      return;
+    }
+    setMessage(null);
+    deleteFileMutation.mutate(key, {
+      onSuccess: () => {
+        setMessage({ type: "success", text: `${key} を削除しました` });
       },
       onError: (err) => {
         setMessage({
@@ -63,83 +130,92 @@ export const KnowledgePanel = () => {
     });
   };
 
+  const handlers = {
+    onView: setViewingFile,
+    onEdit: setEditingFile,
+    onDelete: handleDeleteFile,
+    isDeleting: deleteFileMutation.isPending,
+  };
+
   return (
     <div className="space-y-6">
-      <div className="bg-white rounded-xl border border-stone-200 p-6">
-        <h2 className="text-lg font-bold text-stone-800 mb-4">
-          ナレッジを追加
-        </h2>
-        <CuratedComposer existingKeys={existingKeys} />
-      </div>
-
-      <div className="bg-white rounded-xl border border-stone-200 p-6">
-        <h2 className="text-lg font-bold text-stone-800 mb-4">ファイル一覧</h2>
-
+      <div>
         <div
           role="tablist"
           aria-label="ナレッジの種類"
-          className="flex flex-wrap gap-2 mb-4"
+          className="flex border-b border-stone-300 divide-x divide-stone-300"
         >
-          {FILE_TABS.map((tab) => (
+          {TABS.map((item) => (
             <button
-              key={tab.id}
+              key={item.prefix}
               type="button"
               role="tab"
-              aria-selected={fileTab === tab.id}
-              onClick={() => setFileTab(tab.id)}
-              className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-lg border text-sm font-medium transition-colors ${
-                fileTab === tab.id
-                  ? "border-teal-600 bg-teal-600 text-white"
-                  : "border-stone-300 bg-white text-stone-700 hover:bg-stone-50"
+              aria-selected={tab === item.prefix}
+              onClick={() => setTab(item.prefix)}
+              className={`px-4 py-2 -mb-px text-sm font-medium border-t border-b border-stone-300 rounded-t-lg first:border-l last:border-r transition-colors ${
+                tab === item.prefix
+                  ? "border-b-white bg-white text-stone-800"
+                  : "border-b-transparent bg-stone-100 text-stone-600 hover:text-stone-800"
               }`}
             >
-              {tab.label}
-              {filesData && (
-                <span
-                  className={`text-xs tabular-nums ${
-                    fileTab === tab.id ? "text-teal-100" : "text-stone-500"
-                  }`}
-                >
-                  {partitioned[tab.id].length}
-                </span>
-              )}
+              {item.label}
             </button>
           ))}
         </div>
 
-        {message && (
-          <div
-            className={`mb-4 px-4 py-3 rounded-lg text-sm ${
-              message.type === "success"
-                ? "bg-green-50 text-green-700"
-                : "bg-red-50 text-red-700"
-            }`}
-          >
-            {message.text}
+        <div className="bg-white rounded-b-xl border border-t-0 border-stone-300 p-6">
+          {message && (
+            <div
+              className={`mb-4 px-4 py-3 rounded-lg text-sm ${
+                message.type === "success"
+                  ? "bg-green-50 text-green-700"
+                  : "bg-red-50 text-red-700"
+              }`}
+            >
+              {message.text}
+            </div>
+          )}
+
+          <div hidden={tab !== CURATED_PREFIX} className="space-y-6">
+            <section>
+              <h3 className={SECTION_HEADING}>ナレッジを追加</h3>
+              <CuratedComposer />
+            </section>
+            <section>
+              <h3 className={SECTION_HEADING}>ナレッジ一覧</h3>
+              {tab === CURATED_PREFIX && (
+                <KnowledgeFiles prefix={CURATED_PREFIX} {...handlers} />
+              )}
+            </section>
           </div>
-        )}
 
-        {isLoading && (
-          <div className="text-center py-8 text-stone-500">読み込み中...</div>
-        )}
-
-        {error && (
-          <div className="text-center py-8 text-red-500">
-            エラー:{" "}
-            {error instanceof Error ? error.message : "読み込みに失敗しました"}
+          <div hidden={tab !== OFFICIAL_PREFIX} className="space-y-6">
+            <section>
+              <h3 className={SECTION_HEADING}>公式資料をアップロード</h3>
+              <FileUpload />
+            </section>
+            <section>
+              <div className="flex items-baseline justify-between gap-4 mb-4">
+                <h3 className="text-base font-bold text-stone-800">
+                  公式資料一覧
+                </h3>
+                <button
+                  type="button"
+                  onClick={handleSync}
+                  disabled={syncMutation.isPending}
+                  className="text-sm text-teal-600 hover:text-teal-800 hover:underline disabled:opacity-50"
+                >
+                  {syncMutation.isPending
+                    ? "再同期中..."
+                    : "検索データを再同期"}
+                </button>
+              </div>
+              {tab === OFFICIAL_PREFIX && (
+                <KnowledgeFiles prefix={OFFICIAL_PREFIX} {...handlers} />
+              )}
+            </section>
           </div>
-        )}
-
-        {filesData && (
-          <FileList
-            files={partitioned[fileTab]}
-            onView={(key) => setViewingFile(key)}
-            onEdit={(key) => setEditingFile(key)}
-            onDelete={handleDeleteFile}
-            isDeleting={deleteFileMutation.isPending}
-            emptyMessage={EMPTY_MESSAGE[fileTab]}
-          />
-        )}
+        </div>
       </div>
 
       {viewingFile && (

--- a/web/src/app/dashboard/components/knowledge/CuratedComposer.test.tsx
+++ b/web/src/app/dashboard/components/knowledge/CuratedComposer.test.tsx
@@ -58,8 +58,22 @@ const captureRequest = () => {
   return captured;
 };
 
-const renderComposer = (existingKeys: string[] = []) =>
-  renderWithQuery(<CuratedComposer existingKeys={existingKeys} />);
+const renderComposer = () => renderWithQuery(<CuratedComposer />);
+
+const existingKeys = (keys: string[]) =>
+  server.use(
+    http.get(`${API}/admin/knowledge/files/*`, ({ request }) => {
+      const key = decodeURIComponent(
+        new URL(request.url).pathname.replace("/admin/knowledge/files/", ""),
+      );
+      return keys.includes(key)
+        ? HttpResponse.json({ key, content: "# x" })
+        : HttpResponse.json(
+            { error: { message: "File not found" } },
+            { status: 404 },
+          );
+    }),
+  );
 
 const generateFrom = async (text: string) => {
   fireEvent.change(openText(), { target: { value: text } });
@@ -70,6 +84,7 @@ const generateFrom = async (text: string) => {
 beforeEach(() => {
   localStorage.clear();
   setAuthToken("admin-token");
+  existingKeys([]);
 });
 
 afterEach(() => {
@@ -304,20 +319,22 @@ describe("CuratedComposer", () => {
     expect(generateButton()).toBeDisabled();
   });
 
-  it("保存先は自動で決まり、「変更」で編集でき、既存キーなら上書き警告、/ は不可", async () => {
+  it("保存先は自動で決まり、「変更」で編集でき、同名ファイルがサーバーにあれば上書き警告、/ は不可", async () => {
     captureRequest();
-    renderComposer(["curated/otoineppu-tokyo.md"]);
+    existingKeys(["curated/otoineppu-tokyo.md"]);
+    renderComposer();
     await generateFrom("メモ");
 
-    expect(screen.getByText(OVERWRITE_WARNING)).toBeDefined();
+    expect(await screen.findByText(OVERWRITE_WARNING)).toBeDefined();
     expect(saveButton()).toHaveTextContent("上書きして保存");
 
     fireEvent.click(screen.getByRole("button", { name: "変更" }));
     fireEvent.change(screen.getByLabelText("保存先"), {
       target: { value: "otoineppu-tokyo-2" },
     });
+    await waitFor(() => expect(saveButton()).toBeEnabled());
     expect(screen.queryByText(OVERWRITE_WARNING)).toBeNull();
-    expect(saveButton()).toBeEnabled();
+    expect(saveButton()).toHaveTextContent("保存");
 
     fireEvent.change(screen.getByLabelText("保存先"), {
       target: { value: "a/b" },
@@ -338,6 +355,7 @@ describe("CuratedComposer", () => {
     renderComposer();
     await generateFrom("メモ");
 
+    await waitFor(() => expect(saveButton()).toBeEnabled());
     fireEvent.click(saveButton());
 
     expect(

--- a/web/src/app/dashboard/components/knowledge/CuratedComposer.tsx
+++ b/web/src/app/dashboard/components/knowledge/CuratedComposer.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import {
   useDraftCurated,
+  useKnowledgeFileExists,
   useSaveFile,
 } from "~/app/dashboard/hooks/useKnowledge";
 import { MarkdownText } from "~/components/chat/MarkdownText";
@@ -44,10 +45,6 @@ import {
   splitDraft,
   toDraftRequest,
 } from "./helpers";
-
-type Props = {
-  existingKeys: string[];
-};
 
 const SOURCE_TABS = [
   { kind: "url", label: "URL から作る", icon: LinkIcon },
@@ -104,7 +101,7 @@ const FileThumb = ({
   );
 };
 
-export const CuratedComposer = ({ existingKeys }: Props) => {
+export const CuratedComposer = () => {
   const [urls, setUrls] = useState<string[]>([]);
   const [urlInput, setUrlInput] = useState("");
   const [urlError, setUrlError] = useState(false);
@@ -132,12 +129,14 @@ export const CuratedComposer = ({ existingKeys }: Props) => {
   const busy = draftMutation.isPending || saveMutation.isPending;
   const canGenerate = hasDraftInput(fields) && !busy;
   const key = keyFromSlug(slug);
-  const exists = slug.trim().length > 0 && existingKeys.includes(key);
+  const existing = useKnowledgeFileExists(isValidSlug(slug) ? key : null);
+  const exists = existing.data === true;
   const canSave =
     draft !== null &&
     isValidSlug(slug) &&
     draft.title.trim().length > 0 &&
     draft.body.trim().length > 0 &&
+    !existing.isLoading &&
     !busy;
 
   const commitUrl = (input: string) => {
@@ -353,7 +352,7 @@ export const CuratedComposer = ({ existingKeys }: Props) => {
             <p className="text-sm text-stone-600">
               チラシや写真、PDF の文字を読み取って下書きを作ります
             </p>
-            <div className="flex flex-wrap items-start gap-3">
+            <div className="space-y-3">
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
@@ -365,7 +364,7 @@ export const CuratedComposer = ({ existingKeys }: Props) => {
                 onDrop={onDrop}
                 onPaste={onPaste}
                 disabled={busy || files.length >= CURATED_DRAFT_LIMITS.files}
-                className={`min-w-[240px] min-h-[96px] flex flex-col items-center justify-center gap-1 px-6 rounded-lg border-2 border-dashed text-sm transition-colors disabled:opacity-50 ${
+                className={`w-full min-h-[96px] flex flex-col items-center justify-center gap-1 px-6 rounded-lg border-2 border-dashed text-sm transition-colors disabled:opacity-50 ${
                   dragging
                     ? "border-teal-500 bg-teal-50 text-teal-700"
                     : "border-stone-300 text-stone-600 hover:border-teal-400 hover:text-teal-700"

--- a/web/src/app/dashboard/components/knowledge/FileList.test.tsx
+++ b/web/src/app/dashboard/components/knowledge/FileList.test.tsx
@@ -1,152 +1,116 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { UnifiedFileInfo } from "~/types";
+import type { FileInfo } from "~/types";
 import { FileList } from "./FileList";
 
-const mkFile = (overrides: Partial<UnifiedFileInfo> = {}): UnifiedFileInfo => ({
-  baseName: "doc",
-  hasMarkdown: true,
-  markdown: {
-    key: "doc.md",
-    size: 2048,
-    lastModified: "2025-01-01T00:00:00Z",
-  },
-  original: undefined,
-  ...overrides,
+const info = (key: string): FileInfo => ({
+  key,
+  size: 1,
+  lastModified: "2026-09-07T05:02:00Z",
 });
 
+const renderList = (
+  files: FileInfo[],
+  overrides: Partial<Parameters<typeof FileList>[0]> = {},
+) => {
+  const handlers = { onView: vi.fn(), onEdit: vi.fn(), onDelete: vi.fn() };
+  render(
+    <FileList
+      files={files}
+      loadMoreRef={vi.fn()}
+      hasNextPage={false}
+      isFetchingNextPage={false}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+  return handlers;
+};
+
+const buttonsNamed = (name: string) =>
+  screen.getAllByRole("button").filter((b) => b.textContent === name);
+
 describe("FileList", () => {
-  it("空配列なら『ファイルがありません』を表示", () => {
-    render(<FileList files={[]} />);
-    expect(screen.getByText("ファイルがありません")).toBeDefined();
+  it("空なら emptyMessage を表示し、末尾表示は出さない", () => {
+    renderList([], { emptyMessage: "まだありません" });
+    expect(screen.getByText("まだありません")).toBeDefined();
+    expect(screen.queryByText("すべてのファイルを表示しました")).toBeNull();
   });
 
-  it("baseName を表で表示", () => {
-    render(<FileList files={[mkFile({ baseName: "intro" })]} />);
-    expect(screen.getAllByText("intro").length).toBeGreaterThan(0);
+  it("キーをディレクトリ部分とファイル名に分けて表示する", () => {
+    renderList([info("official/otoko/access/bus-jikoku.md")]);
+    expect(
+      screen.getAllByText("official/otoko/access/").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("bus-jikoku.md").length).toBeGreaterThan(0);
   });
 
-  it("original あり: ファイル名がリンクとして描画される", () => {
-    render(
-      <FileList
-        files={[
-          mkFile({
-            original: {
-              key: "originals/foo.pdf",
-              size: 1024,
-              lastModified: "2025-01-01T00:00:00Z",
-              contentType: "application/pdf",
-            },
-          }),
-        ]}
-      />,
-    );
-    const links = screen.getAllByRole("link");
-    expect(links.length).toBeGreaterThan(0);
+  it("閲覧・編集・削除はキーで呼ばれる", () => {
+    const handlers = renderList([info("curated/usagi.md")]);
+
+    fireEvent.click(buttonsNamed("閲覧")[0] as HTMLElement);
+    fireEvent.click(buttonsNamed("編集")[0] as HTMLElement);
+    fireEvent.click(buttonsNamed("削除")[0] as HTMLElement);
+
+    expect(handlers.onView).toHaveBeenCalledWith("curated/usagi.md");
+    expect(handlers.onEdit).toHaveBeenCalledWith("curated/usagi.md");
+    expect(handlers.onDelete).toHaveBeenCalledWith("curated/usagi.md");
   });
 
-  it("onView が渡されたら閲覧ボタンクリックで呼ばれる", () => {
-    const onView = vi.fn();
-    render(<FileList files={[mkFile({ baseName: "x" })]} onView={onView} />);
+  it("official 行は閲覧と削除だけ、旧配置の行は閲覧だけ", () => {
+    renderList([info("official/kurashi/gomi.md")]);
+    expect(buttonsNamed("閲覧")).toHaveLength(2);
+    expect(buttonsNamed("編集")).toHaveLength(0);
+    expect(buttonsNamed("削除")).toHaveLength(2);
+  });
 
-    const buttons = screen
-      .getAllByRole("button")
-      .filter((b) => b.textContent === "閲覧");
-    if (buttons[0]) {
-      fireEvent.click(buttons[0]);
-      expect(onView).toHaveBeenCalledWith("doc.md");
+  it("curated/ official/ 以外の行には編集も削除も出ない", () => {
+    renderList([info("villotoinep/index.md")]);
+    expect(buttonsNamed("閲覧")).toHaveLength(2);
+    expect(buttonsNamed("編集")).toHaveLength(0);
+    expect(buttonsNamed("削除")).toHaveLength(0);
+  });
+
+  it("削除中は削除ボタンが無効になる", () => {
+    renderList([info("official/a.md")], { isDeleting: true });
+    for (const button of buttonsNamed("削除")) {
+      expect(button).toBeDisabled();
     }
   });
 
-  it("onDelete が渡されたら curated 行の削除ボタンで baseName 経由で呼ばれる", () => {
-    const onDelete = vi.fn();
-
-    render(
+  it("末尾は取得中なら読み込み中、次ページが無ければ完了表示", () => {
+    const { rerender } = render(
       <FileList
-        files={[
-          mkFile({
-            baseName: "curated/rm-me",
-            markdown: {
-              key: "curated/rm-me.md",
-              size: 1,
-              lastModified: "2025-01-01T00:00:00Z",
-            },
-          }),
-        ]}
-        onDelete={onDelete}
-      />,
-    );
-
-    const buttons = screen
-      .getAllByRole("button")
-      .filter((b) => b.textContent === "削除");
-    expect(buttons).toHaveLength(2);
-    fireEvent.click(buttons[0] as HTMLElement);
-    expect(onDelete).toHaveBeenCalledWith("curated/rm-me");
-  });
-
-  it("git 管理の行には削除ボタンが出ず、元ファイルを持つ行には出る", () => {
-    render(
-      <FileList
-        files={[
-          mkFile({ baseName: "villotoinep/index" }),
-          mkFile({
-            baseName: "chirashi",
-            original: {
-              key: "originals/chirashi.pdf",
-              size: 1,
-              lastModified: "2025-01-01T00:00:00Z",
-              contentType: "application/pdf",
-            },
-          }),
-        ]}
+        files={[info("official/a.md")]}
+        onView={vi.fn()}
+        onEdit={vi.fn()}
         onDelete={vi.fn()}
+        loadMoreRef={vi.fn()}
+        hasNextPage={true}
+        isFetchingNextPage={true}
       />,
     );
+    expect(screen.getByText("読み込み中...")).toBeDefined();
+    expect(screen.queryByText("すべてのファイルを表示しました")).toBeNull();
 
-    const buttons = screen
-      .getAllByRole("button")
-      .filter((b) => b.textContent === "削除");
-    expect(buttons).toHaveLength(2);
-  });
-
-  it("emptyMessage があれば空表示の文言を差し替える", () => {
-    render(<FileList files={[]} emptyMessage="まだありません" />);
-    expect(screen.getByText("まだありません")).toBeDefined();
-  });
-
-  it("onEdit が渡されても curated/ 配下の行にだけ編集ボタンが出る", () => {
-    const onEdit = vi.fn();
-    render(
+    rerender(
       <FileList
-        files={[
-          mkFile({
-            baseName: "curated/usagi",
-            markdown: {
-              key: "curated/usagi.md",
-              size: 1,
-              lastModified: "2025-01-01T00:00:00Z",
-            },
-          }),
-          mkFile({
-            baseName: "villotoinep/index",
-            markdown: {
-              key: "villotoinep/index.md",
-              size: 1,
-              lastModified: "2025-01-01T00:00:00Z",
-            },
-          }),
-        ]}
-        onEdit={onEdit}
+        files={[info("official/a.md")]}
+        onView={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        loadMoreRef={vi.fn()}
+        hasNextPage={false}
+        isFetchingNextPage={false}
       />,
     );
+    expect(screen.queryByText("読み込み中...")).toBeNull();
+    expect(screen.getByText("すべてのファイルを表示しました")).toBeDefined();
+  });
 
-    const editButtons = screen
-      .getAllByRole("button")
-      .filter((b) => b.textContent === "編集");
-    // desktop と mobile の 2 レイアウト分
-    expect(editButtons).toHaveLength(2);
-    fireEvent.click(editButtons[0] as HTMLElement);
-    expect(onEdit).toHaveBeenCalledWith("curated/usagi.md");
+  it("末尾要素を loadMoreRef に渡す", () => {
+    const loadMoreRef = vi.fn();
+    renderList([info("official/a.md")], { loadMoreRef, hasNextPage: true });
+    expect(loadMoreRef).toHaveBeenCalledWith(expect.any(HTMLDivElement));
   });
 });

--- a/web/src/app/dashboard/components/knowledge/FileList.tsx
+++ b/web/src/app/dashboard/components/knowledge/FileList.tsx
@@ -1,24 +1,69 @@
-import { knowledgeRepository } from "~/lib/api/repository";
 import { formatDateTime } from "~/lib/format";
-import type { UnifiedFileInfo } from "~/types";
-import { canDeleteFile, isCuratedFile } from "./helpers";
+import type { FileInfo } from "~/types";
+import { canDeleteFile, isCuratedFile, splitKey } from "./helpers";
 
 type Props = {
-  files: UnifiedFileInfo[];
-  onView?: (key: string) => void;
-  onEdit?: (key: string) => void;
-  onDelete?: (baseName: string) => void;
+  files: FileInfo[];
+  onView: (key: string) => void;
+  onEdit: (key: string) => void;
+  onDelete: (key: string) => void;
   isDeleting?: boolean;
   emptyMessage?: string;
+  loadMoreRef: (element: HTMLDivElement | null) => void;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
 };
 
-const formatFileSize = (bytes: number) => {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
+const ACTION_CLASS = "text-teal-600 hover:text-teal-800 font-medium";
 
-const isImageType = (contentType: string) => contentType.startsWith("image/");
+const Actions = ({
+  file,
+  onView,
+  onEdit,
+  onDelete,
+  isDeleting,
+}: Pick<Props, "onView" | "onEdit" | "onDelete" | "isDeleting"> & {
+  file: FileInfo;
+}) => (
+  <>
+    <button
+      type="button"
+      onClick={() => onView(file.key)}
+      className={ACTION_CLASS}
+    >
+      閲覧
+    </button>
+    {isCuratedFile(file) && (
+      <button
+        type="button"
+        onClick={() => onEdit(file.key)}
+        className={ACTION_CLASS}
+      >
+        編集
+      </button>
+    )}
+    {canDeleteFile(file) && (
+      <button
+        type="button"
+        onClick={() => onDelete(file.key)}
+        disabled={isDeleting}
+        className="text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
+      >
+        削除
+      </button>
+    )}
+  </>
+);
+
+const FileName = ({ fileKey }: { fileKey: string }) => {
+  const { dir, name } = splitKey(fileKey);
+  return (
+    <span className="font-mono text-sm break-all">
+      <span className="text-stone-400">{dir}</span>
+      <span className="text-stone-900">{name}</span>
+    </span>
+  );
+};
 
 export const FileList = ({
   files,
@@ -27,6 +72,9 @@ export const FileList = ({
   onDelete,
   isDeleting,
   emptyMessage = "ファイルがありません",
+  loadMoreRef,
+  hasNextPage,
+  isFetchingNextPage,
 }: Props) => {
   if (files.length === 0) {
     return (
@@ -34,18 +82,16 @@ export const FileList = ({
     );
   }
 
+  const actionProps = { onView, onEdit, onDelete, isDeleting };
+
   return (
-    <>
-      {/* Desktop: Table View */}
-      <div className="hidden md:block overflow-auto max-h-[70dvh]">
+    <div className="max-h-[70dvh] overflow-auto">
+      <div className="hidden md:block">
         <table className="min-w-full divide-y divide-stone-200">
           <thead className="bg-stone-50 sticky top-0">
             <tr>
               <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                ファイル名
-              </th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                元ファイル
+                ファイル
               </th>
               <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
                 更新日時
@@ -56,161 +102,50 @@ export const FileList = ({
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-stone-200">
-            {files.map((file) => {
-              const lastModified =
-                file.markdown?.lastModified ||
-                file.original?.lastModified ||
-                "";
-
-              return (
-                <tr key={file.baseName} className="hover:bg-stone-50">
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    <span className="text-sm font-medium text-stone-900">
-                      {file.baseName}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap">
-                    {(() => {
-                      const orig = file.original;
-                      if (!orig) {
-                        return (
-                          <span className="text-sm text-stone-400">-</span>
-                        );
-                      }
-                      return (
-                        <a
-                          href={knowledgeRepository.getOriginalFileUrl(
-                            orig.key,
-                          )}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-sm text-teal-600 hover:text-teal-800 hover:underline"
-                          title="元ファイルをダウンロード"
-                        >
-                          <span>
-                            {isImageType(orig.contentType) ? "🖼️" : "📄"}
-                          </span>
-                          <span>{formatFileSize(orig.size)}</span>
-                        </a>
-                      );
-                    })()}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap text-sm text-stone-500">
-                    {lastModified ? formatDateTime(lastModified) : "-"}
-                  </td>
-                  <td className="px-4 py-3 whitespace-nowrap text-right text-sm">
-                    <div className="flex justify-end gap-3">
-                      {file.hasMarkdown && onView && (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            file.markdown && onView(file.markdown.key)
-                          }
-                          className="text-teal-600 hover:text-teal-800 font-medium"
-                        >
-                          閲覧
-                        </button>
-                      )}
-                      {onEdit && isCuratedFile(file) && (
-                        <button
-                          type="button"
-                          onClick={() =>
-                            file.markdown && onEdit(file.markdown.key)
-                          }
-                          className="text-teal-600 hover:text-teal-800 font-medium"
-                        >
-                          編集
-                        </button>
-                      )}
-                      {onDelete && canDeleteFile(file) && (
-                        <button
-                          type="button"
-                          onClick={() => onDelete(file.baseName)}
-                          disabled={isDeleting}
-                          className="text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
-                        >
-                          削除
-                        </button>
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
+            {files.map((file) => (
+              <tr key={file.key} className="hover:bg-stone-50">
+                <td className="px-4 py-3">
+                  <FileName fileKey={file.key} />
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-sm text-stone-500 tabular-nums">
+                  {formatDateTime(file.lastModified)}
+                </td>
+                <td className="px-4 py-3 whitespace-nowrap text-right text-sm">
+                  <div className="flex justify-end gap-3">
+                    <Actions file={file} {...actionProps} />
+                  </div>
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
 
-      {/* Mobile: Card View */}
-      <div className="md:hidden space-y-3 overflow-y-auto max-h-[70dvh]">
-        {files.map((file) => {
-          const lastModified =
-            file.markdown?.lastModified || file.original?.lastModified || "";
-          const orig = file.original;
-
-          return (
-            <div
-              key={file.baseName}
-              className="border border-stone-200 rounded-lg p-4 space-y-3"
-            >
-              <div className="flex items-start justify-between gap-2">
-                <span className="text-sm font-medium text-stone-900 break-all">
-                  {file.baseName}
-                </span>
-                {orig && (
-                  <a
-                    href={knowledgeRepository.getOriginalFileUrl(orig.key)}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-xs text-teal-600 hover:text-teal-800 shrink-0"
-                    title="元ファイルをダウンロード"
-                  >
-                    <span>{isImageType(orig.contentType) ? "🖼️" : "📄"}</span>
-                    <span>{formatFileSize(orig.size)}</span>
-                  </a>
-                )}
-              </div>
-
-              {lastModified && (
-                <div className="text-xs text-stone-500">
-                  更新: {formatDateTime(lastModified)}
-                </div>
-              )}
-
-              <div className="flex gap-4 pt-2 border-t border-stone-100">
-                {file.hasMarkdown && onView && (
-                  <button
-                    type="button"
-                    onClick={() => file.markdown && onView(file.markdown.key)}
-                    className="text-sm text-teal-600 hover:text-teal-800 font-medium"
-                  >
-                    閲覧
-                  </button>
-                )}
-                {onEdit && isCuratedFile(file) && (
-                  <button
-                    type="button"
-                    onClick={() => file.markdown && onEdit(file.markdown.key)}
-                    className="text-sm text-teal-600 hover:text-teal-800 font-medium"
-                  >
-                    編集
-                  </button>
-                )}
-                {onDelete && canDeleteFile(file) && (
-                  <button
-                    type="button"
-                    onClick={() => onDelete(file.baseName)}
-                    disabled={isDeleting}
-                    className="text-sm text-red-600 hover:text-red-800 font-medium disabled:opacity-50"
-                  >
-                    削除
-                  </button>
-                )}
-              </div>
+      <div className="md:hidden space-y-3">
+        {files.map((file) => (
+          <div
+            key={file.key}
+            className="border border-stone-200 rounded-lg p-4 space-y-3"
+          >
+            <FileName fileKey={file.key} />
+            <div className="text-xs text-stone-500">
+              更新: {formatDateTime(file.lastModified)}
             </div>
-          );
-        })}
+            <div className="flex gap-4 pt-2 border-t border-stone-100 text-sm">
+              <Actions file={file} {...actionProps} />
+            </div>
+          </div>
+        ))}
       </div>
-    </>
+
+      <div ref={loadMoreRef} className="py-4 text-center text-sm">
+        {isFetchingNextPage && (
+          <span className="text-stone-500">読み込み中...</span>
+        )}
+        {!hasNextPage && (
+          <span className="text-stone-400">すべてのファイルを表示しました</span>
+        )}
+      </div>
+    </div>
   );
 };

--- a/web/src/app/dashboard/components/knowledge/FileUpload.test.tsx
+++ b/web/src/app/dashboard/components/knowledge/FileUpload.test.tsx
@@ -1,0 +1,210 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { knowledgeRepository } from "~/lib/api/repository";
+import { renderWithQuery } from "~/test/query";
+import { FileUpload } from "./FileUpload";
+
+const mdFile = (name: string, webkitRelativePath = "") => {
+  const file = new File(["# x"], name, { type: "text/markdown" });
+  Object.defineProperty(file, "webkitRelativePath", {
+    value: webkitRelativePath,
+  });
+  return file;
+};
+
+type Deferred = { resolve: () => void; reject: (e: Error) => void };
+
+const spyUpload = () => vi.spyOn(knowledgeRepository, "uploadFile");
+
+const dropZone = () =>
+  screen.getByText("またはここにドラッグ&ドロップ")
+    .parentElement as HTMLElement;
+
+const fakeFileEntry = (fullPath: string) => ({
+  isFile: true,
+  isDirectory: false,
+  fullPath,
+  name: fullPath.split("/").pop(),
+  file: (resolve: (file: File) => void) =>
+    resolve(mdFile(fullPath.split("/").pop() ?? "")),
+});
+
+const fakeDirectoryEntry = (fullPath: string, children: unknown[]) => {
+  const batches = [children, []];
+  return {
+    isFile: false,
+    isDirectory: true,
+    fullPath,
+    name: fullPath.split("/").pop(),
+    createReader: () => ({
+      readEntries: (resolve: (entries: unknown[]) => void) =>
+        resolve(batches.shift() ?? []),
+    }),
+  };
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("FileUpload", () => {
+  it("初期状態ではステータスを出さない", () => {
+    renderWithQuery(<FileUpload />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("ファイル選択: .md だけを相対パス付きで送り、進捗の後に完了文言を出す", async () => {
+    const pending = new Map<string, Deferred>();
+    const upload = spyUpload().mockImplementation(
+      (_file, filename) =>
+        new Promise((resolve, reject) => {
+          pending.set(filename, {
+            resolve: () =>
+              resolve({ key: `official/${filename}`, message: "" }),
+            reject,
+          });
+        }),
+    );
+    renderWithQuery(<FileUpload />);
+
+    fireEvent.change(screen.getByLabelText("ファイル"), {
+      target: { files: [mdFile("a.md"), mdFile("memo.txt"), mdFile("b.md")] },
+    });
+
+    expect(await screen.findByText("0 / 2")).toBeDefined();
+    expect(upload.mock.calls.map(([, filename]) => filename)).toEqual([
+      "a.md",
+      "b.md",
+    ]);
+
+    pending.get("a.md")?.resolve();
+    expect(await screen.findByText("1 / 2")).toBeDefined();
+
+    pending.get("b.md")?.resolve();
+    expect(
+      await screen.findByText(
+        "2 件をアップロードしました。検索に反映されるまで数分かかります",
+      ),
+    ).toBeDefined();
+  });
+
+  it("フォルダ選択: 選んだフォルダを root にした相対パスで送る", async () => {
+    const upload = spyUpload().mockResolvedValue({ key: "k", message: "" });
+    renderWithQuery(<FileUpload />);
+
+    fireEvent.change(screen.getByLabelText("フォルダ"), {
+      target: {
+        files: [
+          mdFile("gomi.md", "knowledge/kurashi/gomi.md"),
+          mdFile(".DS_Store", "knowledge/.DS_Store"),
+        ],
+      },
+    });
+
+    await screen.findByText(
+      "1 件をアップロードしました。検索に反映されるまで数分かかります",
+    );
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(upload.mock.calls[0]?.[1]).toBe("kurashi/gomi.md");
+  });
+
+  it("フォルダのドロップ: エントリを再帰的に読み、フォルダからの相対パスで送る", async () => {
+    const upload = spyUpload().mockResolvedValue({ key: "k", message: "" });
+    renderWithQuery(<FileUpload />);
+
+    const tree = fakeDirectoryEntry("/knowledge", [
+      fakeFileEntry("/knowledge/top.md"),
+      fakeFileEntry("/knowledge/readme.txt"),
+      fakeDirectoryEntry("/knowledge/kurashi", [
+        fakeFileEntry("/knowledge/kurashi/gomi.md"),
+      ]),
+    ]);
+    fireEvent.drop(dropZone(), {
+      dataTransfer: {
+        items: [
+          { webkitGetAsEntry: () => tree },
+          { webkitGetAsEntry: () => null },
+        ],
+        files: [],
+      },
+    });
+
+    await screen.findByText(
+      "2 件をアップロードしました。検索に反映されるまで数分かかります",
+    );
+    expect(upload.mock.calls.map(([, filename]) => filename)).toEqual([
+      "top.md",
+      "kurashi/gomi.md",
+    ]);
+  });
+
+  it("エントリが取れないドロップは files にフォールバックする", async () => {
+    const upload = spyUpload().mockResolvedValue({ key: "k", message: "" });
+    renderWithQuery(<FileUpload />);
+
+    fireEvent.drop(dropZone(), {
+      dataTransfer: { files: [mdFile("plain.md")] },
+    });
+
+    await screen.findByText(
+      "1 件をアップロードしました。検索に反映されるまで数分かかります",
+    );
+    expect(upload.mock.calls[0]?.[1]).toBe("plain.md");
+  });
+
+  it(".md が 1 件も無ければ何も起こらない", () => {
+    const upload = spyUpload();
+    renderWithQuery(<FileUpload />);
+
+    fireEvent.change(screen.getByLabelText("ファイル"), {
+      target: { files: [mdFile("memo.txt")] },
+    });
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("失敗分は一覧に出て、再試行で失敗した分だけを送り直す", async () => {
+    let failOnce = true;
+    const upload = spyUpload().mockImplementation(async (_file, filename) => {
+      if (filename === "kanko/bad.md" && failOnce) {
+        failOnce = false;
+        throw new Error("boom");
+      }
+      return { key: `official/${filename}`, message: "" };
+    });
+    renderWithQuery(<FileUpload />);
+
+    fireEvent.change(screen.getByLabelText("フォルダ"), {
+      target: {
+        files: [
+          mdFile("a.md", "knowledge/a.md"),
+          mdFile("bad.md", "knowledge/kanko/bad.md"),
+        ],
+      },
+    });
+
+    expect(
+      await screen.findByText("1 件をアップロードしました。1 件が失敗しました"),
+    ).toBeDefined();
+    expect(screen.getByText("official/kanko/bad.md")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "失敗分を再試行" }));
+
+    await screen.findByText(
+      "1 件をアップロードしました。検索に反映されるまで数分かかります",
+    );
+    expect(upload.mock.calls.map(([, filename]) => filename)).toEqual([
+      "a.md",
+      "kanko/bad.md",
+      "kanko/bad.md",
+    ]);
+    await waitFor(() =>
+      expect(screen.queryByText("official/kanko/bad.md")).toBeNull(),
+    );
+  });
+});

--- a/web/src/app/dashboard/components/knowledge/FileUpload.tsx
+++ b/web/src/app/dashboard/components/knowledge/FileUpload.tsx
@@ -1,184 +1,166 @@
 import { ArrowUpTrayIcon } from "@heroicons/react/24/outline";
-import { CONVERTIBLE_MIME_TYPES } from "@nepp-chan/shared/constants/knowledge";
-import { useCallback, useState } from "react";
+import { Button } from "@nepp-chan/shared/ui/Button";
+import { type ChangeEvent, type DragEvent, useRef, useState } from "react";
 import {
-  useConvertFile,
-  useUploadFile,
+  type UploadFailure,
+  type UploadItem,
+  useUploadFiles,
 } from "~/app/dashboard/hooks/useKnowledge";
-import { ConvertDialog } from "./ConvertDialog";
+import {
+  collectMarkdownFiles,
+  type EntryDeps,
+  OFFICIAL_PREFIX,
+  pickedFilesToCandidates,
+  readAllEntries,
+} from "./helpers";
 
-type Props = {
-  onSuccess: () => void;
+type Status =
+  | { kind: "idle" }
+  | { kind: "uploading"; done: number; total: number }
+  | { kind: "done"; uploaded: number; failed: UploadFailure[] };
+
+const entryDeps: EntryDeps = {
+  readDirectory: (dir) => readAllEntries(dir.createReader()),
+  readFile: (entry) =>
+    new Promise((resolve, reject) => entry.file(resolve, reject)),
 };
 
-const ACCEPT_TYPES = ".md,.txt,.jpg,.jpeg,.png,.webp,.gif,.pdf";
-const isConvertibleFile = (file: File) =>
-  (CONVERTIBLE_MIME_TYPES as readonly string[]).includes(file.type);
+const entriesOf = (items: DataTransferItemList | undefined) =>
+  Array.from(items ?? [])
+    .map((item) => item.webkitGetAsEntry())
+    .filter((entry): entry is FileSystemEntry => entry !== null);
 
-export const FileUpload = ({ onSuccess }: Props) => {
-  const [isDragging, setIsDragging] = useState(false);
-  const [message, setMessage] = useState<{
-    type: "success" | "error";
-    text: string;
-  } | null>(null);
-  const [convertFile, setConvertFile] = useState<File | null>(null);
+export const FileUpload = () => {
+  const [dragging, setDragging] = useState(false);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const directoryInputRef = useRef<HTMLInputElement>(null);
+  const uploadMutation = useUploadFiles();
+  const busy = status.kind === "uploading";
 
-  const uploadMutation = useUploadFile();
-  const convertMutation = useConvertFile();
-
-  const handleFile = useCallback(
-    (file: File) => {
-      setMessage(null);
-
-      // 画像/PDF の場合は変換ダイアログを表示
-      if (isConvertibleFile(file)) {
-        setConvertFile(file);
-        return;
-      }
-
-      // Markdown/テキストの場合は直接アップロード
-      uploadMutation.mutate(
-        { file },
-        {
-          onSuccess: (result) => {
-            setMessage({
-              type: "success",
-              text: `${result.key} をアップロードしました。検索への反映には数十秒かかります`,
-            });
-            onSuccess();
-          },
-          onError: (err) => {
-            setMessage({
-              type: "error",
-              text:
-                err instanceof Error
-                  ? err.message
-                  : "アップロードに失敗しました",
-            });
-          },
-        },
-      );
-    },
-    [uploadMutation, onSuccess],
-  );
-
-  const handleConvert = async (filename: string) => {
-    if (!convertFile) return;
-
-    try {
-      const result = await convertMutation.mutateAsync({
-        file: convertFile,
-        filename,
-      });
-      setMessage({
-        type: "success",
-        text: `${result.key} に変換しました。検索への反映には数十秒かかります`,
-      });
-      setConvertFile(null);
-      onSuccess();
-    } catch (err) {
-      setMessage({
-        type: "error",
-        text: err instanceof Error ? err.message : "変換に失敗しました",
-      });
-    }
+  const start = async (items: UploadItem[]) => {
+    if (items.length === 0) return;
+    setStatus({ kind: "uploading", done: 0, total: items.length });
+    const outcome = await uploadMutation.mutateAsync({
+      items,
+      onProgress: (done) =>
+        setStatus({ kind: "uploading", done, total: items.length }),
+    });
+    setStatus({ kind: "done", ...outcome });
   };
 
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragging(true);
-  };
-
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragging(false);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragging(false);
-
-    const file = e.dataTransfer.files[0];
-    if (file) {
-      handleFile(file);
-    }
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      handleFile(file);
-    }
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    void start(pickedFilesToCandidates(e.target.files ?? []));
     e.target.value = "";
   };
 
-  const isLoading = uploadMutation.isPending || convertMutation.isPending;
+  const onDrop = (e: DragEvent<HTMLFieldSetElement>) => {
+    e.preventDefault();
+    setDragging(false);
+    if (busy) return;
+    const entries = entriesOf(e.dataTransfer.items);
+    const files = e.dataTransfer.files;
+    void (
+      entries.length > 0
+        ? collectMarkdownFiles(entries, entryDeps)
+        : Promise.resolve(pickedFilesToCandidates(files))
+    ).then(start);
+  };
 
   return (
     <div className="space-y-4">
-      {/* ドラッグ&ドロップ領域 */}
-      <label
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-        className={`block border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
-          isDragging
-            ? "border-teal-500 bg-teal-50"
-            : "border-stone-300 hover:border-stone-400"
+      <fieldset
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={onDrop}
+        className={`border-2 border-dashed rounded-xl px-6 py-8 text-center space-y-3 transition-colors ${
+          dragging ? "border-teal-500 bg-teal-50" : "border-stone-300"
         }`}
       >
-        <div className="space-y-2">
-          <ArrowUpTrayIcon
-            className="mx-auto h-12 w-12 text-stone-400"
-            aria-hidden="true"
-          />
-          <div className="text-sm text-stone-600">
-            <span className="text-teal-600 hover:text-teal-700 font-medium">
-              ファイルを選択
-            </span>
-            <span className="pl-1">またはドラッグ&ドロップ</span>
-          </div>
-          <p className="text-xs text-stone-500">
-            Markdown, テキスト, 画像 (PNG, JPEG, WebP, GIF), PDF
-          </p>
-          <input
-            type="file"
-            className="sr-only"
-            accept={ACCEPT_TYPES}
-            onChange={handleInputChange}
-            disabled={isLoading}
-          />
-        </div>
-      </label>
-
-      {/* ローディング */}
-      {isLoading && (
-        <div className="text-center text-sm text-stone-500">
-          {convertMutation.isPending ? "変換中..." : "アップロード中..."}
-        </div>
-      )}
-
-      {/* メッセージ */}
-      {message && (
-        <div
-          className={`px-4 py-3 rounded-lg text-sm ${
-            message.type === "success"
-              ? "bg-green-50 text-green-700"
-              : "bg-red-50 text-red-700"
-          }`}
-        >
-          {message.text}
-        </div>
-      )}
-
-      {/* 変換ダイアログ */}
-      {convertFile && (
-        <ConvertDialog
-          file={convertFile}
-          onConvert={handleConvert}
-          onCancel={() => setConvertFile(null)}
-          isConverting={convertMutation.isPending}
+        <legend className="sr-only">公式資料のアップロード</legend>
+        <ArrowUpTrayIcon
+          className="mx-auto h-10 w-10 text-stone-400"
+          aria-hidden="true"
         />
+        <div className="flex flex-wrap justify-center gap-2">
+          <Button
+            type="button"
+            onClick={() => directoryInputRef.current?.click()}
+            disabled={busy}
+          >
+            フォルダを選択
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={busy}
+          >
+            ファイルを選択
+          </Button>
+        </div>
+        <p className="text-sm text-stone-500">またはここにドラッグ&ドロップ</p>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept=".md"
+          onChange={onInputChange}
+          className="hidden"
+          aria-label="ファイル"
+        />
+        <input
+          ref={directoryInputRef}
+          type="file"
+          {...{ webkitdirectory: "" }}
+          onChange={onInputChange}
+          className="hidden"
+          aria-label="フォルダ"
+        />
+      </fieldset>
+
+      {status.kind === "uploading" && (
+        <output className="block px-4 py-3 rounded-lg bg-stone-100 text-sm text-stone-600">
+          アップロード中...{" "}
+          <span className="tabular-nums text-stone-900 font-medium">
+            {status.done} / {status.total}
+          </span>
+        </output>
+      )}
+
+      {status.kind === "done" && status.failed.length === 0 && (
+        <output className="block px-4 py-3 rounded-lg bg-green-50 text-sm text-green-700">
+          {status.uploaded}{" "}
+          件をアップロードしました。検索に反映されるまで数分かかります
+        </output>
+      )}
+
+      {status.kind === "done" && status.failed.length > 0 && (
+        <output className="block px-4 py-3 rounded-lg bg-amber-50 text-sm text-amber-800 space-y-2">
+          <p>
+            {status.uploaded} 件をアップロードしました。{status.failed.length}{" "}
+            件が失敗しました
+          </p>
+          <ul className="list-disc pl-5 font-mono text-xs text-stone-800">
+            {status.failed.map((failure) => (
+              <li key={failure.relativePath}>
+                {OFFICIAL_PREFIX}
+                {failure.relativePath}
+              </li>
+            ))}
+          </ul>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => start(status.failed)}
+          >
+            失敗分を再試行
+          </Button>
+        </output>
       )}
     </div>
   );

--- a/web/src/app/dashboard/components/knowledge/helpers.test.ts
+++ b/web/src/app/dashboard/components/knowledge/helpers.test.ts
@@ -1,27 +1,52 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   addUrls,
   canDeleteFile,
+  collectMarkdownFiles,
   extractUrls,
   hasDraftInput,
   hostLabel,
   isCuratedKey,
+  isOfficialKey,
+  isUploadableMarkdown,
   isValidSlug,
   joinDraft,
   keyFromSlug,
-  partitionFiles,
+  pickedFilesToCandidates,
+  readAllEntries,
+  runWithConcurrency,
   slugFromKey,
   splitDraft,
+  splitKey,
+  stripTopFolder,
   toDraftRequest,
+  toRelativePath,
 } from "./helpers";
 
 const file = new File(["x"], "f.png", { type: "image/png" });
+const info = (key: string) => ({
+  key,
+  size: 1,
+  lastModified: "2025-01-01T00:00:00Z",
+});
 
-describe("isCuratedKey", () => {
-  it("curated/ 配下だけ真", () => {
+describe("isCuratedKey / isOfficialKey", () => {
+  it("それぞれのプレフィクス配下だけ真", () => {
     expect(isCuratedKey("curated/usagi.md")).toBe(true);
-    expect(isCuratedKey("villotoinep/index.md")).toBe(false);
-    expect(isCuratedKey("welcome-guide.md")).toBe(false);
+    expect(isCuratedKey("official/usagi.md")).toBe(false);
+    expect(isOfficialKey("official/kurashi/gomi.md")).toBe(true);
+    expect(isOfficialKey("curated/usagi.md")).toBe(false);
+    expect(isOfficialKey("official.md")).toBe(false);
+  });
+});
+
+describe("splitKey", () => {
+  it("最後の / でディレクトリ部分とファイル名に分ける", () => {
+    expect(splitKey("official/kurashi/gomi.md")).toEqual({
+      dir: "official/kurashi/",
+      name: "gomi.md",
+    });
+    expect(splitKey("welcome.md")).toEqual({ dir: "", name: "welcome.md" });
   });
 });
 
@@ -198,61 +223,215 @@ describe("hostLabel", () => {
   });
 });
 
-describe("partitionFiles", () => {
-  const md = (key: string) => ({
-    baseName: key.replace(/\.md$/, ""),
-    hasMarkdown: true,
-    markdown: { key, size: 1, lastModified: "2025-01-01T00:00:00Z" },
-    original: undefined,
-  });
-
-  it("curated/ 配下と、それ以外に分ける", () => {
-    const curated = md("curated/usagi.md");
-    const base = md("villotoinep/index.md");
-    const converted = {
-      ...md("chirashi.md"),
-      original: {
-        key: "originals/chirashi.pdf",
-        size: 1,
-        lastModified: "2025-01-01T00:00:00Z",
-        contentType: "application/pdf",
-      },
-    };
-    expect(partitionFiles([base, curated, converted])).toEqual({
-      curated: [curated],
-      base: [base, converted],
-    });
+describe("canDeleteFile", () => {
+  it("curated/ か official/ 配下だけ削除できる", () => {
+    expect(canDeleteFile(info("curated/usagi.md"))).toBe(true);
+    expect(canDeleteFile(info("official/villotoinep/index.md"))).toBe(true);
+    expect(canDeleteFile(info("villotoinep/index.md"))).toBe(false);
+    expect(canDeleteFile(info("chirashi.md"))).toBe(false);
   });
 });
 
-describe("canDeleteFile", () => {
-  const md = (key: string) => ({
-    baseName: key.replace(/\.md$/, ""),
-    hasMarkdown: true,
-    markdown: { key, size: 1, lastModified: "2025-01-01T00:00:00Z" },
-    original: undefined,
+describe("toRelativePath", () => {
+  it("先頭の / を落とし、それ以外は変えない", () => {
+    expect(toRelativePath("/kurashi/gomi.md")).toBe("kurashi/gomi.md");
+    expect(toRelativePath("//a.md")).toBe("a.md");
+    expect(toRelativePath("kurashi/gomi.md")).toBe("kurashi/gomi.md");
   });
-  const original = {
-    key: "originals/x.pdf",
-    size: 1,
-    lastModified: "2025-01-01T00:00:00Z",
-    contentType: "application/pdf",
+});
+
+describe("stripTopFolder", () => {
+  it("先頭のフォルダ名だけを落とし、フォルダが無ければそのまま", () => {
+    expect(stripTopFolder("knowledge/kurashi/gomi.md")).toBe("kurashi/gomi.md");
+    expect(stripTopFolder("knowledge/index.md")).toBe("index.md");
+    expect(stripTopFolder("top.md")).toBe("top.md");
+  });
+});
+
+describe("isUploadableMarkdown", () => {
+  it(".md だけを受け付ける", () => {
+    expect(isUploadableMarkdown("kurashi/gomi.md")).toBe(true);
+    expect(isUploadableMarkdown("gomi.md")).toBe(true);
+    expect(isUploadableMarkdown("gomi.txt")).toBe(false);
+    expect(isUploadableMarkdown("gomi.MD")).toBe(false);
+    expect(isUploadableMarkdown("gomi.md.bak")).toBe(false);
+  });
+
+  it("dotfile は除外する。ディレクトリ名の . は見ない", () => {
+    expect(isUploadableMarkdown(".DS_Store")).toBe(false);
+    expect(isUploadableMarkdown("kurashi/.hidden.md")).toBe(false);
+    expect(isUploadableMarkdown(".obsidian/note.md")).toBe(true);
+  });
+});
+
+describe("pickedFilesToCandidates", () => {
+  const picked = (name: string, webkitRelativePath = "") => {
+    const f = new File(["x"], name);
+    Object.defineProperty(f, "webkitRelativePath", {
+      value: webkitRelativePath,
+    });
+    return f;
   };
 
-  it("curated/ 配下か、元ファイルを持つ行だけ削除できる", () => {
-    expect(canDeleteFile(md("curated/usagi.md"))).toBe(true);
-    expect(canDeleteFile({ ...md("chirashi.md"), original })).toBe(true);
-    expect(canDeleteFile(md("villotoinep/index.md"))).toBe(false);
+  it("フォルダ選択では選んだフォルダを root として先頭のフォルダ名を落とし、ファイル選択ではファイル名を使う", () => {
+    const result = pickedFilesToCandidates([
+      picked("gomi.md", "knowledge/kurashi/gomi.md"),
+      picked("index.md", "knowledge/index.md"),
+      picked("top.md"),
+    ]);
+    expect(result.map((c) => c.relativePath)).toEqual([
+      "kurashi/gomi.md",
+      "index.md",
+      "top.md",
+    ]);
   });
 
-  it("Markdown が無く元ファイルだけの行も削除できる", () => {
-    expect(
-      canDeleteFile({
-        baseName: "x",
-        hasMarkdown: false,
-        markdown: undefined,
-        original,
-      }),
-    ).toBe(true);
+  it(".md 以外と dotfile は落とす", () => {
+    const result = pickedFilesToCandidates([
+      picked("memo.txt"),
+      picked(".DS_Store", "kurashi/.DS_Store"),
+      picked("ok.md"),
+    ]);
+    expect(result.map((c) => c.relativePath)).toEqual(["ok.md"]);
+  });
+});
+
+describe("readAllEntries", () => {
+  const entry = (name: string) => ({ name }) as unknown as FileSystemEntry;
+
+  it("空配列が返るまで readEntries を繰り返して結合する", async () => {
+    const batches = [[entry("a"), entry("b")], [entry("c")], []];
+    const readEntries = vi.fn(
+      (resolve: (entries: FileSystemEntry[]) => void) => {
+        resolve(batches.shift() ?? []);
+      },
+    );
+
+    const result = await readAllEntries({ readEntries });
+
+    expect(result.map((e) => e.name)).toEqual(["a", "b", "c"]);
+    expect(readEntries).toHaveBeenCalledTimes(3);
+  });
+
+  it("読み取りエラーは reject する", async () => {
+    const readEntries = (
+      _resolve: (entries: FileSystemEntry[]) => void,
+      reject?: (error: DOMException) => void,
+    ) => reject?.(new DOMException("denied"));
+
+    await expect(readAllEntries({ readEntries })).rejects.toThrow("denied");
+  });
+});
+
+describe("collectMarkdownFiles", () => {
+  type Node =
+    | { kind: "file"; fullPath: string }
+    | { kind: "dir"; fullPath: string; children: Node[] };
+
+  const toEntry = (node: Node) =>
+    ({
+      isFile: node.kind === "file",
+      isDirectory: node.kind === "dir",
+      fullPath: node.fullPath,
+      name: node.fullPath.split("/").pop(),
+      children: node.kind === "dir" ? node.children : undefined,
+    }) as unknown as FileSystemEntry;
+
+  const deps = {
+    readDirectory: vi.fn(async (dir: FileSystemDirectoryEntry) =>
+      ((dir as unknown as { children: Node[] }).children ?? []).map(toEntry),
+    ),
+    readFile: vi.fn(
+      async (entry: FileSystemFileEntry) =>
+        new File([entry.fullPath], entry.name),
+    ),
+  };
+
+  it("ドロップしたフォルダを root として再帰的に走査し、.md だけをフォルダからの相対パスで返す", async () => {
+    const tree: Node[] = [
+      { fullPath: "/single.md", kind: "file" },
+      {
+        fullPath: "/knowledge",
+        kind: "dir",
+        children: [
+          { fullPath: "/knowledge/top.md", kind: "file" },
+          { fullPath: "/knowledge/readme.txt", kind: "file" },
+          {
+            fullPath: "/knowledge/kurashi",
+            kind: "dir",
+            children: [
+              { fullPath: "/knowledge/kurashi/gomi.md", kind: "file" },
+              { fullPath: "/knowledge/kurashi/.DS_Store", kind: "file" },
+              {
+                fullPath: "/knowledge/kurashi/deep",
+                kind: "dir",
+                children: [
+                  {
+                    fullPath: "/knowledge/kurashi/deep/suido.md",
+                    kind: "file",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = await collectMarkdownFiles(tree.map(toEntry), deps);
+
+    expect(result.map((c) => c.relativePath)).toEqual([
+      "single.md",
+      "top.md",
+      "kurashi/gomi.md",
+      "kurashi/deep/suido.md",
+    ]);
+    expect(result.map((c) => c.file.name)).toEqual([
+      "single.md",
+      "top.md",
+      "gomi.md",
+      "suido.md",
+    ]);
+    expect(deps.readFile).toHaveBeenCalledTimes(4);
+  });
+
+  it("空のディレクトリは何も返さない", async () => {
+    const result = await collectMarkdownFiles(
+      [toEntry({ fullPath: "/empty", kind: "dir", children: [] })],
+      deps,
+    );
+    expect(result).toEqual([]);
+  });
+});
+
+describe("runWithConcurrency", () => {
+  it("同時実行数を上限に抑えつつ、結果を元の順序で返す", async () => {
+    let running = 0;
+    let peak = 0;
+    const tasks = [5, 1, 3, 2, 4].map((n) => async () => {
+      running += 1;
+      peak = Math.max(peak, running);
+      await new Promise((r) => setTimeout(r, n));
+      running -= 1;
+      return n;
+    });
+
+    const results = await runWithConcurrency(tasks, 2);
+
+    expect(results).toEqual([5, 1, 3, 2, 4]);
+    expect(peak).toBe(2);
+  });
+
+  it("タスクが空なら空配列", async () => {
+    expect(await runWithConcurrency([], 3)).toEqual([]);
+  });
+
+  it("1 つが reject したら全体が reject する", async () => {
+    await expect(
+      runWithConcurrency(
+        [async () => 1, async () => Promise.reject(new Error("x"))],
+        3,
+      ),
+    ).rejects.toThrow("x");
   });
 });

--- a/web/src/app/dashboard/components/knowledge/helpers.ts
+++ b/web/src/app/dashboard/components/knowledge/helpers.ts
@@ -1,7 +1,12 @@
-import { CONVERTIBLE_MIME_TYPES } from "@nepp-chan/shared/constants/knowledge";
-import type { CuratedDraftRequest, UnifiedFileInfo } from "~/types";
+import {
+  CONVERTIBLE_MIME_TYPES,
+  CURATED_PREFIX,
+  OFFICIAL_PREFIX,
+} from "@nepp-chan/shared/constants/knowledge";
+import type { CuratedDraftRequest, FileInfo } from "~/types";
 
-export const CURATED_PREFIX = "curated/";
+export type { KnowledgePrefix } from "@nepp-chan/shared/constants/knowledge";
+export { CURATED_PREFIX, OFFICIAL_PREFIX };
 export const DRAFT_FILE_ACCEPT = CONVERTIBLE_MIME_TYPES.join(",");
 export const INPUT_CLASS =
   "w-full px-3 py-2 border border-stone-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-teal-500 focus:border-transparent disabled:bg-stone-100";
@@ -18,17 +23,112 @@ export type DraftFormFields = {
 };
 
 export const isCuratedKey = (key: string) => key.startsWith(CURATED_PREFIX);
+export const isOfficialKey = (key: string) => key.startsWith(OFFICIAL_PREFIX);
 
-export const isCuratedFile = (file: UnifiedFileInfo) =>
-  !!file.markdown && isCuratedKey(file.markdown.key);
+export const isCuratedFile = (file: FileInfo) => isCuratedKey(file.key);
+export const isOfficialFile = (file: FileInfo) => isOfficialKey(file.key);
 
-export const canDeleteFile = (file: UnifiedFileInfo) =>
-  isCuratedFile(file) || !!file.original;
+export const canDeleteFile = (file: FileInfo) =>
+  isCuratedFile(file) || isOfficialFile(file);
 
-export const partitionFiles = (files: UnifiedFileInfo[]) => ({
-  curated: files.filter(isCuratedFile),
-  base: files.filter((file) => !isCuratedFile(file)),
-});
+export const splitKey = (key: string) => {
+  const index = key.lastIndexOf("/") + 1;
+  return { dir: key.slice(0, index), name: key.slice(index) };
+};
+
+export const toRelativePath = (path: string) => path.replace(/^\/+/, "");
+
+export const isUploadableMarkdown = (path: string) => {
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  return name.endsWith(".md") && !name.startsWith(".");
+};
+
+export type UploadCandidate = { file: File; relativePath: string };
+
+export const stripTopFolder = (path: string) =>
+  path.slice(path.indexOf("/") + 1);
+
+export const pickedFilesToCandidates = (files: Iterable<File>) =>
+  Array.from(files)
+    .map((file) => ({
+      file,
+      relativePath: file.webkitRelativePath
+        ? stripTopFolder(toRelativePath(file.webkitRelativePath))
+        : file.name,
+    }))
+    .filter((candidate) => isUploadableMarkdown(candidate.relativePath));
+
+export type EntryReader = Pick<FileSystemDirectoryReader, "readEntries">;
+
+export const readAllEntries = async (reader: EntryReader) => {
+  const all: FileSystemEntry[] = [];
+  while (true) {
+    const batch = await new Promise<FileSystemEntry[]>((resolve, reject) =>
+      reader.readEntries(resolve, reject),
+    );
+    if (batch.length === 0) return all;
+    all.push(...batch);
+  }
+};
+
+export type EntryDeps = {
+  readDirectory: (dir: FileSystemDirectoryEntry) => Promise<FileSystemEntry[]>;
+  readFile: (entry: FileSystemFileEntry) => Promise<File>;
+};
+
+const walkEntries = async (
+  entries: FileSystemEntry[],
+  root: string,
+  deps: EntryDeps,
+): Promise<UploadCandidate[]> => {
+  const collected: UploadCandidate[] = [];
+  for (const entry of entries) {
+    if (entry.isDirectory) {
+      const children = await deps.readDirectory(
+        entry as FileSystemDirectoryEntry,
+      );
+      collected.push(...(await walkEntries(children, root, deps)));
+    } else if (entry.isFile) {
+      const relativePath = toRelativePath(entry.fullPath.slice(root.length));
+      if (!isUploadableMarkdown(relativePath)) continue;
+      collected.push({
+        file: await deps.readFile(entry as FileSystemFileEntry),
+        relativePath,
+      });
+    }
+  }
+  return collected;
+};
+
+export const collectMarkdownFiles = async (
+  entries: FileSystemEntry[],
+  deps: EntryDeps,
+) => {
+  const collected: UploadCandidate[] = [];
+  for (const entry of entries) {
+    const root = entry.isDirectory ? entry.fullPath : "";
+    collected.push(...(await walkEntries([entry], root, deps)));
+  }
+  return collected;
+};
+
+export const runWithConcurrency = async <T>(
+  tasks: (() => Promise<T>)[],
+  limit: number,
+) => {
+  const results = new Array<T>(tasks.length);
+  let next = 0;
+  const worker = async () => {
+    while (next < tasks.length) {
+      const index = next++;
+      results[index] = await tasks[index]();
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, tasks.length) }, worker),
+  );
+  return results;
+};
 
 export const slugFromKey = (key: string) =>
   (key.startsWith(CURATED_PREFIX)

--- a/web/src/app/dashboard/hooks/keys.ts
+++ b/web/src/app/dashboard/hooks/keys.ts
@@ -26,9 +26,13 @@ export const dashboardKeys = {
   feedbacks: ["dashboard", "feedbacks"] as const,
   feedbackDetail: (id: string) => ["dashboard", "feedback", id] as const,
   knowledgeFiles: ["dashboard", "knowledge", "files"] as const,
-  knowledgeUnifiedFiles: ["dashboard", "knowledge", "unified"] as const,
+  knowledgeFilesByPrefix: (prefix: string) =>
+    ["dashboard", "knowledge", "files", prefix] as const,
+  knowledgeFileContents: ["dashboard", "knowledge", "file"] as const,
   knowledgeFile: (key: string) =>
     ["dashboard", "knowledge", "file", key] as const,
+  knowledgeFileExists: (key: string) =>
+    ["dashboard", "knowledge", "file", key, "exists"] as const,
   polls: ["dashboard", "polls"] as const,
   pollResults: (id: string) => ["dashboard", "poll", "results", id] as const,
   invitations: ["dashboard", "invitations"] as const,

--- a/web/src/app/dashboard/hooks/useKnowledge.test.ts
+++ b/web/src/app/dashboard/hooks/useKnowledge.test.ts
@@ -1,7 +1,8 @@
 import { act, waitFor } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { knowledgeRepository } from "~/lib/api/repository";
 import { setAuthToken } from "~/lib/auth-token";
 import { server } from "~/test/msw-server";
 import { renderHookWithQuery } from "~/test/query";
@@ -10,11 +11,11 @@ import {
   useDeleteFile,
   useDraftCurated,
   useKnowledgeFile,
+  useKnowledgeFileExists,
   useKnowledgeFiles,
-  useReconvertFile,
   useSaveFile,
-  useUnifiedFiles,
-  useUploadFile,
+  useSyncKnowledge,
+  useUploadFiles,
 } from "./useKnowledge";
 
 const API = "http://localhost:8787";
@@ -48,28 +49,116 @@ describe("useKnowledgeFile", () => {
   });
 });
 
-describe("useKnowledgeFiles / useUnifiedFiles", () => {
-  it("useKnowledgeFiles: 200 を返したら data に反映", async () => {
+describe("useKnowledgeFileExists", () => {
+  it("200 なら true", async () => {
     server.use(
-      http.get(`${API}/admin/knowledge/files`, () =>
-        HttpResponse.json({ files: [] }),
+      http.get(`${API}/admin/knowledge/files/*`, () =>
+        HttpResponse.json({ content: "# title" }),
       ),
     );
 
-    const { result } = renderHookWithQuery(() => useKnowledgeFiles());
+    const { result } = renderHookWithQuery(() =>
+      useKnowledgeFileExists("curated/usagi.md"),
+    );
+
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data?.files).toEqual([]);
+    expect(result.current.data).toBe(true);
   });
 
-  it("useUnifiedFiles", async () => {
+  it("404 なら再試行せず false", async () => {
+    let calls = 0;
     server.use(
-      http.get(`${API}/admin/knowledge/unified`, () =>
-        HttpResponse.json({ files: [] }),
+      http.get(`${API}/admin/knowledge/files/*`, () => {
+        calls += 1;
+        return HttpResponse.json(
+          { error: { message: "File not found" } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    const { result } = renderHookWithQuery(() =>
+      useKnowledgeFileExists("curated/missing.md"),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(false);
+    expect(calls).toBe(1);
+  });
+
+  it("404 以外の失敗はエラーのまま", async () => {
+    server.use(
+      http.get(`${API}/admin/knowledge/files/*`, () =>
+        HttpResponse.json({ error: { message: "boom" } }, { status: 500 }),
       ),
     );
 
-    const { result } = renderHookWithQuery(() => useUnifiedFiles());
+    const { result } = renderHookWithQuery(() =>
+      useKnowledgeFileExists("curated/x.md"),
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("key=null なら fetchStatus は idle", () => {
+    const { result } = renderHookWithQuery(() => useKnowledgeFileExists(null));
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+describe("useKnowledgeFiles", () => {
+  it("prefix と limit をクエリに載せ、nextCursor で次ページを取る", async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get(`${API}/admin/knowledge/files`, ({ request }) => {
+        const url = new URL(request.url);
+        seen.push(url.search);
+        const cursor = url.searchParams.get("cursor");
+        return HttpResponse.json(
+          cursor
+            ? {
+                files: [
+                  {
+                    key: "official/b.md",
+                    size: 1,
+                    lastModified: "2026-01-01T00:00:00Z",
+                  },
+                ],
+                nextCursor: null,
+                hasMore: false,
+              }
+            : {
+                files: [
+                  {
+                    key: "official/a.md",
+                    size: 1,
+                    lastModified: "2026-01-01T00:00:00Z",
+                  },
+                ],
+                nextCursor: "c1",
+                hasMore: true,
+              },
+        );
+      }),
+    );
+
+    const { result } = renderHookWithQuery(() =>
+      useKnowledgeFiles("official/", 1),
+    );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(true);
+    expect(new URLSearchParams(seen[0]).get("prefix")).toBe("official/");
+    expect(new URLSearchParams(seen[0]).get("limit")).toBe("1");
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(false));
+    expect(new URLSearchParams(seen[1]).get("cursor")).toBe("c1");
+    expect(
+      result.current.data?.pages.flatMap((p) => p.files.map((f) => f.key)),
+    ).toEqual(["official/a.md", "official/b.md"]);
   });
 });
 
@@ -104,22 +193,20 @@ describe("knowledge mutations", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 
-  it("useUploadFile: 成功で isSuccess", async () => {
+  it("useSyncKnowledge: 投入件数を返す", async () => {
     server.use(
-      http.post(`${API}/admin/knowledge/upload`, () =>
-        HttpResponse.json({ key: "k", chunks: 1 }),
+      http.post(`${API}/admin/knowledge/sync`, () =>
+        HttpResponse.json({ message: "queued", queued: 338 }),
       ),
     );
 
-    const { result } = renderHookWithQuery(() => useUploadFile());
+    const { result } = renderHookWithQuery(() => useSyncKnowledge());
 
     await act(async () => {
-      await result.current.mutateAsync({
-        file: new File(["x"], "f.md"),
-        filename: "f.md",
-      });
+      await result.current.mutateAsync();
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.queued).toBe(338);
   });
 
   it("useConvertFile: 成功で isSuccess", async () => {
@@ -139,23 +226,50 @@ describe("knowledge mutations", () => {
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
+});
 
-  it("useReconvertFile: 成功で isSuccess", async () => {
-    server.use(
-      http.post(`${API}/admin/knowledge/reconvert`, () =>
-        HttpResponse.json({ key: "k", chunks: 1 }),
-      ),
-    );
+describe("useUploadFiles", () => {
+  const item = (relativePath: string) => ({
+    file: new File(["# x"], relativePath.split("/").pop() ?? relativePath),
+    relativePath,
+  });
 
-    const { result } = renderHookWithQuery(() => useReconvertFile());
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
+  it("全件を相対パス付きで送り、進捗を件数で通知し、失敗分だけを返す", async () => {
+    const upload = vi
+      .spyOn(knowledgeRepository, "uploadFile")
+      .mockImplementation(async (_file, filename) => {
+        if (filename === "kanko/bad.md") throw new Error("boom");
+        return { key: `official/${filename}`, message: "" };
+      });
+    const progress: number[] = [];
+    const items = [item("a.md"), item("kanko/bad.md"), item("kurashi/c.md")];
+
+    const { result } = renderHookWithQuery(() => useUploadFiles());
+    let outcome: Awaited<ReturnType<typeof result.current.mutateAsync>> | null =
+      null;
     await act(async () => {
-      await result.current.mutateAsync({
-        originalKey: "originals/x.pdf",
-        filename: "x",
+      outcome = await result.current.mutateAsync({
+        items,
+        onProgress: (done) => progress.push(done),
       });
     });
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(
+      upload.mock.calls.map(([file, filename]) => [file.name, filename]),
+    ).toEqual([
+      ["a.md", "a.md"],
+      ["bad.md", "kanko/bad.md"],
+      ["c.md", "kurashi/c.md"],
+    ]);
+    expect(progress).toEqual([1, 2, 3]);
+    expect(outcome).toEqual({
+      uploaded: 2,
+      failed: [{ ...items[1], error: "boom" }],
+    });
   });
 });
 

--- a/web/src/app/dashboard/hooks/useKnowledge.ts
+++ b/web/src/app/dashboard/hooks/useKnowledge.ts
@@ -1,12 +1,23 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@nepp-chan/shared/api";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
+import type { KnowledgePrefix } from "~/app/dashboard/components/knowledge/helpers";
+import { runWithConcurrency } from "~/app/dashboard/components/knowledge/helpers";
 import { knowledgeRepository } from "~/lib/api/repository";
 import { dashboardKeys } from "./keys";
 
-export const useKnowledgeFiles = () =>
-  useQuery({
-    queryKey: dashboardKeys.knowledgeFiles,
-    queryFn: knowledgeRepository.fetchFiles,
+export const useKnowledgeFiles = (prefix: KnowledgePrefix, limit = 30) =>
+  useInfiniteQuery({
+    queryKey: [...dashboardKeys.knowledgeFilesByPrefix(prefix), limit],
+    queryFn: ({ pageParam }) =>
+      knowledgeRepository.fetchFiles({ prefix, limit, cursor: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
 export const useKnowledgeFile = (key: string | null) =>
@@ -19,12 +30,32 @@ export const useKnowledgeFile = (key: string | null) =>
     enabled: !!key,
   });
 
+const isNotFound = (error: unknown) =>
+  error instanceof ApiError && error.status === 404;
+
+export const useKnowledgeFileExists = (key: string | null) =>
+  useQuery({
+    queryKey: dashboardKeys.knowledgeFileExists(key ?? ""),
+    queryFn: async () => {
+      if (!key) throw new Error("Key is required");
+      try {
+        await knowledgeRepository.fetchFileContent(key);
+        return true;
+      } catch (error) {
+        if (isNotFound(error)) return false;
+        throw error;
+      }
+    },
+    enabled: !!key,
+    retry: false,
+  });
+
 const invalidateKnowledge = (
   queryClient: ReturnType<typeof useQueryClient>,
 ) => {
   queryClient.invalidateQueries({ queryKey: dashboardKeys.knowledgeFiles });
   queryClient.invalidateQueries({
-    queryKey: dashboardKeys.knowledgeUnifiedFiles,
+    queryKey: dashboardKeys.knowledgeFileContents,
   });
 };
 
@@ -45,11 +76,54 @@ export const useDeleteFile = () => {
   });
 };
 
-export const useUploadFile = () => {
+export type UploadItem = { file: File; relativePath: string };
+export type UploadFailure = UploadItem & { error: string };
+export type UploadOutcome = { uploaded: number; failed: UploadFailure[] };
+
+const UPLOAD_CONCURRENCY = 3;
+
+export const useUploadFiles = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ file, filename }: { file: File; filename?: string }) =>
-      knowledgeRepository.uploadFile(file, filename),
+    mutationFn: async ({
+      items,
+      onProgress,
+    }: {
+      items: UploadItem[];
+      onProgress?: (done: number) => void;
+    }): Promise<UploadOutcome> => {
+      let done = 0;
+      const results = await runWithConcurrency(
+        items.map((item) => async () => {
+          try {
+            await knowledgeRepository.uploadFile(item.file, item.relativePath);
+            return null;
+          } catch (error) {
+            return {
+              ...item,
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "アップロードに失敗しました",
+            };
+          } finally {
+            done += 1;
+            onProgress?.(done);
+          }
+        }),
+        UPLOAD_CONCURRENCY,
+      );
+      const failed = results.filter((r): r is UploadFailure => r !== null);
+      return { uploaded: items.length - failed.length, failed };
+    },
+    onSettled: () => invalidateKnowledge(queryClient),
+  });
+};
+
+export const useSyncKnowledge = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: knowledgeRepository.syncAll,
     onSuccess: () => invalidateKnowledge(queryClient),
   });
 };
@@ -67,27 +141,3 @@ export const useDraftCurated = () =>
   useMutation({
     mutationFn: knowledgeRepository.draftCurated,
   });
-
-export const useUnifiedFiles = () =>
-  useQuery({
-    queryKey: dashboardKeys.knowledgeUnifiedFiles,
-    queryFn: knowledgeRepository.fetchUnifiedFiles,
-  });
-
-export const useReconvertFile = () => {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({
-      originalKey,
-      filename,
-    }: {
-      originalKey: string;
-      filename: string;
-    }) => knowledgeRepository.reconvertFile(originalKey, filename),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: dashboardKeys.knowledgeUnifiedFiles,
-      });
-    },
-  });
-};

--- a/web/src/lib/api/repository.ts
+++ b/web/src/lib/api/repository.ts
@@ -10,7 +10,7 @@ import { createPollRepository } from "@nepp-chan/shared/api/repository/poll-repo
 import { createThreadRepository } from "@nepp-chan/shared/api/repository/thread-repository";
 import { createWidgetSiteRepository } from "@nepp-chan/shared/api/repository/widget-site-repository";
 
-import { API_BASE, client } from "./client";
+import { client } from "./client";
 
 /**
  * shared/api/repository の factory を web の client で合成した repository 群。
@@ -22,7 +22,7 @@ export const broadcastRepository = createBroadcastRepository(client);
 export const emergencyRepository = createEmergencyRepository(client);
 export const feedbackRepository = createFeedbackRepository(client);
 export const invitationRepository = createInvitationRepository(client);
-export const knowledgeRepository = createKnowledgeRepository(client, API_BASE);
+export const knowledgeRepository = createKnowledgeRepository(client);
 export const personaRepository = createPersonaRepository(client);
 export const pollRepository = createPollRepository(client);
 export const threadRepository = createThreadRepository(client);


### PR DESCRIPTION
## 概要

管理画面のナレッジタブに、公式資料（Markdown）をフォルダごと一括投入する機能を追加する。R2 のキーは `official/` と `curated/` のプレフィクスで区分し、ルート直下には置かない。

## 変更

- `POST /admin/knowledge/upload` はサーバー側で `official/` を前置する。クライアントは相対パスだけを送る
- `GET /admin/knowledge/files` を `prefix` / `limit` / `cursor` のページングにし、`/unified` と `/originals/{key}` を削除する
- 旧配置のオブジェクトを全削除する一時的な `DELETE /admin/knowledge/legacy` を追加する。移行後に別 PR で消す
- `knowledge:upload` の書き込み先を `official/<path>` にする。`--clean` の挙動は変えない
- ナレッジタブを 1 カード + フォルダ型タブ「追加したナレッジ」「公式資料」に組み替え、タブごとに入力と一覧を置く
- 公式資料タブはフォルダ選択・複数ファイル選択・フォルダドロップに対応し、`.md` 以外と dotfile は無視する。選んだフォルダを root として階層を保つ
- 進捗 n / m、完了、失敗キー一覧と「失敗分を再試行」を 1 行のステータスで出す
- 一覧は `useInfiniteQuery` と無限スクロールにし、公式資料タブから「検索データを再同期」で `POST /sync` を叩けるようにする
- 「ナレッジを追加」の上書き警告は `GET /files/{key}` の 404 判定に置き換え、確認中は保存を無効にする

## 検証

| 項目 | 結果 |
|---|---|
| `pnpm lint`、server / shared / web の全テスト | 通過 |
| 画面から `knowledge/` フォルダを投入（local） | 335 件が `official/otoko/...` の形で保存 |
| `DELETE /admin/knowledge/legacy`（local バケット） | 1,956 件削除、`official/` `curated/` は残存 |
| `--clean` 後に再同期し `wrangler vectorize info` | 4,210 ベクター（基準値と一致） |
| 失敗 → 再試行、30 件超の無限スクロールの実機確認 | 未実行（単体テストのみ） |

## 画面

![追加したナレッジタブ](https://github.com/user-attachments/assets/46272d26-6579-414d-b788-4d6f8a172e9f)
![公式資料タブ](https://github.com/user-attachments/assets/45206290-8d69-4120-9c2e-d3eda436bf08)
![画像・PDF から作るのドロップ領域](https://github.com/user-attachments/assets/cefa1293-3082-4eba-af80-1027714b7aae)

## 移行 / 注意

- デプロイ後、環境ごとに 1 回だけ旧配置を削除し、その後に新しい公式資料を画面から投入する。実行タイミングは運用担当が決める

```bash
curl -X DELETE -H "Authorization: Bearer <super_admin token>" https://<api host>/admin/knowledge/legacy
```

- `nepp-chan-server-local` は CI 対象外で、デプロイ済みのコードが古いと R2 イベント経由の同期が旧 ID で走る。local では公式資料タブの「検索データを再同期」で手元の dev プロセスから同期する
- `wrangler dev` の remote バインディング経由では R2 put がまれに 500 になる。画面の「失敗分を再試行」で拾える。本番の Worker 実行では発生しない

## フォローアップ

- 移行完了後に `DELETE /admin/knowledge/legacy` を削除する
